### PR TITLE
Fix redundant type assertions and add readonly modifiers

### DIFF
--- a/test/diagram/realposition.spec.ts
+++ b/test/diagram/realposition.spec.ts
@@ -28,7 +28,7 @@ describe("RealPosition", () => {
     const result = real.getPositionsAtTime(545599, 0.4)
     console.log(result)
     expect(result).to.not.be.null
-    expect(result!["1"].x).to.be.closeTo(1.5, 0.01)
+    expect(result["1"].x).to.be.closeTo(1.5, 0.01)
     done()
   })
 })

--- a/test/mocks/inmemorymessagerelay.ts
+++ b/test/mocks/inmemorymessagerelay.ts
@@ -1,7 +1,10 @@
 import { MessageRelay } from "../../src/network/client/messagerelay"
 
 export class InMemoryMessageRelay implements MessageRelay {
-  private subscriptions: Map<string, Set<(message: string) => void>> = new Map()
+  private readonly subscriptions: Map<
+    string,
+    Set<(message: string) => void>
+  > = new Map()
 
   subscribe(
     channel: string,

--- a/test/network/bot/eventhandler.spec.ts
+++ b/test/network/bot/eventhandler.spec.ts
@@ -75,7 +75,7 @@ describe("BotEventHandler Respot Logic", () => {
     )
     expect(placeBallEvents).to.have.length(1)
 
-    const placeBallEvent = placeBallEvents[0] as PlaceBallEvent
+    const placeBallEvent = placeBallEvents[0]
 
     const cueBallPos = placeBallEvent.pos
     expect(cueBallPos.x).to.be.lessThan(0)
@@ -215,7 +215,7 @@ describe("BotEventHandler Respot Logic", () => {
 
     // Verify result is PlaceBall controller with correct position
     expect(resultController).to.be.instanceof(PlaceBall)
-    const placeBallController = resultController as PlaceBall
+    const placeBallController = resultController
 
     // Cue ball position should be in kitchen (negative x)
     expect(placeBallController.startPos.x).to.be.lessThan(0)

--- a/test/rules/nineball.spec.ts
+++ b/test/rules/nineball.spec.ts
@@ -135,7 +135,7 @@ describe("NineBall Rules", () => {
 
     const rerackEvents = sentEvents.filter((e) => e instanceof RerackEvent)
     expect(rerackEvents).to.have.length(1)
-    const rerack = rerackEvents[0] as RerackEvent
+    const rerack = rerackEvents[0]
     expect(rerack.ballinfo.balls).to.have.length(1)
     expect(rerack.ballinfo.balls[0].id).to.equal(nineBall.id)
 


### PR DESCRIPTION
This PR addresses 5 code smells identified by SonarCloud:
1. Unnecessary non-null assertion in `test/diagram/realposition.spec.ts`.
2. Unnecessary type assertions in `test/network/bot/eventhandler.spec.ts` (L78 and L218).
3. Unnecessary type assertion in `test/rules/nineball.spec.ts` (L138).
4. Missing `readonly` modifier for `subscriptions` in `test/mocks/inmemorymessagerelay.ts`.

All tests and linting passed.

---
*PR created automatically by Jules for task [3686780422667229179](https://jules.google.com/task/3686780422667229179) started by @tailuge*