### PR TITLE
Add AimCalculator for bot aiming logic

### DIFF
--- a/src/network/bot/aimcalculator.ts
+++ b/src/network/bot/aimcalculator.ts
@@ -1,0 +1,87 @@
+import { Vector3 } from "three"
+import { Pocket } from "../../model/physics/pocket"
+
+export class AimCalculator {
+  private readonly ballRadius: number
+
+  constructor(ballRadius: number) {
+    this.ballRadius = ballRadius
+  }
+
+  /**
+   * Main entry point: Determines the optimal aim point (Ghost Ball position).
+   * Note: The source of the pocket list is typically PocketGeometry.pocketCenters.
+   */
+  public getAimPoint(
+    cuePos: Vector3,
+    targetPos: Vector3,
+    pockets: Vector3[]
+  ): Vector3 | null {
+    const bestPocket = this.findBestPocket(cuePos, targetPos, pockets)
+
+    if (!bestPocket) return null
+    return this.calculateGhostBallPos(targetPos, bestPocket)
+  }
+
+  /**
+   * Extracts positions from a list of Pocket objects.
+   * Note: The source of the pocket list is typically PocketGeometry.pocketCenters.
+   */
+  public extractPocketPositions(pockets: Pocket[]): Vector3[] {
+    return pockets.map((pocket) => pocket.pos)
+  }
+
+  /**
+   * Filters pockets that are 'forward' relative to the shot line,
+   * then selects the closest one to the target ball.
+   */
+  private findBestPocket(
+    cuePos: Vector3,
+    targetPos: Vector3,
+    pockets: Vector3[]
+  ): Vector3 | undefined {
+    return pockets
+      .filter((pocket) => this.isPocketAhead(cuePos, targetPos, pocket))
+      .sort(
+        (a, b) => this.distanceSq(targetPos, a) - this.distanceSq(targetPos, b)
+      )[0]
+  }
+
+  /**
+   * Checks if a pocket is reachable (ahead of the cue-to-target line).
+   * Uses dot product: (Cue->Target) . (Target->Pocket) > 0
+   */
+  private isPocketAhead(
+    cuePos: Vector3,
+    targetPos: Vector3,
+    pocket: Vector3
+  ): boolean {
+    const shotLine = this.getDirectionVector(cuePos, targetPos)
+    const pocketLine = this.getDirectionVector(targetPos, pocket)
+    return shotLine.dot(pocketLine) > 0
+  }
+
+  /**
+   * Calculates the Ghost Ball position (Aim Point).
+   * Logic: TargetPos + (Normalized(Pocket->Target) * 2 * Radius)
+   */
+  private calculateGhostBallPos(targetPos: Vector3, pocket: Vector3): Vector3 {
+    // Vector pointing FROM pocket TO target ball
+    const incidentVector = this.getDirectionVector(pocket, targetPos)
+
+    // Offset target position by 2 radii along that vector
+    return targetPos
+      .clone()
+      .add(incidentVector.multiplyScalar(this.ballRadius * 2))
+  }
+
+  // --- Low-level Helpers ---
+
+  private getDirectionVector(from: Vector3, to: Vector3): Vector3 {
+    return new Vector3().subVectors(to, from).normalize() // subVectors is immutable to inputs
+  }
+
+  private distanceSq(v1: Vector3, v2: Vector3): number {
+    return v1.distanceToSquared(v2) // Squared is faster than sqrt for sorting
+  }
+}

--- a/src/network/bot/eventhandler.ts
+++ b/src/network/bot/eventhandler.ts
@@ -5,18 +5,22 @@ import { EventType } from "../../events/eventtype"
 import { HitEvent } from "../../events/hitevent"
 import { Vector3 } from "three"
 import { R } from "../../model/physics/constants"
+import { AimCalculator } from "./aimcalculator"
+import { PocketGeometry } from "../../view/pocketgeometry"
 import { StartAimEvent } from "../../events/startaimevent"
 import { Outcome } from "../../model/outcome"
 import { NineBall } from "../../controller/rules/nineball"
 import { PlaceBallEvent } from "../../events/placeballevent"
 import { WatchEvent } from "../../events/watchevent"
 import { EventUtil } from "../../events/eventutil"
+import { atan2 } from "../../utils/utils"
 
 export class BotEventHandler {
   private logs: Logger
   private container: Container
   private publishToPlayer: (event: GameEvent) => void
   protected enqueueMessage: (message: string) => void
+  private calculator: AimCalculator
 
   constructor(
     logs: Logger,
@@ -28,6 +32,7 @@ export class BotEventHandler {
     this.container = container
     this.publishToPlayer = publishToPlayer
     this.enqueueMessage = enqueueMessage
+    this.calculator = new AimCalculator(R)
   }
 
   handle(event): void {
@@ -84,7 +89,7 @@ export class BotEventHandler {
   }
 
   private handleStartAim(): void {
-    const hitEvent = this.generateRandomShot()
+    const hitEvent = this.generateCalculatedShot()
     this.publishToPlayer(hitEvent)
   }
 
@@ -104,8 +109,41 @@ export class BotEventHandler {
       event.useStartPos ? event.pos : this.container.rules.placeBall()
     )
     cueball.setStationary()
-    const hitEvent = this.generateRandomShot()
+    const hitEvent = this.generateCalculatedShot()
     this.publishToPlayer(hitEvent)
+  }
+
+  private generateCalculatedShot(): HitEvent {
+    const table = this.container.table
+    const cueball = table.cueball
+    const targetBall = this.container.rules.nextCandidateBall()
+
+    if (!targetBall) {
+      return this.generateRandomShot()
+    }
+
+    const pockets = this.calculator.extractPocketPositions(
+      PocketGeometry.pocketCenters
+    )
+    const aimPoint = this.calculator.getAimPoint(
+      cueball.pos,
+      targetBall.pos,
+      pockets
+    )
+
+    if (!aimPoint) {
+      return this.generateRandomShot()
+    }
+
+    const lineTo = aimPoint.clone().sub(cueball.pos)
+    const aim = table.cue.aim
+    aim.angle = atan2(lineTo.y, lineTo.x)
+    aim.i = table.balls.indexOf(cueball)
+    aim.power = 80 * R
+    aim.offset = new Vector3(0, 0)
+
+    const hitEvent = new HitEvent(table.serialise())
+    return hitEvent
   }
 
   private generateRandomShot(): HitEvent {

--- a/src/network/bot/eventhandler.ts
+++ b/src/network/bot/eventhandler.ts
@@ -20,7 +20,7 @@ export class BotEventHandler {
   private container: Container
   private publishToPlayer: (event: GameEvent) => void
   protected enqueueMessage: (message: string) => void
-  private calculator: AimCalculator
+  private readonly calculator: AimCalculator
 
   constructor(
     logs: Logger,

--- a/test/network/bot/aimcalculator.spec.ts
+++ b/test/network/bot/aimcalculator.spec.ts
@@ -1,0 +1,67 @@
+import { Vector3 } from "three"
+import { AimCalculator } from "../../../src/network/bot/aimcalculator"
+import { Pocket } from "../../../src/model/physics/pocket"
+
+describe("AimCalculator", () => {
+  const ballRadius = 0.5
+  const calculator = new AimCalculator(ballRadius)
+
+  describe("getAimPoint", () => {
+    it("should return the ghost ball position for a simple straight shot", () => {
+      const cuePos = new Vector3(0, 0, 0)
+      const targetPos = new Vector3(2, 0, 0)
+      const pocketPos = new Vector3(4, 0, 0)
+      const pockets = [pocketPos]
+
+      const aimPoint = calculator.getAimPoint(cuePos, targetPos, pockets)
+
+      // Incident vector from pocket to target is (-1, 0, 0)
+      // Ghost ball is at targetPos + incidentVector * 2 * ballRadius
+      // Ghost ball = (2, 0, 0) + (-1, 0, 0) * 1 = (1, 0, 0)
+      expect(aimPoint?.x).toBeCloseTo(1)
+      expect(aimPoint?.y).toBeCloseTo(0)
+      expect(aimPoint?.z).toBeCloseTo(0)
+    })
+
+    it("should return null if no pockets are ahead", () => {
+      const cuePos = new Vector3(0, 0, 0)
+      const targetPos = new Vector3(2, 0, 0)
+      const pocketPos = new Vector3(-2, 0, 0) // Behind
+      const pockets = [pocketPos]
+
+      const aimPoint = calculator.getAimPoint(cuePos, targetPos, pockets)
+
+      expect(aimPoint).toBeNull()
+    })
+
+    it("should choose the closest pocket among those that are ahead", () => {
+      const cuePos = new Vector3(0, 0, 0)
+      const targetPos = new Vector3(2, 0, 0)
+      const pocket1 = new Vector3(10, 0, 0) // Far
+      const pocket2 = new Vector3(4, 0, 0) // Close
+      const pockets = [pocket1, pocket2]
+
+      const aimPoint = calculator.getAimPoint(cuePos, targetPos, pockets)
+
+      // Should choose pocket2
+      // Incident vector from pocket2 (4,0,0) to target (2,0,0) is (-1,0,0)
+      // Ghost ball = (2,0,0) + (-1,0,0) * 1 = (1,0,0)
+      expect(aimPoint?.x).toBeCloseTo(1)
+      expect(aimPoint?.y).toBeCloseTo(0)
+    })
+  })
+
+  describe("extractPocketPositions", () => {
+    it("should extract positions from a list of Pocket objects", () => {
+      const p1 = new Pocket(new Vector3(1, 2, 3), 1)
+      const p2 = new Pocket(new Vector3(4, 5, 6), 1)
+      const pockets = [p1, p2]
+
+      const positions = calculator.extractPocketPositions(pockets)
+
+      expect(positions).toHaveLength(2)
+      expect(positions[0]).toEqual(p1.pos)
+      expect(positions[1]).toEqual(p2.pos)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new `AimCalculator` class to the bot directory. This class is responsible for determining the optimal aim point (Ghost Ball position) for a given shot. It includes logic to filter pockets that are "ahead" of the shot line and select the closest one. It also provides a utility method to extract positions from `Pocket` objects and documents the expected source of these pockets. Unit tests are included to verify the logic.

---
*PR created automatically by Jules for task [18397829545405062756](https://jules.google.com/task/18397829545405062756) started by @tailuge*