### PR TITLE
Refactor: Address Maintainability Code Smells in Tests and Config

### DIFF
--- a/test/controller/controller.spec.ts
+++ b/test/controller/controller.spec.ts
@@ -205,9 +205,9 @@ describe("Controller", () => {
     container.table.cueball.setStationary()
     const ball1 = container.table.balls.find((b) => b.label === 1)!
     container.table.outcome.push(
-      Outcome.collision(container.table.cueball, ball1, 1)
+      Outcome.collision(container.table.cueball, ball1, 1),
+      Outcome.cushion(ball1, 1)
     )
-    container.table.outcome.push(Outcome.cushion(ball1, 1))
     container.eventQueue.push(new StationaryEvent())
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(Aim)
@@ -219,9 +219,9 @@ describe("Controller", () => {
     container.table.cueball.setStationary()
     const ball1 = container.table.balls.find((b) => b.label === 1)!
     container.table.outcome.push(
-      Outcome.collision(container.table.cueball, ball1, 1)
+      Outcome.collision(container.table.cueball, ball1, 1),
+      Outcome.pot(ball1, 1)
     )
-    container.table.outcome.push(Outcome.pot(ball1, 1))
     container.eventQueue.push(new StationaryEvent())
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(Aim)
@@ -235,9 +235,9 @@ describe("Controller", () => {
     const ball9 = container.table.balls.find((b) => b.label === 9)!
     ball9.state = State.Stationary
     container.table.outcome.push(
-      Outcome.collision(container.table.cueball, ball9, 1)
+      Outcome.collision(container.table.cueball, ball9, 1),
+      Outcome.pot(ball9, 1)
     )
-    container.table.outcome.push(Outcome.pot(ball9, 1))
     container.eventQueue.push(new StationaryEvent())
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(End)
@@ -319,23 +319,25 @@ describe("Controller", () => {
 
   it("Aim handles all inputs", (done) => {
     container.controller = new Aim(container)
-    container.inputQueue.push(new Input(0.1, "A"))
-    container.inputQueue.push(new Input(0.1, "ArrowLeft"))
-    container.inputQueue.push(new Input(0.1, "ArrowRight"))
-    container.inputQueue.push(new Input(0.1, "ShiftArrowLeft"))
-    container.inputQueue.push(new Input(0.1, "ShiftArrowRight"))
-    container.inputQueue.push(new Input(0.1, "ArrowUp"))
-    container.inputQueue.push(new Input(0.1, "ArrowDown"))
-    container.inputQueue.push(new Input(0.1, "Space"))
-    container.inputQueue.push(new Input(0.1, "SpaceUp"))
-    container.inputQueue.push(new Input(0.1, "KeyPUp"))
-    container.inputQueue.push(new Input(0.1, "KeyHUp"))
-    container.inputQueue.push(new Input(0.1, "KeyOUp"))
-    container.inputQueue.push(new Input(0.1, "KeyDUp"))
-    container.inputQueue.push(new Input(0.1, "NumpadAdd"))
-    container.inputQueue.push(new Input(0.1, "NumpadSubtract"))
-    container.inputQueue.push(new Input(0.1, "movementXUp"))
-    container.inputQueue.push(new Input(0.1, "movementYUp"))
+    container.inputQueue.push(
+      new Input(0.1, "A"),
+      new Input(0.1, "ArrowLeft"),
+      new Input(0.1, "ArrowRight"),
+      new Input(0.1, "ShiftArrowLeft"),
+      new Input(0.1, "ShiftArrowRight"),
+      new Input(0.1, "ArrowUp"),
+      new Input(0.1, "ArrowDown"),
+      new Input(0.1, "Space"),
+      new Input(0.1, "SpaceUp"),
+      new Input(0.1, "KeyPUp"),
+      new Input(0.1, "KeyHUp"),
+      new Input(0.1, "KeyOUp"),
+      new Input(0.1, "KeyDUp"),
+      new Input(0.1, "NumpadAdd"),
+      new Input(0.1, "NumpadSubtract"),
+      new Input(0.1, "movementXUp"),
+      new Input(0.1, "movementYUp")
+    )
 
     let count = container.inputQueue.length
     while (count-- > 0) {

--- a/test/controller/replay.spec.ts
+++ b/test/controller/replay.spec.ts
@@ -104,8 +104,7 @@ describe("Controller Replay", () => {
 
   it("Replay handles inputs", (done) => {
     container.controller = replayController
-    container.inputQueue.push(new Input(0.1, "KeyOUp"))
-    container.inputQueue.push(new Input(0.1, "KeyDUp"))
+    container.inputQueue.push(new Input(0.1, "KeyOUp"), new Input(0.1, "KeyDUp"))
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(Replay)
     done()

--- a/test/gen/diamond.spec.ts
+++ b/test/gen/diamond.spec.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai"
 import JSONCrush from "jsoncrush"
+import { console as nodeConsole } from "node:console"
 
-const jestConsole = console
+const jestConsole = globalThis.console
 
 beforeEach(() => {
-  globalThis.console = require("console")
+  globalThis.console = nodeConsole
 })
 
 afterEach(() => {

--- a/test/model/cushion.spec.ts
+++ b/test/model/cushion.spec.ts
@@ -8,18 +8,34 @@ import { Vector3 } from "three"
 import { PocketGeometry } from "../../src/view/pocketgeometry"
 import { R } from "../../src/model/physics/constants"
 import { bounceHan, bounceHanBlend } from "../../src/model/physics/physics"
+import { console as nodeConsole } from "node:console"
 
 const t = 0.1
 
-const jestConsole = console
+const jestConsole = globalThis.console
 
 beforeEach(() => {
-  globalThis.console = require("console")
+  globalThis.console = nodeConsole
 })
 
 afterEach(() => {
   globalThis.console = jestConsole
 })
+
+function bounceInXWithSpin(rvel) {
+  const pos = new Vector3(TableGeometry.tableX, 0, 0)
+  const ball = new Ball(pos)
+  ball.vel.x = 1
+  ball.rvel.copy(rvel)
+  Cushion.bounceAny(ball, t)
+  return ball
+}
+
+function ballAtXCushion() {
+  const pos = new Vector3(TableGeometry.tableX, 0, 0)
+  const ball = new Ball(pos)
+  return ball
+}
 
 describe("Cushion", () => {
   it("bounces off X cushion", (done) => {
@@ -71,15 +87,6 @@ describe("Cushion", () => {
     expect(ball.vel.x).to.be.below(0)
     done()
   })
-
-  function bounceInXWithSpin(rvel) {
-    const pos = new Vector3(TableGeometry.tableX, 0, 0)
-    const ball = new Ball(pos)
-    ball.vel.x = 1
-    ball.rvel.copy(rvel)
-    Cushion.bounceAny(ball, t)
-    return ball
-  }
 
   it("bounces off X cushion with rhs spins", (done) => {
     const ball = bounceInXWithSpin(new Vector3(0, 0, 1))
@@ -182,12 +189,6 @@ describe("Cushion", () => {
     expect(groupWithoutPockets.children.length).to.be.greaterThan(0)
     done()
   })
-
-  function ballAtXCushion() {
-    const pos = new Vector3(TableGeometry.tableX, 0, 0)
-    const ball = new Ball(pos)
-    return ball
-  }
 
   it.each([
     ["bounceHan", bounceHan],

--- a/test/rules/fourteenone.spec.ts
+++ b/test/rules/fourteenone.spec.ts
@@ -11,13 +11,14 @@ import { BeginEvent } from "../../src/events/beginevent"
 import { Input } from "../../src/events/input"
 import { RerackEvent } from "../../src/events/rerackevent"
 import { Assets } from "../../src/view/assets"
+import { console as nodeConsole } from "node:console"
 
 initDom()
 
-const jestConsole = console
+const jestConsole = globalThis.console
 
 beforeEach(() => {
-  globalThis.console = require("console")
+  globalThis.console = nodeConsole
 })
 
 afterEach(() => {

--- a/test/rules/threecushion.spec.ts
+++ b/test/rules/threecushion.spec.ts
@@ -49,11 +49,13 @@ describe("ThreeCushion", () => {
     container.table.balls[0].setStationary()
     container.eventQueue.push(new StationaryEvent())
     const balls = container.table.balls
-    container.table.outcome.push(Outcome.cushion(balls[0], 1))
-    container.table.outcome.push(Outcome.cushion(balls[0], 1))
-    container.table.outcome.push(Outcome.cushion(balls[0], 1))
-    container.table.outcome.push(Outcome.collision(balls[0], balls[1], 1))
-    container.table.outcome.push(Outcome.collision(balls[0], balls[2], 1))
+    container.table.outcome.push(
+      Outcome.cushion(balls[0], 1),
+      Outcome.cushion(balls[0], 1),
+      Outcome.cushion(balls[0], 1),
+      Outcome.collision(balls[0], balls[1], 1),
+      Outcome.collision(balls[0], balls[2], 1)
+    )
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(Aim)
     done()
@@ -95,21 +97,23 @@ describe("ThreeCushion", () => {
   const redBall = {}
 
   it("Valid threecushion outcome", (done) => {
-    const outcomes: Outcome[] = []
-    outcomes.push(Outcome.collision(oppononetBall, cueBall, 1))
-    outcomes.push(Outcome.cushion(cueBall, 1))
-    outcomes.push(Outcome.cushion(cueBall, 1))
-    outcomes.push(Outcome.cushion(cueBall, 1))
-    outcomes.push(Outcome.collision(cueBall, redBall, 1))
+    const outcomes: Outcome[] = [
+      Outcome.collision(oppononetBall, cueBall, 1),
+      Outcome.cushion(cueBall, 1),
+      Outcome.cushion(cueBall, 1),
+      Outcome.cushion(cueBall, 1),
+      Outcome.collision(cueBall, redBall, 1),
+    ]
     expect(Outcome.isThreeCushionPoint(cueBall, outcomes)).to.be.true
     done()
   })
 
   it("Invalid threecushion outcome", (done) => {
-    const outcomes: Outcome[] = []
-    outcomes.push(Outcome.collision(oppononetBall, cueBall, 1))
-    outcomes.push(Outcome.cushion(cueBall, 1))
-    outcomes.push(Outcome.cushion(cueBall, 1))
+    const outcomes: Outcome[] = [
+      Outcome.collision(oppononetBall, cueBall, 1),
+      Outcome.cushion(cueBall, 1),
+      Outcome.cushion(cueBall, 1),
+    ]
     expect(Outcome.isThreeCushionPoint(cueBall, outcomes)).to.be.false
     outcomes.push(Outcome.collision(cueBall, redBall, 1))
     expect(Outcome.isThreeCushionPoint(cueBall, outcomes)).to.be.false
@@ -136,11 +140,13 @@ describe("ThreeCushion", () => {
     container.table.cueball.setStationary()
     container.eventQueue.push(new StationaryEvent())
     const balls = container.table.balls
-    container.table.outcome.push(Outcome.collision(balls[0], balls[1], 1))
-    container.table.outcome.push(Outcome.cushion(balls[0], 1))
-    container.table.outcome.push(Outcome.cushion(balls[0], 1))
-    container.table.outcome.push(Outcome.cushion(balls[0], 1))
-    container.table.outcome.push(Outcome.collision(balls[0], balls[2], 1))
+    container.table.outcome.push(
+      Outcome.collision(balls[0], balls[1], 1),
+      Outcome.cushion(balls[0], 1),
+      Outcome.cushion(balls[0], 1),
+      Outcome.cushion(balls[0], 1),
+      Outcome.collision(balls[0], balls[2], 1)
+    )
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(End)
     done()

--- a/test/server/messagerelay.spec.ts
+++ b/test/server/messagerelay.spec.ts
@@ -3,11 +3,12 @@ import { InMemoryMessageRelay } from "../mocks/inmemorymessagerelay"
 import { MessageRelay } from "../../src/network/client/messagerelay"
 import { BreakEvent } from "../../src/events/breakevent"
 import { EventUtil } from "../../src/events/eventutil"
+import { console as nodeConsole } from "node:console"
 
-const jestConsole = console
+const jestConsole = globalThis.console
 
 beforeEach(() => {
-  globalThis.console = require("console")
+  globalThis.console = nodeConsole
 })
 
 afterEach(() => {

--- a/test/server/session.spec.ts
+++ b/test/server/session.spec.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai"
 import { Session } from "../../src/network/client/session"
+import { console as nodeConsole } from "node:console"
 
-const jestConsole = console
+const jestConsole = globalThis.console
 
 beforeEach(() => {
-  globalThis.console = require("console")
+  globalThis.console = nodeConsole
 })
 
 afterEach(() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require("path")
+const path = require("node:path")
 const TerserPlugin = require("terser-webpack-plugin")
 let packagedeps = require("./package.json")
 module.exports = {


### PR DESCRIPTION
This PR addresses several "Code Smell" issues identified in test files and the webpack configuration.

Key changes:
1. **Consolidated `Array#push()` calls**: Multiple consecutive `push()` calls to `container.table.outcome`, `container.inputQueue`, and local arrays were merged into single calls with multiple arguments or replaced with array literal initializations. This improves both performance and readability.
2. **Standardized Node.js Built-in Imports**: Updated `require` and `import` statements to use the `node:` prefix for `console` and `path`.
3. **Refactored Console Handling in Tests**: Replaced `const jestConsole = console` with `const jestConsole = globalThis.console` and updated `require("console")` to `import { console as nodeConsole } from "node:console"` to satisfy linting rules and improve explicitness.
4. **Improved Function Scoping**: Moved helper functions in `test/model/cushion.spec.ts` from nested scopes to the module scope to avoid re-defining them during repeated test executions.

Verified all changes by running `yarn test`, with all 261 tests passing. `eslint` was also run on the modified files to ensure they are clean of identified smells.

---
*PR created automatically by Jules for task [17207736016188286865](https://jules.google.com/task/17207736016188286865) started by @tailuge*