### PR TITLE
Refactor nine-ball access to use array indexing

### DIFF
--- a/src/controller/rules/nineball.ts
+++ b/src/controller/rules/nineball.ts
@@ -95,12 +95,12 @@ export class NineBall implements Rules {
     })
     this.startTurn()
     const pots = Outcome.pots(outcome)
-    const nineBallPotted = pots.some((b) => b.label === 9)
+    const nineBallPotted = pots.includes(this.container.table.balls[9])
     const cueball = this.container.table.cueball
 
     if (nineBallPotted) {
       this.respotNineBall()
-      const nineBall = this.container.table.balls.find((b) => b.label === 9)
+      const nineBall = this.container.table.balls[9]
       if (nineBall) {
         const respot = RerackEvent.fromJson({
           balls: [nineBall.serialise()],
@@ -212,7 +212,8 @@ export class NineBall implements Rules {
 
   isEndOfGame(outcome: Outcome[]) {
     return (
-      !this.isFoul(outcome) && Outcome.pots(outcome).some((b) => b.label === 9)
+      !this.isFoul(outcome) &&
+      Outcome.pots(outcome).includes(this.container.table.balls[9])
     )
   }
 


### PR DESCRIPTION
This change refactors the way the 9-ball is accessed in the Nine Ball rules controller. Instead of searching the balls array for a ball with label 9, it now uses direct array indexing `balls[9]`. This matches the rack layout where the 9-ball is always at index 9.

Changes:
- In `handleFoul`, `nineBallPotted` now uses `pots.includes(this.container.table.balls[9])`.
- In `handleFoul`, `nineBall` is retrieved via `this.container.table.balls[9]`.
- In `isEndOfGame`, the condition now uses `Outcome.pots(outcome).includes(this.container.table.balls[9])`.

Verified with tests and linting.

---
*PR created automatically by Jules for task [12869829470511680669](https://jules.google.com/task/12869829470511680669) started by @tailuge*