### PR TITLE
Clear scheduled shot timer on replay abort

### DIFF
--- a/src/controller/replay.ts
+++ b/src/controller/replay.ts
@@ -106,6 +106,8 @@ export class Replay extends ControllerBase {
 
   override handleAbort(_: AbortEvent): Controller {
     console.log("Replay aborted")
+    clearTimeout(this.timer)
+    this.timer = undefined
     return new End(this.container)
   }
 


### PR DESCRIPTION
This PR fixes a bug where aborting a replay would not clear the pending shot timer. This could result in a `HitEvent` being triggered after the game state had already transitioned away from the replay, potentially causing unexpected behavior in subsequent states.

Changes:
- Modified `src/controller/replay.ts` to call `clearTimeout(this.timer)` and set `this.timer = undefined` within `handleAbort`.
- Added a new regression test in `test/controller/replay.spec.ts` that uses fake timers to ensure no events are pushed to the queue after an abort.
- Fixed a minor naming inconsistency in an existing test case.

---
*PR created automatically by Jules for task [9628765376757507324](https://jules.google.com/task/9628765376757507324) started by @tailuge*