### PR TITLE
Add red glow effect to challenge emoji

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -570,3 +570,7 @@ label {
 #botDebugLog::-webkit-scrollbar-thumb:hover {
   background: #777;
 }
+
+.challenge-icon {
+  text-shadow: 0 0 8px #ff0000, 0 0 12px #ff0000;
+}

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -79,9 +79,12 @@ export class LobbyIndicator {
   private updateDisplay(): void {
     if (!this.element) return
     const challenged = this.challenger !== null
-    const challengeIcon = challenged ? " ⚔️" : ""
-    this.element.textContent = ` ${this.count} 👥${challengeIcon}`
+    this.element.textContent = ` ${this.count} 👥`
     if (challenged) {
+      const challengeSpan = document.createElement("span")
+      challengeSpan.className = "challenge-icon"
+      challengeSpan.textContent = " ⚔️"
+      this.element.appendChild(challengeSpan)
       this.element.setAttribute(
         "aria-label",
         `Multiplayer Lobby - ${this.count} online - YOU ARE CHALLENGED!`


### PR DESCRIPTION
This change implements a red glow for the ⚔️ emoji in the lobby indicator when a challenge is active.
- Modified `src/view/lobbyindicator.ts` to wrap the emoji in a `<span class="challenge-icon">`.
- Added CSS to `dist/index.css` to apply a red `text-shadow` to `.challenge-icon`.
- Verified the change with automated tests and a Playwright visual verification script.

---
*PR created automatically by Jules for task [64299020779042698](https://jules.google.com/task/64299020779042698) started by @tailuge*