### PR TITLE
Refactor static properties to readonly to resolve code smells

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -53,6 +53,7 @@ export class Container {
   lobbyIndicator: LobbyIndicator
   relay: MessageRelay | null = null
   scoreReporter: ScoreReporter | null = null
+  zoomFactor: number = 1
   frame: (timestamp: number) => void
 
   private localScores = {
@@ -82,9 +83,11 @@ export class Container {
       id,
       relay = null,
       scoreReporter = null,
+      zoomFactor,
     } = config
     this.log = log
     this.rules = RuleFactory.create(ruletype, this)
+    this.zoomFactor = zoomFactor ?? this.rules.zoomFactor ?? 1
     this.table = this.rules.table()
     this.view = new View(element, this.table, assets)
     this.table.cue.aimInputs = new AimInputs(this)
@@ -260,7 +263,7 @@ export class Container {
       this.table.advance(this.step)
     }
     this.table.updateBallMesh(computedElapsed)
-    this.view.update(computedElapsed, this.table.cue.aim)
+    this.view.update(computedElapsed, this.table.cue.aim, this.zoomFactor)
     this.table.cue.update(computedElapsed)
     if (!stateBefore && this.table.allStationary()) {
       this.eventQueue.push(new StationaryEvent())

--- a/src/container/containerconfig.ts
+++ b/src/container/containerconfig.ts
@@ -11,4 +11,5 @@ export interface ContainerConfig {
   id?: string
   relay?: MessageRelay | null
   scoreReporter?: ScoreReporter | null
+  zoomFactor?: number
 }

--- a/src/controller/rules/nineball.ts
+++ b/src/controller/rules/nineball.ts
@@ -25,6 +25,7 @@ export class NineBall implements Rules {
   currentBreak = 0
   previousBreak = 0
   rulename = "nineball"
+  readonly zoomFactor = 1
 
   constructor(container) {
     this.container = container

--- a/src/controller/rules/rules.ts
+++ b/src/controller/rules/rules.ts
@@ -23,4 +23,5 @@ export interface Rules {
   nextCandidateBall()
   startTurn()
   handleGameEnd(isWinner: boolean): Controller
+  readonly zoomFactor?: number
 }

--- a/src/controller/rules/snooker.ts
+++ b/src/controller/rules/snooker.ts
@@ -27,6 +27,7 @@ export class Snooker implements Rules {
   previousBreak = 0
   foulPoints = 0
   rulename = "snooker"
+  readonly zoomFactor = 1
 
   static readonly tablemodel = "models/d-snooker.min.gltf"
 

--- a/src/controller/rules/threecushion.ts
+++ b/src/controller/rules/threecushion.ts
@@ -9,7 +9,6 @@ import { Outcome } from "../../model/outcome"
 import { R } from "../../model/physics/constants"
 import { Table } from "../../model/table"
 import { Rack } from "../../utils/rack"
-import { CameraTop } from "../../view/cameratop"
 import { TableGeometry } from "../../view/tablegeometry"
 import { Rules } from "./rules"
 import { zero, isFirstShot } from "../../utils/utils"
@@ -25,6 +24,7 @@ export class ThreeCushion implements Rules {
   currentBreak = 0
   previousBreak = 0
   rulename = "threecushion"
+  readonly zoomFactor = 0.92
 
   constructor(container) {
     this.container = container
@@ -66,7 +66,6 @@ export class ThreeCushion implements Rules {
 
   table(): Table {
     this.tableGeometry()
-    CameraTop.zoomFactor = 0.92
     const table = new Table(this.rack())
     this.cueball = table.cueball
     return table

--- a/src/diagram/diagramcontainer.ts
+++ b/src/diagram/diagramcontainer.ts
@@ -2,7 +2,6 @@ import { Container } from "../container/container"
 import { ContainerConfig } from "../container/containerconfig"
 import { Keyboard } from "../events/keyboard"
 import { BreakEvent } from "../events/breakevent"
-import { CameraTop } from "../view/cameratop"
 import { bounceHan } from "../model/physics/physics"
 import { Assets } from "../view/assets"
 import { RealOverlay } from "./real/realoverlay"
@@ -28,7 +27,6 @@ export class DiagramContainer {
     this.replay = replay
     this.ruletype = ruletype
     this.canvas3d = canvas3d
-    CameraTop.zoomFactor = 0.88
   }
 
   start() {
@@ -39,6 +37,7 @@ export class DiagramContainer {
       assets: Assets.localAssets(this.ruletype),
       ruletype: this.ruletype,
       keyboard: keyboard,
+      zoomFactor: 0.88,
       id: "diagram",
     }
     this.container = new Container(config)

--- a/src/view/assets.ts
+++ b/src/view/assets.ts
@@ -4,7 +4,6 @@ import { importGltf } from "../utils/gltf"
 import { Rules } from "../controller/rules/rules"
 import { Sound } from "./sound"
 import { TableMesh } from "./tablemesh"
-import { CueMesh } from "./cuemesh"
 import { TableGeometry } from "./tablegeometry"
 
 export class Assets {
@@ -35,7 +34,6 @@ export class Assets {
     })
     importGltf("models/cue.gltf", (m) => {
       this.cue = m
-      CueMesh.mesh = m.scene.children[0]
       this.done()
     })
   }

--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -20,22 +20,27 @@ export class Camera {
 
   elapsed: number
 
-  update(elapsed, aim: AimEvent) {
+  update(elapsed, aim: AimEvent, zoomFactor: number = 1) {
     this.elapsed = elapsed
-    this.mode(aim)
+    this.mode(aim, zoomFactor)
   }
 
-  topView(_: AimEvent) {
+  topView(_: AimEvent, zoomFactor: number = 1) {
     this.camera.fov = CameraTop.fov
     this.camera.position.lerp(
-      CameraTop.viewPoint(this.camera.aspect, this.camera.fov, this.tempVec),
+      CameraTop.viewPoint(
+        this.camera.aspect,
+        this.camera.fov,
+        zoomFactor,
+        this.tempVec
+      ),
       0.9
     )
     this.camera.up = up
     this.camera.lookAt(zero)
   }
 
-  aimView(aim: AimEvent, fraction = 0.08) {
+  aimView(aim: AimEvent, _zoomFactor: number = 1, fraction = 0.08) {
     const h = this.height
     const portrait = this.camera.aspect < 0.8
     this.camera.fov = portrait ? 60 : 40

--- a/src/view/cameratop.ts
+++ b/src/view/cameratop.ts
@@ -6,21 +6,18 @@ export class CameraTop {
   static readonly aspectLimit = 1.78
   static readonly portrait = 0.95
   static readonly fov = 20
-  static zoomFactor = 1
+  static readonly zoomFactor = 1
 
   private static lastFov: number
   private static lastZoom: number
   private static cachedDist: number
 
-  static viewPoint(aspectRatio, fov, target = new Vector3()) {
-    if (
-      fov !== CameraTop.lastFov ||
-      CameraTop.zoomFactor !== CameraTop.lastZoom
-    ) {
+  static viewPoint(aspectRatio, fov, zoomFactor = 1, target = new Vector3()) {
+    if (fov !== CameraTop.lastFov || zoomFactor !== CameraTop.lastZoom) {
       CameraTop.cachedDist =
-        CameraTop.zoomFactor / (2 * Math.tan((fov * Math.PI) / 360))
+        zoomFactor / (2 * Math.tan((fov * Math.PI) / 360))
       CameraTop.lastFov = fov
-      CameraTop.lastZoom = CameraTop.zoomFactor
+      CameraTop.lastZoom = zoomFactor
     }
     const dist = CameraTop.cachedDist
 

--- a/src/view/cuemesh.ts
+++ b/src/view/cuemesh.ts
@@ -10,7 +10,7 @@ import {
 } from "three"
 
 export class CueMesh {
-  static mesh: Mesh
+  static readonly mesh: Mesh = undefined as any
 
   private static readonly material = new MeshPhongMaterial({
     color: 0x885577,

--- a/src/view/pocketgeometry.ts
+++ b/src/view/pocketgeometry.ts
@@ -8,39 +8,149 @@ import { R } from "../model/physics/constants"
 // N 1 0.9 Qn{x: 0, y: 12.0, z: 0}
 
 export class PocketGeometry {
-  static PX: number
-  static PY: number
-  static knuckleInset: number
-  static knuckleRadius: number
-  static middleKnuckleInset: number
-  static middleKnuckleRadius: number
-  static cornerRadius: number
-  static middleRadius: number
+  static readonly PX = TableGeometry.tableX + R * (0.8 / 0.5)
+  static readonly PY = TableGeometry.tableY + R * (0.8 / 0.5)
+  static readonly knuckleInset = (R * 1.6) / 0.5
+  static readonly knuckleRadius = (R * 0.31) / 0.5
+  static readonly middleKnuckleInset = (R * 1.385) / 0.5
+  static readonly middleKnuckleRadius = (R * 0.2) / 0.5
+  static readonly cornerRadius = (R * 1.1) / 0.5
+  static readonly middleRadius = (R * 0.9) / 0.5
 
-  static pockets
-  static knuckles
-  static pocketCenters
+  static readonly pockets: { [key: string]: any } = PocketGeometry.pocketLayout(R)
+  static readonly knuckles: Knuckle[] = PocketGeometry.enumerateKnuckles()
+  static readonly pocketCenters: Pocket[] = PocketGeometry.enumerateCenters()
 
-  static {
-    PocketGeometry.scaleToRadius(R)
+  private static pocketLayout(r) {
+    const px = PocketGeometry.PX
+    const py = PocketGeometry.PY
+    const cornerRadius = PocketGeometry.cornerRadius
+    const middleRadius = PocketGeometry.middleRadius
+    const knuckleInset = PocketGeometry.knuckleInset
+    const knuckleRadius = PocketGeometry.knuckleRadius
+    const middleKnuckleInset = PocketGeometry.middleKnuckleInset
+    const middleKnuckleRadius = PocketGeometry.middleKnuckleRadius
+
+    return {
+      pocketNW: {
+        pocket: new Pocket(new Vector3(-px, py, 0), cornerRadius),
+        knuckleNE: new Knuckle(
+          new Vector3(
+            -TableGeometry.X + knuckleInset,
+            TableGeometry.Y + knuckleRadius,
+            0
+          ),
+          knuckleRadius
+        ),
+        knuckleSW: new Knuckle(
+          new Vector3(
+            -TableGeometry.X - knuckleRadius,
+            TableGeometry.Y - knuckleInset,
+            0
+          ),
+          knuckleRadius
+        ),
+      },
+      pocketN: {
+        pocket: new Pocket(new Vector3(0, py + (r * 0.7) / 0.5, 0), middleRadius),
+        knuckleNE: new Knuckle(
+          new Vector3(
+            middleKnuckleInset,
+            TableGeometry.Y + middleKnuckleRadius,
+            0
+          ),
+          middleKnuckleRadius
+        ),
+        knuckleNW: new Knuckle(
+          new Vector3(
+            -middleKnuckleInset,
+            TableGeometry.Y + middleKnuckleRadius,
+            0
+          ),
+          middleKnuckleRadius
+        ),
+      },
+      pocketS: {
+        pocket: new Pocket(new Vector3(0, -py - (r * 0.7) / 0.5, 0), middleRadius),
+        knuckleSE: new Knuckle(
+          new Vector3(
+            middleKnuckleInset,
+            -TableGeometry.Y - middleKnuckleRadius,
+            0
+          ),
+          middleKnuckleRadius
+        ),
+        knuckleSW: new Knuckle(
+          new Vector3(
+            -middleKnuckleInset,
+            -TableGeometry.Y - middleKnuckleRadius,
+            0
+          ),
+          middleKnuckleRadius
+        ),
+      },
+      pocketNE: {
+        pocket: new Pocket(new Vector3(px, py, 0), cornerRadius),
+        knuckleNW: new Knuckle(
+          new Vector3(
+            TableGeometry.X - knuckleInset,
+            TableGeometry.Y + knuckleRadius,
+            0
+          ),
+          knuckleRadius
+        ),
+        knuckleSE: new Knuckle(
+          new Vector3(
+            TableGeometry.X + knuckleRadius,
+            TableGeometry.Y - knuckleInset,
+            0
+          ),
+          knuckleRadius
+        ),
+      },
+      pocketSE: {
+        pocket: new Pocket(new Vector3(px, -py, 0), cornerRadius),
+        knuckleNE: new Knuckle(
+          new Vector3(
+            TableGeometry.X + knuckleRadius,
+            -TableGeometry.Y + knuckleInset,
+            0
+          ),
+          knuckleRadius
+        ),
+        knuckleSW: new Knuckle(
+          new Vector3(
+            TableGeometry.X - knuckleInset,
+            -TableGeometry.Y - knuckleRadius,
+            0
+          ),
+          knuckleRadius
+        ),
+      },
+      pocketSW: {
+        pocket: new Pocket(new Vector3(-px, -py, 0), cornerRadius),
+        knuckleSE: new Knuckle(
+          new Vector3(
+            -TableGeometry.X + knuckleInset,
+            -TableGeometry.Y - knuckleRadius,
+            0
+          ),
+          knuckleRadius
+        ),
+        knuckleNW: new Knuckle(
+          new Vector3(
+            -TableGeometry.X - knuckleRadius,
+            -TableGeometry.Y + knuckleInset,
+            0
+          ),
+          knuckleRadius
+        ),
+      },
+    }
   }
 
-  static scaleToRadius(R) {
-    PocketGeometry.PX = TableGeometry.tableX + R * (0.8 / 0.5)
-    PocketGeometry.PY = TableGeometry.tableY + R * (0.8 / 0.5)
-    PocketGeometry.knuckleInset = (R * 1.6) / 0.5
-    PocketGeometry.knuckleRadius = (R * 0.31) / 0.5
-    PocketGeometry.middleKnuckleInset = (R * 1.385) / 0.5
-    PocketGeometry.middleKnuckleRadius = (R * 0.2) / 0.5
-    PocketGeometry.cornerRadius = (R * 1.1) / 0.5
-    PocketGeometry.middleRadius = (R * 0.9) / 0.5
-    PocketGeometry.pocketLayout(R)
-    PocketGeometry.enumerateCenters()
-    PocketGeometry.enumerateKnuckles()
-  }
-
-  static enumerateKnuckles() {
-    PocketGeometry.knuckles = [
+  private static enumerateKnuckles() {
+    return [
       PocketGeometry.pockets.pocketNW.knuckleNE,
       PocketGeometry.pockets.pocketNW.knuckleSW,
       PocketGeometry.pockets.pocketN.knuckleNW,
@@ -56,8 +166,8 @@ export class PocketGeometry {
     ]
   }
 
-  static enumerateCenters() {
-    PocketGeometry.pocketCenters = [
+  private static enumerateCenters() {
+    return [
       PocketGeometry.pockets.pocketNW.pocket,
       PocketGeometry.pockets.pocketSW.pocket,
       PocketGeometry.pockets.pocketN.pocket,
@@ -65,142 +175,5 @@ export class PocketGeometry {
       PocketGeometry.pockets.pocketNE.pocket,
       PocketGeometry.pockets.pocketSE.pocket,
     ]
-  }
-
-  static pocketLayout(R) {
-    PocketGeometry.pockets = {
-      pocketNW: {
-        pocket: new Pocket(
-          new Vector3(-PocketGeometry.PX, PocketGeometry.PY, 0),
-          PocketGeometry.cornerRadius
-        ),
-        knuckleNE: new Knuckle(
-          new Vector3(
-            -TableGeometry.X + PocketGeometry.knuckleInset,
-            TableGeometry.Y + PocketGeometry.knuckleRadius,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-        knuckleSW: new Knuckle(
-          new Vector3(
-            -TableGeometry.X - PocketGeometry.knuckleRadius,
-            TableGeometry.Y - PocketGeometry.knuckleInset,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-      },
-      pocketN: {
-        pocket: new Pocket(
-          new Vector3(0, PocketGeometry.PY + (R * 0.7) / 0.5, 0),
-          PocketGeometry.middleRadius
-        ),
-        knuckleNE: new Knuckle(
-          new Vector3(
-            PocketGeometry.middleKnuckleInset,
-            TableGeometry.Y + PocketGeometry.middleKnuckleRadius,
-            0
-          ),
-          PocketGeometry.middleKnuckleRadius
-        ),
-        knuckleNW: new Knuckle(
-          new Vector3(
-            -PocketGeometry.middleKnuckleInset,
-            TableGeometry.Y + PocketGeometry.middleKnuckleRadius,
-            0
-          ),
-          PocketGeometry.middleKnuckleRadius
-        ),
-      },
-      pocketS: {
-        pocket: new Pocket(
-          new Vector3(0, -PocketGeometry.PY - (R * 0.7) / 0.5, 0),
-          PocketGeometry.middleRadius
-        ),
-        knuckleSE: new Knuckle(
-          new Vector3(
-            PocketGeometry.middleKnuckleInset,
-            -TableGeometry.Y - PocketGeometry.middleKnuckleRadius,
-            0
-          ),
-          PocketGeometry.middleKnuckleRadius
-        ),
-        knuckleSW: new Knuckle(
-          new Vector3(
-            -PocketGeometry.middleKnuckleInset,
-            -TableGeometry.Y - PocketGeometry.middleKnuckleRadius,
-            0
-          ),
-          PocketGeometry.middleKnuckleRadius
-        ),
-      },
-      pocketNE: {
-        pocket: new Pocket(
-          new Vector3(PocketGeometry.PX, PocketGeometry.PY, 0),
-          PocketGeometry.cornerRadius
-        ),
-        knuckleNW: new Knuckle(
-          new Vector3(
-            TableGeometry.X - PocketGeometry.knuckleInset,
-            TableGeometry.Y + PocketGeometry.knuckleRadius,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-        knuckleSE: new Knuckle(
-          new Vector3(
-            TableGeometry.X + PocketGeometry.knuckleRadius,
-            TableGeometry.Y - PocketGeometry.knuckleInset,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-      },
-      pocketSE: {
-        pocket: new Pocket(
-          new Vector3(PocketGeometry.PX, -PocketGeometry.PY, 0),
-          PocketGeometry.cornerRadius
-        ),
-        knuckleNE: new Knuckle(
-          new Vector3(
-            TableGeometry.X + PocketGeometry.knuckleRadius,
-            -TableGeometry.Y + PocketGeometry.knuckleInset,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-        knuckleSW: new Knuckle(
-          new Vector3(
-            TableGeometry.X - PocketGeometry.knuckleInset,
-            -TableGeometry.Y - PocketGeometry.knuckleRadius,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-      },
-      pocketSW: {
-        pocket: new Pocket(
-          new Vector3(-PocketGeometry.PX, -PocketGeometry.PY, 0),
-          PocketGeometry.cornerRadius
-        ),
-        knuckleSE: new Knuckle(
-          new Vector3(
-            -TableGeometry.X + PocketGeometry.knuckleInset,
-            -TableGeometry.Y - PocketGeometry.knuckleRadius,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-        knuckleNW: new Knuckle(
-          new Vector3(
-            -TableGeometry.X - PocketGeometry.knuckleRadius,
-            -TableGeometry.Y + PocketGeometry.knuckleInset,
-            0
-          ),
-          PocketGeometry.knuckleRadius
-        ),
-      },
-    }
   }
 }

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -34,8 +34,8 @@ export class View {
     this.initialiseScene()
   }
 
-  update(elapsed, aim: AimEvent) {
-    this.camera.update(elapsed, aim)
+  update(elapsed, aim: AimEvent, zoomFactor: number = 1) {
+    this.camera.update(elapsed, aim, zoomFactor)
   }
 
   sizeChanged() {


### PR DESCRIPTION
This PR addresses several SonarCloud "Code Smell" reports by making `public static` properties `readonly`. 

Key changes:
1. **PocketGeometry**: Converted all 11 static properties to `readonly`. Since they were previously initialized in a static block using logic derived from other constants, they are now initialized inline at declaration using private static helper methods.
2. **CueMesh**: Made the `mesh` property `readonly`. Investigation revealed this property was completely unused in the application (the cue rendering uses `createCue` which returns a new mesh). Removed the redundant assignment in `assets.ts`.
3. **CameraTop**: Resolved the static mutability of `zoomFactor`. Instead of a global static, `zoomFactor` is now part of the `Rules` and `ContainerConfig` state. It is passed down to `CameraTop.viewPoint` during the rendering loop. This improves maintainability by removing global state and allowing per-instance zoom configurations.

All tests passed, and linting is clean.

---
*PR created automatically by Jules for task [17527400713385266782](https://jules.google.com/task/17527400713385266782) started by @tailuge*