### PR TITLE
Add automated build-time versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ rg.sh
 
 dist/SCOREPLANREMOTE.md
 telemetry-id
+src/utils/version.ts

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   "scripts": {
     "test": "jest --config ./test/jest.config.js --verbose --silent",
     "coverage": "jest --config ./test/jest.config.js --coverage --silent",
+    "version-gen": "node -e \"const d=new Date();const v=d.getFullYear().toString().slice(-2)+('0'+(d.getMonth()+1)).slice(-2)+('0'+d.getDate()).slice(-2)+'.'+('0'+d.getHours()).slice(-2);require('fs').writeFileSync('src/utils/version.ts', 'export const VERSION = \\'' + v + '\\';\\n')\"",
+    "predev": "npm run version-gen",
     "dev": "webpack",
+    "prebuild": "npm run version-gen",
     "build": "webpack",
+    "prelint": "npm run version-gen",
     "lint": "tsc --noEmit && eslint .",
     "prettify": "prettier --cache true --write --trailing-comma es5 --no-semi {src,test}/**/*.[jt]s dist/**/*.{css,html} *.[jt]s *.json",
     "markdownlint": "npx markdownlint-cli2 README.md --fix",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import { BrowserContainer } from "./container/browsercontainer"
 import { logusage } from "./utils/usage"
 import { getCanvas } from "./utils/dom"
+import { VERSION } from "./utils/version"
 
 initialise()
 
 function initialise() {
+  console.log("Version:", VERSION)
   const canvas3d = getCanvas("viewP1")!
   const params = new URLSearchParams(location.search)
   const browserContainer = new BrowserContainer(canvas3d, params)


### PR DESCRIPTION
Implemented an automated build-time versioning system. A new script `version-gen` in `package.json` generates a `src/utils/version.ts` file containing a `VERSION` constant formatted as `YYMMDD.HH`. This process is automated via `predev`, `prebuild`, and `prelint` hooks to ensure the version is always up-to-date and available for the TypeScript compiler and application. The generated file is excluded from version control to prevent unnecessary noise. The version is logged to the console upon application startup for easy verification.

---
*PR created automatically by Jules for task [11866976347835434699](https://jules.google.com/task/11866976347835434699) started by @tailuge*