### PR TITLE
Optimize GitHub Workflow and Cleanup Coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install dependencies
         run: yarn install
@@ -40,6 +40,15 @@ jobs:
           ./codecov
           echo done
 
+      - name: delete coverage
+        run: rm -rf coverage
+
+      - name: upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifact
+          path: dist/
+
   deploy:
     needs: build
     runs-on: ubuntu-latest
@@ -55,19 +64,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: install dependencies
-        run: yarn install
+      - name: download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-artifact
+          path: dist/
 
-      - name: build
-        run: yarn build
-
-      - name: remove node_modules
+      - name: cleanup for deployment
         run: |
-          echo "Removing node_modules to avoid uploading dependencies"
-          du -hs *
-          rm -rf node_modules src test
+          echo "Removing unnecessary files for deployment"
+          rm -rf node_modules src test .github
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
The GitHub workflow has been optimized to improve efficiency and maintainability.

Key changes:
1.  **Upgraded Actions:** Updated `actions/checkout` to `v4` and used `v4` for artifact upload/download actions for improved performance and security.
2.  **Redundancy Removal:** The `deploy` job now depends on the `build` job and uses the pre-built `dist/` directory via GitHub Actions artifacts. This eliminates the need for redundant `yarn install` and `yarn build` steps in the deployment phase.
3.  **Coverage Cleanup:** Added a step in the `build` job to delete the `coverage/` directory after it has been uploaded to Codecov, as requested.
4.  **Deployment Cleanup:** Refined the cleanup step in the `deploy` job to remove source code (`src/`, `test/`) and workflow configurations (`.github/`) before publishing to GitHub Pages.

These changes ensure a faster CI/CD pipeline and a cleaner deployment artifact.

---
*PR created automatically by Jules for task [6094669031134260503](https://jules.google.com/task/6094669031134260503) started by @tailuge*