### PR TITLE
Improve bot aiming and spin validity

### DIFF
--- a/src/network/bot/aimcalculator.ts
+++ b/src/network/bot/aimcalculator.ts
@@ -46,7 +46,7 @@ export class AimCalculator {
     aim.power = 80 * R
     aim.offset = new Vector3(0, (Math.random() - 0.5) * 0.6)
 
-    if (table.cue.intersectsAnything(table)) {
+    if (table.cue.intersectsAnything(table, aim)) {
       aim.offset.set(0, table.cue.offCenterLimit, 0)
     }
 

--- a/src/network/bot/aimcalculator.ts
+++ b/src/network/bot/aimcalculator.ts
@@ -45,6 +45,11 @@ export class AimCalculator {
     aim.angle = atan2(lineTo.y, lineTo.x) + (Math.random() - 0.5) * noise
     aim.power = 80 * R
     aim.offset = new Vector3(0, (Math.random() - 0.5) * 0.6)
+
+    if (table.cue.intersectsAnything(table)) {
+      aim.offset.set(0, table.cue.offCenterLimit, 0)
+    }
+
     return new HitEvent(table.serialise())
   }
 
@@ -55,7 +60,6 @@ export class AimCalculator {
   ): Vector3 {
     return pockets
       .map((p) => ({ pocket: p, score: this.cutScore(cuePos, targetPos, p) }))
-      .filter((x) => x.score < 0.8)
       .sort((a, b) => a.score - b.score)[0].pocket
   }
 

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -138,17 +138,17 @@ export class Cue {
     this.placerMesh.visible = false
   }
 
-  spinOffset() {
-    return upCross(unitAtAngle(this.aim.angle, this.tempVec2))
-      .multiplyScalar(this.aim.offset.x * 2 * R)
-      .setZ(this.aim.offset.y * 2 * R)
+  spinOffset(aim: AimEvent = this.aim) {
+    return upCross(unitAtAngle(aim.angle, this.tempVec2))
+      .multiplyScalar(aim.offset.x * 2 * R)
+      .setZ(aim.offset.y * 2 * R)
   }
 
-  intersectsAnything(table: Table) {
-    const offset = this.spinOffset()
+  intersectsAnything(table: Table, aim: AimEvent = this.aim) {
+    const offset = this.spinOffset(aim)
     const origin = this.tempVec.copy(table.cueball.pos).add(offset)
     const direction = norm(
-      unitAtAngle(this.aim.angle + Math.PI, this.tempVec2).setZ(0.1)
+      unitAtAngle(aim.angle + Math.PI, this.tempVec2).setZ(0.1)
     )
     this.raycaster.set(origin, direction)
     const items: Mesh[] = []

--- a/test/network/bot/aimcalculator.spec.ts
+++ b/test/network/bot/aimcalculator.spec.ts
@@ -2,6 +2,8 @@ import { Vector3 } from "three"
 import { AimCalculator } from "../../../src/network/bot/aimcalculator"
 import { Pocket } from "../../../src/model/physics/pocket"
 import { R } from "../../../src/model/physics/constants"
+import { Table } from "../../../src/model/table"
+import { Ball } from "../../../src/model/ball"
 
 describe("AimCalculator", () => {
   const calculator = new AimCalculator()
@@ -21,6 +23,61 @@ describe("AimCalculator", () => {
       expect(aimPoint?.x).toBeCloseTo(2 - 2 * R)
       expect(aimPoint?.y).toBeCloseTo(0)
       expect(aimPoint?.z).toBeCloseTo(0)
+    })
+
+    it("should return an aim point even for very difficult cut shots (score > 0.8)", () => {
+      const cuePos = new Vector3(0, 0, 0)
+      const targetPos = new Vector3(2, 0, 0)
+      // A pocket that requires a very sharp cut
+      // shotLine = (1, 0, 0)
+      // pocketLine = targetPos to pocket
+      // If pocket is at (2, 2, 0), pocketLine is (0, 1, 0)
+      // dot product is 0, score is 1.0 (which is > 0.8)
+      const pocketPos = new Vector3(2, 2, 0)
+      const pockets = [pocketPos]
+
+      const aimPoint = calculator.getAimPoint(cuePos, targetPos, pockets)
+
+      expect(aimPoint).toBeDefined()
+      // Ghost ball should be at (2, -R*2, 0) because pocket is at (2, 2, 0)
+      // Wait, incident vector from pocket (2, 2) to target (2, 0) is (0, -2) -> (0, -1) normalized
+      // Ghost ball = targetPos + (0, -1) * 2 * R = (2, -2*R, 0)
+      expect(aimPoint?.x).toBeCloseTo(2)
+      expect(aimPoint?.y).toBeCloseTo(-2 * R)
+    })
+  })
+
+  describe("generateRandomShot", () => {
+    it("should set spin to max top spin if cue intersects another ball", () => {
+      const cueball = new Ball(new Vector3(0, 0, 0))
+      const table = new Table([cueball])
+
+      // Mock intersectsAnything to return true
+      jest.spyOn(table.cue, "intersectsAnything").mockReturnValue(true)
+
+      const targetPos = new Vector3(10, 0, 0)
+      const hitEvent = calculator.generateRandomShot(table, 0, targetPos) as any
+
+      const aimData = hitEvent.tablejson.aim
+      expect(aimData.offset.y).toBe(table.cue.offCenterLimit)
+      expect(aimData.offset.x).toBe(0)
+    })
+
+    it("should not set spin to max top spin if cue does not intersect anything", () => {
+      const cueball = new Ball(new Vector3(0, 0, 0))
+      const table = new Table([cueball])
+
+      // Mock intersectsAnything to return false
+      jest.spyOn(table.cue, "intersectsAnything").mockReturnValue(false)
+
+      const targetPos = new Vector3(10, 0, 0)
+      const hitEvent = calculator.generateRandomShot(table, 0, targetPos) as any
+
+      const aimData = hitEvent.tablejson.aim
+      // By default generateRandomShot sets a random offset.y between -0.3 and 0.3
+      // and offset.x to 0.
+      expect(aimData.offset.x).toBe(0)
+      // It's random, but it should stay as it was (which is not necessarily max top spin)
     })
   })
 


### PR DESCRIPTION
Improved the bot's aiming capabilities by allowing it to take more difficult shots and ensuring its spin is valid to avoid cue-ball intersections. Added corresponding tests.

---
*PR created automatically by Jules for task [4000867141571486497](https://jules.google.com/task/4000867141571486497) started by @tailuge*