### PR TITLE
Implement External Challenge Acceptance

### DIFF
--- a/src/network/client/presenceclient.ts
+++ b/src/network/client/presenceclient.ts
@@ -14,6 +14,11 @@ export interface PresenceMessage {
   opponentId?: string
 }
 
+export interface ChallengerInfo {
+  userId: string
+  userName: string
+}
+
 type PresenceEntry = {
   userName: string
   locale?: string
@@ -28,9 +33,11 @@ export class PresenceClient {
   private pruneTimer: ReturnType<typeof setInterval> | null = null
   private joinTimer: ReturnType<typeof setTimeout> | null = null
   private started = false
-  private isChallenged = false
+  private challenger: ChallengerInfo | null = null
   private readonly callbacks: Array<(count: number) => void> = []
-  private readonly challengeCallbacks: Array<(challenged: boolean) => void> = []
+  private readonly challengeCallbacks: Array<
+    (challenger: ChallengerInfo | null) => void
+  > = []
 
   static readonly subscribeURL =
     "wss://billiards-network.onrender.com/subscribe/presence/lobby"
@@ -53,7 +60,9 @@ export class PresenceClient {
     this.callbacks.push(callback)
   }
 
-  onChallengeChange(callback: (challenged: boolean) => void): void {
+  onChallengeChange(
+    callback: (challenger: ChallengerInfo | null) => void
+  ): void {
     this.challengeCallbacks.push(callback)
   }
 
@@ -204,20 +213,20 @@ export class PresenceClient {
   }
 
   private pruneAndNotify(now: number): void {
-    let challenged = false
+    let challenger: ChallengerInfo | null = null
     const staleIds: string[] = []
     this.users.forEach((entry, id) => {
       if (now - entry.lastSeen > PresenceClient.ttlMs) {
         staleIds.push(id)
       } else if (entry.opponentId === this.userId) {
-        challenged = true
+        challenger = { userId: id, userName: entry.userName }
       }
     })
     staleIds.forEach((id) => this.users.delete(id))
-    this.notify(this.users.size, challenged)
+    this.notify(this.users.size, challenger)
   }
 
-  private notify(count: number, challenged: boolean): void {
+  private notify(count: number, challenger: ChallengerInfo | null): void {
     // Create copies of the callback arrays to prevent modification during iteration.
     const currentCallbacks = [...this.callbacks]
     const currentChallengeCallbacks = [...this.challengeCallbacks]
@@ -230,11 +239,18 @@ export class PresenceClient {
       }
     })
 
-    if (challenged !== this.isChallenged) {
-      this.isChallenged = challenged
+    const challengerChanged =
+      (challenger === null) !== (this.challenger === null) ||
+      (challenger !== null &&
+        this.challenger !== null &&
+        (challenger.userId !== this.challenger.userId ||
+          challenger.userName !== this.challenger.userName))
+
+    if (challengerChanged) {
+      this.challenger = challenger
       currentChallengeCallbacks.forEach((callback) => {
         try {
-          callback(challenged)
+          callback(challenger)
         } catch {
           // Ignore UI callback failures.
         }

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -1,5 +1,8 @@
 import { MessageRelay } from "../network/client/messagerelay"
-import { PresenceClient } from "../network/client/presenceclient"
+import {
+  ChallengerInfo,
+  PresenceClient,
+} from "../network/client/presenceclient"
 import { Session } from "../network/client/session"
 import { Rules } from "../controller/rules/rules"
 import { id } from "../utils/dom"
@@ -9,25 +12,27 @@ export class LobbyIndicator {
   private readonly presenceClient: PresenceClient
   private hasLiveCount = false
   private count = 0
-  private challenged = false
-  private static readonly GAME_URL =
-    "https://scoreboard-tailuge.vercel.app/game"
+  private challenger: ChallengerInfo | null = null
+  private readonly rules: Rules
+  private static readonly LOBBY_URL =
+    "https://scoreboard-tailuge.vercel.app/lobby"
 
   constructor(
     private readonly relay: MessageRelay | null,
     rules: Rules
   ) {
+    this.rules = rules
     this.element = id("lobby")
     if (this.element) {
       if (this.element instanceof HTMLAnchorElement) {
-        this.element.setAttribute("href", LobbyIndicator.GAME_URL)
+        this.element.setAttribute("href", this.getLobbyUrl())
         this.element.setAttribute("target", "_blank")
         this.element.setAttribute("rel", "noopener noreferrer")
       } else {
         this.element.addEventListener("click", () => {
           if (typeof globalThis.open === "function") {
             globalThis.open(
-              LobbyIndicator.GAME_URL,
+              this.getLobbyUrl(),
               "_blank",
               "noopener,noreferrer"
             )
@@ -57,8 +62,8 @@ export class LobbyIndicator {
       this.count = count
       this.updateDisplay()
     })
-    this.presenceClient.onChallengeChange((challenged) => {
-      this.challenged = challenged
+    this.presenceClient.onChallengeChange((challenger) => {
+      this.challenger = challenger
       this.updateDisplay()
     })
     this.presenceClient.start()
@@ -77,9 +82,10 @@ export class LobbyIndicator {
 
   private updateDisplay(): void {
     if (!this.element) return
-    const challengeIcon = this.challenged ? " ⚔️" : ""
+    const challenged = this.challenger !== null
+    const challengeIcon = challenged ? " ⚔️" : ""
     this.element.textContent = ` ${this.count} 👥${challengeIcon}`
-    if (this.challenged) {
+    if (challenged) {
       this.element.setAttribute(
         "aria-label",
         `Multiplayer Lobby - ${this.count} online - YOU ARE CHALLENGED!`
@@ -90,6 +96,29 @@ export class LobbyIndicator {
         `Multiplayer Lobby - ${this.count} online`
       )
     }
+    if (this.element instanceof HTMLAnchorElement) {
+      this.element.setAttribute("href", this.getLobbyUrl())
+    }
+  }
+
+  private getLobbyUrl(): string {
+    if (!this.challenger) {
+      return LobbyIndicator.LOBBY_URL
+    }
+
+    const url = new URL(LobbyIndicator.LOBBY_URL)
+    url.searchParams.set("action", "join")
+    url.searchParams.set("ruletype", this.rules.rulename)
+    url.searchParams.set("opponentId", this.challenger.userId)
+    url.searchParams.set("opponentName", this.challenger.userName)
+
+    const session = Session.hasInstance() ? Session.getInstance() : undefined
+    if (session) {
+      url.searchParams.set("username", session.playername)
+      url.searchParams.set("userId", session.clientId)
+    }
+
+    return url.toString()
   }
 
   stop(): void {

--- a/test/network/client/presenceclient.spec.ts
+++ b/test/network/client/presenceclient.spec.ts
@@ -118,23 +118,28 @@ describe("PresenceClient", () => {
 
   describe("Challenge detection", () => {
     let client: PresenceClient
-    let challenges: boolean[]
+    let challenges: Array<any>
 
     beforeEach(() => {
       client = new PresenceClient("u1", "Alice")
       challenges = []
-      client.onChallengeChange((challenged) => challenges.push(challenged))
+      client.onChallengeChange((challenger) => challenges.push(challenger))
       client.start()
     })
 
-    const sendPresence = (type: string, userId: string, opponentId?: string) => {
+    const sendPresence = (
+      type: string,
+      userId: string,
+      opponentId?: string,
+      userName = "Bob"
+    ) => {
       const ws = MockWebSocket.instances[0]
       ws.onmessage?.({
         data: JSON.stringify({
           messageType: "presence",
           type,
           userId,
-          userName: "Bob",
+          userName,
           opponentId,
           timestamp: Date.now(),
         }),
@@ -143,18 +148,18 @@ describe("PresenceClient", () => {
 
     it("triggers challenge callback when opponentId matches current user", () => {
       sendPresence("heartbeat", "u2", "u1")
-      expect(challenges).toEqual([true])
+      expect(challenges).toEqual([{ userId: "u2", userName: "Bob" }])
 
       sendPresence("heartbeat", "u2")
-      expect(challenges).toEqual([true, false])
+      expect(challenges).toEqual([{ userId: "u2", userName: "Bob" }, null])
     })
 
     it("removes challenge when challenger leaves", () => {
       sendPresence("heartbeat", "u2", "u1")
-      expect(challenges).toEqual([true])
+      expect(challenges).toEqual([{ userId: "u2", userName: "Bob" }])
 
       sendPresence("leave", "u2")
-      expect(challenges).toEqual([true, false])
+      expect(challenges).toEqual([{ userId: "u2", userName: "Bob" }, null])
     })
 
     it("handles messages with locale and preserves it", () => {

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -36,13 +36,24 @@ describe("LobbyIndicator", () => {
     // Trigger challenge (this is a bit tricky as presenceClient is private)
     // We can reach it via (indicator as any).presenceClient
     const presenceClient = (indicator as any).presenceClient
-    presenceClient.challengeCallbacks.forEach((cb: any) => cb(true))
+    presenceClient.challengeCallbacks.forEach((cb: any) =>
+      cb({ userId: "u2", userName: "Bob" })
+    )
 
     expect(element?.textContent).to.contain("⚔️")
     expect(element?.getAttribute("aria-label")).to.contain("YOU ARE CHALLENGED")
 
-    presenceClient.challengeCallbacks.forEach((cb: any) => cb(false))
+    const href = element?.getAttribute("href") ?? ""
+    expect(href).to.contain("action=join")
+    expect(href).to.contain("ruletype=nineball")
+    expect(href).to.contain("opponentId=u2")
+    expect(href).to.contain("opponentName=Bob")
+
+    presenceClient.challengeCallbacks.forEach((cb: any) => cb(null))
     expect(element?.textContent).to.not.contain("⚔️")
+    expect(element?.getAttribute("href")).to.equal(
+      "https://scoreboard-tailuge.vercel.app/lobby"
+    )
   })
 
   it("handles non-anchor elements and click events", async () => {
@@ -67,7 +78,7 @@ describe("LobbyIndicator", () => {
     }) as any
 
     div.click()
-    expect(openedUrl).to.equal("https://scoreboard-tailuge.vercel.app/game")
+    expect(openedUrl).to.equal("https://scoreboard-tailuge.vercel.app/lobby")
 
     document.body.removeChild(div)
     document.getElementById = originalGetElementById


### PR DESCRIPTION
This change implements the external challenge acceptance flow. When a user receives a challenge (detected via PresenceClient), the LobbyIndicator now constructs a URL pointing to `https://scoreboard-tailuge.vercel.app/lobby` with the required query parameters: `action=join`, `ruletype`, `opponentId`, `opponentName`, `userId`, and `username`. This allows the user to accept the challenge automatically by clicking the lobby icon (sword emoji).

Key modifications:
- `PresenceClient`: Refactored challenge detection to track `ChallengerInfo` (userId and userName) and updated `onChallengeChange` to propagate this data.
- `LobbyIndicator`: Updated to use the new challenger info for dynamic URL construction and changed the base URL to the lobby endpoint.
- Tests: Updated existing tests and added new assertions to verify correct URL generation and challenger tracking.

---
*PR created automatically by Jules for task [8177796342766753567](https://jules.google.com/task/8177796342766753567) started by @tailuge*