### PR TITLE
Add root-to-dist redirect for GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
       - name: cleanup for deployment
         run: |
           echo "Removing unnecessary files for deployment"
+          cp dist/redirect.html index.html
           rm -rf node_modules src test .github
 
       - name: Upload artifact

--- a/dist/redirect.html
+++ b/dist/redirect.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Billiards Pool Game - Free Physics Simulator | Break Builder</title>
+    <link rel="icon" type="image/png" href="dist/favicon.png" />
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="0; url=./dist/index.html" />
+    <script type="text/javascript">
+      window.location.href = "./dist/index.html"
+    </script>
+    <meta
+      name="description"
+      content="Play free online billiards with realistic physics simulation. Browser-based pool game with multiplayer support. Built by tailuge - open source and playable on desktop and mobile."
+    />
+    <meta name="robots" content="index,follow" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
+    />
+    <link rel="canonical" href="https://tailuge.github.io/billiards/dist/" />
+    <meta
+      property="og:title"
+      content="Billiards Pool Game - Free Online Physics Simulator"
+    />
+    <meta
+      property="og:description"
+      content="Play realistic pool online with accurate physics. Open source billiards simulation in your browser."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://tailuge.github.io/billiards/dist/"
+    />
+    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:title"
+      content="Billiards Pool Game - Free Physics Simulator"
+    />
+    <meta
+      name="twitter:description"
+      content="Play realistic pool online with accurate physics simulation. Open source and browser-based."
+    />
+  </head>
+  <body>
+    If you are not redirected, <a href="./dist/index.html">click here</a>.
+  </body>
+</html>


### PR DESCRIPTION
The user wanted a way to redirect from the root of the GitHub Pages site to the `dist/index.html` file where the application lives.

I implemented this by:
1. Creating a `dist/redirect.html` file that contains:
   - SEO metadata (title, description, OpenGraph tags) copied from `dist/index.html`.
   - A `<meta http-equiv="refresh" content="0; url=./dist/index.html" />` tag for redirection.
   - A JavaScript `window.location.href = "./dist/index.html"` fallback.
   - A manual link in the body in case both fail.
2. Modifying the GitHub Actions workflow (`.github/workflows/main.yml`) to copy this file to the root `index.html` during the `cleanup for deployment` step.

This setup allows GitHub Pages to serve the redirect from the root while maintaining the application structure in the `dist/` directory.

---
*PR created automatically by Jules for task [12966411602832928509](https://jules.google.com/task/12966411602832928509) started by @tailuge*