### PR TITLE
Refactor Throttle class for AIM events

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -121,7 +121,7 @@ export class Container {
     this.sendEvent(new ChatEvent(this.id, msg))
   }
 
-  throttle = new Throttle(0, (event) => {
+  throttle = new Throttle(250, (event) => {
     this.broadcast(event)
   })
 

--- a/src/events/throttle.ts
+++ b/src/events/throttle.ts
@@ -6,7 +6,6 @@ import { GameEvent } from "./gameevent"
  */
 export class Throttle {
   period: number
-  pending: GameEvent | null = null
   sentTime: number = 0
   apply = (_) => {}
 
@@ -15,23 +14,15 @@ export class Throttle {
     this.apply = apply
   }
 
-  flush() {
-    if (this.pending) {
-      this.apply(this.pending)
-      this.pending = null
-    }
-  }
-
   send(event: GameEvent) {
-    if (
-      performance.now() > this.sentTime + this.period ||
-      event.type !== EventType.AIM
-    ) {
-      this.flush()
+    if (event.type !== EventType.AIM) {
       this.apply(event)
-      this.sentTime = performance.now()
       return
     }
-    this.pending = event
+
+    if (performance.now() > this.sentTime + this.period) {
+      this.apply(event)
+      this.sentTime = performance.now()
+    }
   }
 }

--- a/test/events/throttle.spec.ts
+++ b/test/events/throttle.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai"
+import { Throttle } from "../../src/events/throttle"
+import { EventType } from "../../src/events/eventtype"
+import { GameEvent } from "../../src/events/gameevent"
+
+class MockEvent extends GameEvent {
+  constructor(type: EventType) {
+    super()
+    this.type = type
+  }
+  applyToController(controller: any) {
+    return controller
+  }
+}
+
+describe("Throttle", () => {
+  let nowValue = 1000
+  let originalNow: any
+
+  beforeEach(() => {
+    nowValue = 1000
+    originalNow = performance.now
+    performance.now = () => nowValue
+  })
+
+  afterEach(() => {
+    performance.now = originalNow
+  })
+
+  it("should immediately send a non-AIM message", () => {
+    let sentEvent: any = null
+    const throttle = new Throttle(250, (event) => {
+      sentEvent = event
+    })
+    const event = new MockEvent(EventType.HIT)
+    throttle.send(event)
+    expect(sentEvent).to.equal(event)
+  })
+
+  it("should immediately send the first AIM message", () => {
+    let sentEvent: any = null
+    const throttle = new Throttle(250, (event) => {
+      sentEvent = event
+    })
+    const event = new MockEvent(EventType.AIM)
+    throttle.send(event)
+    expect(sentEvent).to.equal(event)
+  })
+
+  it("should skip subsequent AIM messages if sent within the period", () => {
+    const sentEvents: any[] = []
+    const throttle = new Throttle(250, (event) => {
+      sentEvents.push(event)
+    })
+
+    const event1 = new MockEvent(EventType.AIM)
+    const event2 = new MockEvent(EventType.AIM)
+
+    throttle.send(event1)
+    nowValue += 100 // 100ms later
+    throttle.send(event2)
+
+    expect(sentEvents).to.have.lengthOf(1)
+    expect(sentEvents[0]).to.equal(event1)
+  })
+
+  it("should send AIM message if sent after the period", () => {
+    const sentEvents: any[] = []
+    const throttle = new Throttle(250, (event) => {
+      sentEvents.push(event)
+    })
+
+    const event1 = new MockEvent(EventType.AIM)
+    const event2 = new MockEvent(EventType.AIM)
+
+    throttle.send(event1)
+    nowValue += 251 // 251ms later
+    throttle.send(event2)
+
+    expect(sentEvents).to.have.lengthOf(2)
+    expect(sentEvents[0]).to.equal(event1)
+    expect(sentEvents[1]).to.equal(event2)
+  })
+
+  it("should always send non-AIM messages even if an AIM was just sent", () => {
+    const sentEvents: any[] = []
+    const throttle = new Throttle(250, (event) => {
+      sentEvents.push(event)
+    })
+
+    const event1 = new MockEvent(EventType.AIM)
+    const event2 = new MockEvent(EventType.HIT)
+
+    throttle.send(event1)
+    nowValue += 100 // 100ms later
+    throttle.send(event2)
+
+    expect(sentEvents).to.have.lengthOf(2)
+    expect(sentEvents[0]).to.equal(event1)
+    expect(sentEvents[1]).to.equal(event2)
+  })
+
+  it("should NOT send skipped AIM messages when a subsequent non-AIM message is sent", () => {
+    const sentEvents: any[] = []
+    const throttle = new Throttle(250, (event) => {
+      sentEvents.push(event)
+    })
+
+    const event1 = new MockEvent(EventType.AIM)
+    const event2 = new MockEvent(EventType.AIM)
+    const event3 = new MockEvent(EventType.HIT)
+
+    throttle.send(event1)
+    nowValue += 100
+    throttle.send(event2) // Should be skipped in new implementation, but pending in old
+    nowValue += 50
+    throttle.send(event3) // Should be sent immediately
+
+    expect(sentEvents).to.have.lengthOf(2)
+    expect(sentEvents[0]).to.equal(event1)
+    expect(sentEvents[1]).to.equal(event3)
+  })
+})


### PR DESCRIPTION
This change modifies the `Throttle` class to implement a more direct and efficient event dispatching strategy. Non-AIM events are no longer delayed by AIM throttling. AIM events are now rate-limited to 250ms by dropping intermediate updates instead of buffering them. This simplifies the class by removing the need for a `flush` method and state management for pending events. `Container` has been updated to use the new 250ms period, and a new test suite verifies the updated semantics.

---
*PR created automatically by Jules for task [13240292181411302467](https://jules.google.com/task/13240292181411302467) started by @tailuge*