### PR TITLE
Add 'ua' field to presence message

### DIFF
--- a/src/network/client/presenceclient.ts
+++ b/src/network/client/presenceclient.ts
@@ -7,6 +7,7 @@ export interface PresenceMessage {
   userName: string
   locale?: string
   originUrl?: string
+  ua?: string
   timestamp?: number
   ruletype?: string
   isBot?: boolean
@@ -39,7 +40,8 @@ export class PresenceClient {
     private readonly locale?: string,
     private readonly originUrl?: string,
     private readonly ruletype?: string,
-    private readonly isBot?: boolean
+    private readonly isBot?: boolean,
+    private readonly ua?: string
   ) {}
 
   onCountChange(callback: (count: number) => void): void {
@@ -199,6 +201,9 @@ export class PresenceClient {
     }
     if (this.isBot !== undefined) {
       payload.isBot = this.isBot
+    }
+    if (this.ua !== undefined) {
+      payload.ua = this.ua
     }
 
     fetch(PresenceClient.publishURL, {

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -17,13 +17,15 @@ export class LobbyIndicator {
     const session = Session.hasInstance() ? Session.getInstance() : undefined
     const locale = globalThis.navigator?.language
     const originUrl = globalThis.location?.host
+    const ua = globalThis.navigator?.userAgent
     this.presenceClient = new PresenceClient(
       session?.clientId ?? "default",
       session?.playername ?? "Anon",
       locale,
       originUrl,
       rules.rulename,
-      session?.botMode
+      session?.botMode,
+      ua
     )
   }
 

--- a/test/network/client/presenceclient.spec.ts
+++ b/test/network/client/presenceclient.spec.ts
@@ -98,4 +98,21 @@ describe("PresenceClient", () => {
     expect(leaveCall).toBeDefined()
     expect(leaveCall[1].keepalive).toBe(true)
   })
+
+  it("includes ua field in payload if provided", () => {
+    const client = new PresenceClient(
+      "u1",
+      "Alice",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "Mozilla/5.0"
+    )
+    client.start()
+    jest.advanceTimersByTime(100)
+
+    const joinBody = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(joinBody.ua).toBe("Mozilla/5.0")
+  })
 })


### PR DESCRIPTION
This change adds a new field `ua` (user agent) to the presence messages sent by the application. This is useful for analytics and debugging client-specific issues.

Changes:
- **PresenceMessage Interface**: Added optional `ua` field.
- **PresenceClient Class**: Updated to accept `ua` in its constructor and include it in the JSON payload sent during `publish`.
- **LobbyIndicator Class**: Now extracts `globalThis.navigator?.userAgent` and passes it to the `PresenceClient` instance.
- **Tests**: Added a new test case to `presenceclient.spec.ts` to ensure the `ua` field is correctly included in the network requests.

---
*PR created automatically by Jules for task [1079761324217803826](https://jules.google.com/task/1079761324217803826) started by @tailuge*