### PR TITLE
Refactor test files for lint and style consistency

### DIFF
--- a/test/controller/replay.spec.ts
+++ b/test/controller/replay.spec.ts
@@ -19,7 +19,7 @@ import { Assets } from "../../src/view/assets"
 initDom()
 
 jest.useFakeTimers()
-jest.spyOn(global, "setTimeout")
+jest.spyOn(globalThis, "setTimeout")
 
 describe("Controller Replay", () => {
   let container: Container

--- a/test/diagram/realposition.spec.ts
+++ b/test/diagram/realposition.spec.ts
@@ -18,7 +18,7 @@ const real = new RealPosition(example)
 
 describe("RealPosition", () => {
   it("Use initial position up to move", (done) => {
-    const result0 = real.getPositionsAtTime(545599, 0.0)
+    const result0 = real.getPositionsAtTime(545599, 0)
     const result1 = real.getPositionsAtTime(545599, 0.039)
     expect(result1).to.deep.equal(result0)
     done()

--- a/test/gen/diamond.spec.ts
+++ b/test/gen/diamond.spec.ts
@@ -4,11 +4,11 @@ import JSONCrush from "jsoncrush"
 const jestConsole = console
 
 beforeEach(() => {
-  global.console = require("console")
+  globalThis.console = require("console")
 })
 
 afterEach(() => {
-  global.console = jestConsole
+  globalThis.console = jestConsole
 })
 
 describe("jsonCrush", () => {

--- a/test/model/cushion.spec.ts
+++ b/test/model/cushion.spec.ts
@@ -14,11 +14,11 @@ const t = 0.1
 const jestConsole = console
 
 beforeEach(() => {
-  global.console = require("console")
+  globalThis.console = require("console")
 })
 
 afterEach(() => {
-  global.console = jestConsole
+  globalThis.console = jestConsole
 })
 
 describe("Cushion", () => {

--- a/test/model/physics.spec.ts
+++ b/test/model/physics.spec.ts
@@ -40,7 +40,7 @@ describe("Physics", () => {
   })
 
   it("bounceHan with right side makes ball move right on bounce and reduces spin", (done) => {
-    const v = new Vector3(1.0, 0, 0)
+    const v = new Vector3(1, 0, 0)
     const w = new Vector3(0, 0, -5)
     const delta = bounceHan(v, w)
     expect(delta.v.y).to.be.greaterThan(0)

--- a/test/model/table.spec.ts
+++ b/test/model/table.spec.ts
@@ -59,8 +59,8 @@ describe("Table", () => {
     const a = new Ball(zero)
     a.vel.x = 100 * R
     a.state = State.Sliding
-    const b = new Ball(new Vector3(2.0 * R, 0, 0))
-    const c = new Ball(new Vector3(4.0 * R, 0, 0))
+    const b = new Ball(new Vector3(2 * R, 0, 0))
+    const c = new Ball(new Vector3(4 * R, 0, 0))
     const table = new Table([a, b, c])
     expect(table.allStationary()).to.be.false
     expect(table.prepareAdvanceAll(t)).to.be.false

--- a/test/network/client/scorereporter.spec.ts
+++ b/test/network/client/scorereporter.spec.ts
@@ -8,7 +8,7 @@ describe("ScoreReporter", () => {
   beforeEach(() => {
     mockFetch = jest.fn()
     // Mock the global fetch function
-    global.fetch = mockFetch
+    globalThis.fetch = mockFetch
     jest.spyOn(console, "error").mockImplementation(() => {}) // Suppress console.error during tests
   })
 

--- a/test/rules/fourteenone.spec.ts
+++ b/test/rules/fourteenone.spec.ts
@@ -17,11 +17,11 @@ initDom()
 const jestConsole = console
 
 beforeEach(() => {
-  global.console = require("console")
+  globalThis.console = require("console")
 })
 
 afterEach(() => {
-  global.console = jestConsole
+  globalThis.console = jestConsole
 })
 
 describe("FourteenOne", () => {

--- a/test/rules/snooker.spec.ts
+++ b/test/rules/snooker.spec.ts
@@ -24,11 +24,11 @@ initDom()
 const jestConsole = console
 
 beforeEach(() => {
-  global.console = require("console")
+  globalThis.console = require("console")
 })
 
 afterEach(() => {
-  global.console = jestConsole
+  globalThis.console = jestConsole
 })
 
 describe("Snooker", () => {

--- a/test/server/messagerelay.spec.ts
+++ b/test/server/messagerelay.spec.ts
@@ -7,11 +7,11 @@ import { EventUtil } from "../../src/events/eventutil"
 const jestConsole = console
 
 beforeEach(() => {
-  global.console = require("console")
+  globalThis.console = require("console")
 })
 
 afterEach(() => {
-  global.console = jestConsole
+  globalThis.console = jestConsole
 })
 
 describe("MessageRelay", () => {

--- a/test/server/session.spec.ts
+++ b/test/server/session.spec.ts
@@ -4,11 +4,11 @@ import { Session } from "../../src/network/client/session"
 const jestConsole = console
 
 beforeEach(() => {
-  global.console = require("console")
+  globalThis.console = require("console")
 })
 
 afterEach(() => {
-  global.console = jestConsole
+  globalThis.console = jestConsole
 })
 
 describe("Session", () => {

--- a/test/view/cameratop.spec.ts
+++ b/test/view/cameratop.spec.ts
@@ -20,7 +20,7 @@ describe("View", () => {
   })
   it("mobile device scale to width", (done) => {
     const distance = CameraTop.viewPoint(0.4, fov)
-    expect(distance.z).to.be.approximately(7.0, 1)
+    expect(distance.z).to.be.approximately(7, 1)
     done()
   })
 })

--- a/test/view/dom.ts
+++ b/test/view/dom.ts
@@ -1,5 +1,5 @@
-import fs from "fs"
-import path from "path"
+import fs from "node:fs"
+import path from "node:path"
 jest.dontMock("fs")
 
 const html = fs.readFileSync(


### PR DESCRIPTION
This submission fixes several lint-like issues in the test suite as requested.
1. Replaced `global` with `globalThis` in multiple spec files.
2. Removed zero fractions from numbers (e.g., `0.0` to `0`) in several spec files.
3. Updated `test/view/dom.ts` to use `node:fs` and `node:path` imports.

Verified all occurrences in the current codebase. Note that some line numbers provided in the original request did not contain the issues in the current version of the files, but all actual instances were addressed. All tests passed and linting is clean.

---
*PR created automatically by Jules for task [9305125988050825972](https://jules.google.com/task/9305125988050825972) started by @tailuge*