### PR TITLE
Disable hit button in spectator mode

### DIFF
--- a/src/view/aiminputs.ts
+++ b/src/view/aiminputs.ts
@@ -1,6 +1,7 @@
 import { Color, Vector3 } from "three"
 import { Container } from "../container/container"
 import { Input } from "../events/input"
+import { Session } from "../network/client/session"
 import { Overlap } from "../utils/overlap"
 import { unitAtAngle } from "../utils/utils"
 
@@ -26,6 +27,9 @@ export class AimInputs {
     this.objectBallStyle = document.getElementById("objectBall")?.style
     this.overlap = new Overlap(this.container.table.balls)
     this.addListeners()
+    if (Session.isSpectator()) {
+      this.setDisabled(true)
+    }
   }
 
   addListeners() {
@@ -47,7 +51,7 @@ export class AimInputs {
 
   setDisabled(disabled: boolean) {
     if (this.cueHitElement) {
-      this.cueHitElement.disabled = disabled
+      this.cueHitElement.disabled = disabled || Session.isSpectator()
     }
   }
 

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -4,6 +4,7 @@ import { initDom, canvas3d } from "./dom"
 import { Container } from "../../src/container/container"
 import { fireEvent } from "@testing-library/dom"
 import { Assets } from "../../src/view/assets"
+import { Session } from "../../src/network/client/session"
 
 initDom()
 
@@ -41,6 +42,16 @@ describe("AimInput", () => {
   it("mouse wheel updates power", (done) => {
     aiminputs.mousewheel({ deltaY: 10 })
     expect(aiminputs.container.table.cue.aim.power).to.greaterThan(0)
+    done()
+  })
+
+  it("spectator mode disables hit button", (done) => {
+    Session.init("id", "name", "table", true)
+    const spectatorAimInputs = new AimInputs(container)
+    expect(spectatorAimInputs.cueHitElement.disabled).to.be.true
+    spectatorAimInputs.setDisabled(false)
+    expect(spectatorAimInputs.cueHitElement.disabled).to.be.true
+    Session.reset()
     done()
   })
 })


### PR DESCRIPTION
The hit button is now disabled for spectators to prevent confusion and accidental local interactions that don't affect the game state. This is enforced both at initialization and when game states attempt to enable the button.

---
*PR created automatically by Jules for task [446124769944786827](https://jules.google.com/task/446124769944786827) started by @tailuge*