### PR TITLE
feat: differentiate win/loss notifications and fix CSS for Android Fi…

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -107,6 +107,10 @@ export class Container {
     this.sendEvent(new NotificationEvent(data, duration))
   }
 
+  notifyLocal(data: NotificationData | string, duration?: number) {
+    this.notification.show(data, duration)
+  }
+
   advance(elapsed) {
     this.frame?.(elapsed)
 

--- a/src/controller/rules/rules.ts
+++ b/src/controller/rules/rules.ts
@@ -23,4 +23,5 @@ export interface Rules {
   asset(): string
   nextCandidateBall()
   startTurn()
+  handleGameEnd(isWinner: boolean): Controller
 }

--- a/src/controller/rules/threecushion.ts
+++ b/src/controller/rules/threecushion.ts
@@ -15,6 +15,9 @@ import { Rules } from "./rules"
 import { zero } from "../../utils/utils"
 import { Respot } from "../../utils/respot"
 import { StartAimEvent } from "../../events/startaimevent"
+import { End } from "../end"
+import { Session } from "../../network/client/session"
+import { MatchResult } from "../../network/client/matchresult"
 
 export class ThreeCushion implements Rules {
   readonly container: Container
@@ -107,6 +110,26 @@ export class ThreeCushion implements Rules {
 
   isEndOfGame(_: Outcome[]) {
     return false
+  }
+
+  handleGameEnd(isWinner: boolean): Controller {
+    const session = Session.hasInstance() ? Session.getInstance() : null
+    this.container.notifyLocal({
+      type: "GameOver",
+      title: isWinner ? "YOU WON" : "YOU LOST",
+      icon: isWinner ? "🏆" : "🥈",
+      extraClass: isWinner ? "is-winner" : "is-loser",
+      duration: 30000,
+    })
+
+    const result: MatchResult = {
+      winner: isWinner
+        ? session?.playername || "Anon"
+        : session?.opponentName || "Opponent",
+      winnerScore: this.score,
+      gameType: this.rulename,
+    }
+    return new End(this.container, isWinner ? result : undefined)
   }
 
   allowsPlaceBall() {

--- a/src/controller/watchshot.ts
+++ b/src/controller/watchshot.ts
@@ -2,7 +2,6 @@ import { Aim } from "./aim"
 import { WatchAim } from "./watchaim"
 import { ControllerBase } from "./controllerbase"
 import { PlaceBall } from "./placeball"
-import { End } from "./end"
 import { PlaceBallEvent } from "../events/placeballevent"
 
 export class WatchShot extends ControllerBase {
@@ -15,7 +14,7 @@ export class WatchShot extends ControllerBase {
   override handleStationary(_) {
     const outcome = this.container.table.outcome
     if (this.container.rules.isEndOfGame(outcome)) {
-      return new End(this.container)
+      return this.container.rules.handleGameEnd(false)
     }
     return this
   }

--- a/src/view/notification.ts
+++ b/src/view/notification.ts
@@ -1,12 +1,11 @@
-import { Session } from "../network/client/session"
-
 export interface NotificationData {
   type: "Foul" | "GameOver" | "Info"
   title: string
   subtext?: string
   extra?: string
   duration?: number
-  winnerClientId?: string
+  icon?: string
+  extraClass?: string
 }
 
 export class Notification {
@@ -18,17 +17,9 @@ export class Notification {
   }
 
   private getIcon(data: NotificationData): string {
+    if (data.icon) return data.icon
     if (data.type === "Foul") return "🎱"
-    if (data.type === "GameOver") {
-      if (data.winnerClientId && Session.hasInstance()) {
-        const session = Session.getInstance()
-        if (session.clientId === data.winnerClientId) {
-          return "🏆"
-        }
-        return "🥈"
-      }
-      return "🏆"
-    }
+    if (data.type === "GameOver") return "🏆"
     return "🔵"
   }
 
@@ -66,17 +57,10 @@ export class Notification {
 
   private processData(data: NotificationData) {
     let typeClass = `type-${data.type}`
-    const icon = this.getIcon(data)
-
-    if (data.type === "GameOver" && data.winnerClientId && Session.hasInstance()) {
-      const session = Session.getInstance()
-      if (session.clientId === data.winnerClientId) {
-        typeClass += " is-winner"
-      } else {
-        typeClass += " is-loser"
-      }
+    if (data.extraClass) {
+      typeClass += ` ${data.extraClass}`
     }
-
+    const icon = this.getIcon(data)
     const extraContentHtml = this.renderExtra(data.extra)
 
     const content = `

--- a/test/rules/nineball.spec.ts
+++ b/test/rules/nineball.spec.ts
@@ -219,7 +219,7 @@ describe("NineBall Rules", () => {
   })
 
   it("should trigger game over notification", () => {
-    const notifySpy = jest.spyOn(container, "notify")
+    const notifySpy = jest.spyOn(container, "notifyLocal")
     container.table.balls.forEach((b) => {
       if (b !== container.table.cueball && b.label !== 9) {
         b.state = State.InPocket
@@ -233,17 +233,18 @@ describe("NineBall Rules", () => {
     nineball.update(outcome)
     expect(notifySpy.mock.calls[0][0]).to.deep.equal({
       type: "GameOver",
-      title: "GAME OVER",
-      subtext: "You won!",
+      title: "YOU WON",
+      subtext: "Congratulations!",
       extra: `<button onclick="location.reload()">New Game</button><button onclick="location.href='https://scoreboard-tailuge.vercel.app/'">Lobby</button>`,
+      icon: "🏆",
+      extraClass: "is-winner",
       duration: 30000,
-      winnerClientId: "test-client",
     })
   })
 
   it("should trigger game over notification with only lobby button in 2-player mode", () => {
     container.isSinglePlayer = false
-    const notifySpy = jest.spyOn(container, "notify")
+    const notifySpy = jest.spyOn(container, "notifyLocal")
     container.table.balls.forEach((b) => {
       if (b !== container.table.cueball && b.label !== 9) {
         b.state = State.InPocket
@@ -257,11 +258,12 @@ describe("NineBall Rules", () => {
     nineball.update(outcome)
     expect(notifySpy.mock.calls[0][0]).to.deep.equal({
       type: "GameOver",
-      title: "GAME OVER",
-      subtext: "You won!",
+      title: "YOU WON",
+      subtext: "Congratulations!",
       extra: `<button onclick="location.href='https://scoreboard-tailuge.vercel.app/'">Lobby</button>`,
+      icon: "🏆",
+      extraClass: "is-winner",
       duration: 30000,
-      winnerClientId: "test-client",
     })
   })
 })


### PR DESCRIPTION
…refox

- Updated `NotificationData` and `Notification` to support explicit icons and extra CSS classes.
- Refactored `index.css` to use a "vanilla" style for notifications, removing `backdrop-filter` for better compatibility with Android Firefox.
- Added `is-winner` (gold) and `is-loser` (silver) themes for notifications.
- Added `notifyLocal` to `Container` to show local-only notifications.
- Updated `Rules` interface and implementations (NineBall, Snooker, ThreeCushion) to handle game end locally with personalized messages and icons.
- Updated `WatchShot` controller to trigger "YOU LOST" notification for opponents/spectators.
- Updated tests in `nineball.spec.ts` to match new notification logic.