### PR TITLE
Address code smells in BotRelay and BotEventHandler

### DIFF
--- a/src/network/bot/botrelay.ts
+++ b/src/network/bot/botrelay.ts
@@ -8,11 +8,11 @@ import { Container } from "../../container/container"
 import { GameEvent } from "../../events/gameevent"
 
 export class BotRelay implements MessageRelay {
-  private messageQueue: string[] = []
+  private readonly messageQueue: string[] = []
   private timeoutId: ReturnType<typeof setTimeout> | null = null
   private callback: ((message: string) => void) | null = null
-  private logs: Logger
-  private eventHandler: BotEventHandler
+  private readonly logs: Logger
+  private readonly eventHandler: BotEventHandler
 
   constructor(logs: Logger, container: Container) {
     this.logs = logs
@@ -45,9 +45,7 @@ export class BotRelay implements MessageRelay {
    */
   enqueueMessage(message: string): void {
     this.messageQueue.push(message)
-    if (this.timeoutId === null) {
-      this.timeoutId = setTimeout(() => this.processQueue(), 500)
-    }
+    this.timeoutId ??= setTimeout(() => this.processQueue(), 500)
   }
 
   publish(_channel: string, message: string, _prefix?: string): void {

--- a/src/network/bot/eventhandler.ts
+++ b/src/network/bot/eventhandler.ts
@@ -16,9 +16,9 @@ import { Respot } from "../../utils/respot"
 import { gameOverButtons } from "../../utils/gameover"
 
 export class BotEventHandler {
-  private logs: Logger
-  private container: Container
-  private publishToPlayer: (event: GameEvent) => void
+  private readonly logs: Logger
+  private readonly container: Container
+  private readonly publishToPlayer: (event: GameEvent) => void
   protected enqueueMessage: (message: string) => void
   private readonly calculator: AimCalculator
 
@@ -116,9 +116,9 @@ export class BotEventHandler {
     const table = this.container.table
 
     if (event.respot) {
-      const ball = table.balls.find((b) => b.id === event.respot!.id)
+      const ball = table.balls.find((b) => b.id === event.respot.id)
       if (ball) {
-        ball.pos.copy(event.respot!.pos)
+        ball.pos.copy(event.respot.pos)
         ball.setStationary()
       }
     }


### PR DESCRIPTION
This PR addresses several code smells in the bot-related classes to improve maintainability and follow TypeScript best practices.

Key changes:
1.  **Readonly Members:** Fields in `BotRelay` (`messageQueue`, `logs`, `eventHandler`) and `BotEventHandler` (`logs`, `container`, `publishToPlayer`) that are only assigned in the constructor are now marked as `readonly`.
2.  **Nullish Coalescing Assignment:** In `BotRelay.enqueueMessage`, the logic for initializing `this.timeoutId` has been simplified using the `??=` operator.
3.  **Redundant Assertions:** Removed unnecessary `!` operators in `BotEventHandler.handlePlaceBall` where the TypeScript compiler already knows `event.respot` is defined due to a preceding `if` block.

Tests were run and all passed.

---
*PR created automatically by Jules for task [283108514795820080](https://jules.google.com/task/283108514795820080) started by @tailuge*