### PR TITLE
Refactor network modules to address code smells

### DIFF
--- a/src/network/bot/aimcalculator.ts
+++ b/src/network/bot/aimcalculator.ts
@@ -60,9 +60,10 @@ export class AimCalculator {
     // Use filtered list if available, otherwise fallback to the full list
     const candidates = ahead.length > 0 ? ahead : pockets
 
-    return candidates.sort(
+    const sorted = [...candidates].sort(
       (a, b) => a.distanceToSquared(targetPos) - b.distanceToSquared(targetPos)
-    )[0]
+    )
+    return sorted[0]
   }
 
   private isPocketAhead(

--- a/src/network/client/presenceclient.ts
+++ b/src/network/client/presenceclient.ts
@@ -59,9 +59,12 @@ export class PresenceClient {
       this.pruneAndNotify(Date.now())
     }, 1000)
 
-    if (typeof window !== "undefined" && window.addEventListener) {
-      window.addEventListener("beforeunload", this.handleUnload)
-      window.addEventListener("pagehide", this.handleUnload)
+    if (
+      typeof globalThis.window !== "undefined" &&
+      globalThis.window.addEventListener
+    ) {
+      globalThis.window.addEventListener("beforeunload", this.handleUnload)
+      globalThis.window.addEventListener("pagehide", this.handleUnload)
     }
   }
 
@@ -77,9 +80,12 @@ export class PresenceClient {
       clearInterval(this.pruneTimer)
       this.pruneTimer = null
     }
-    if (typeof window !== "undefined" && window.removeEventListener) {
-      window.removeEventListener("beforeunload", this.handleUnload)
-      window.removeEventListener("pagehide", this.handleUnload)
+    if (
+      typeof globalThis.window !== "undefined" &&
+      globalThis.window.removeEventListener
+    ) {
+      globalThis.window.removeEventListener("beforeunload", this.handleUnload)
+      globalThis.window.removeEventListener("pagehide", this.handleUnload)
     }
     if (this.websocket) {
       try {
@@ -92,7 +98,7 @@ export class PresenceClient {
     this.publish("leave", true)
   }
 
-  private handleUnload = (): void => {
+  private readonly handleUnload = (): void => {
     this.publish("leave", true)
   }
 

--- a/src/network/client/scorereporter.ts
+++ b/src/network/client/scorereporter.ts
@@ -2,7 +2,7 @@
 import { MatchResult } from "./matchresult"
 
 export class ScoreReporter {
-  private baseURL: string
+  private readonly baseURL: string
   private readonly defaultBaseURL = "scoreboard-tailuge.vercel.app" // Default URL as per SCOREPLAN.md
 
   constructor(baseURL?: string) {


### PR DESCRIPTION
This PR addresses several code smells identified in the network modules:
1. In `src/network/bot/aimcalculator.ts`, an in-place `sort` operation was used within an expression, which could mutate the source array and was less readable. I refactored it to use a separate statement and the spread operator `[...candidates].sort()` to ensure the original array remains untouched.
2. In `src/network/client/presenceclient.ts`, direct `window` references were replaced with `globalThis.window` to improve consistency and portability. The `handleUnload` property was also marked as `readonly`.
3. In `src/network/client/scorereporter.ts`, the `baseURL` property was marked as `readonly` as it is only assigned in the constructor.

All changes have been verified with `yarn lint` and relevant unit tests.

---
*PR created automatically by Jules for task [7672705794815288193](https://jules.google.com/task/7672705794815288193) started by @tailuge*