### PR TITLE
Spectator Name Sniffing for HUD

### DIFF
--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -52,17 +52,29 @@ export class Spectate extends ControllerBase {
     }
 
     let changed = false
-    if (event.type === EventType.BEGIN && !session.spectatedP1Name) {
+    if (
+      event.type === EventType.BEGIN &&
+      !session.spectatedP1Name &&
+      event.playername
+    ) {
       session.spectatedP1Name = event.playername
       changed = true
-    } else if (event.type === EventType.WATCHAIM && !session.spectatedP2Name) {
+    } else if (
+      event.type === EventType.WATCHAIM &&
+      !session.spectatedP2Name &&
+      event.playername
+    ) {
       session.spectatedP2Name = event.playername
       changed = true
     }
 
     if (changed) {
       const scores = this.container.getOrderedScores()
-      this.container.updateScoreHud(scores.p1, scores.p2, 0)
+      this.container.updateScoreHud(
+        scores.p1,
+        scores.p2,
+        this.container.currentBreak
+      )
     }
   }
 

--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -7,6 +7,8 @@ import { ScoreEvent } from "../events/scoreevent"
 import { PlaceBallEvent } from "../events/placeballevent"
 import { RerackEvent } from "../events/rerackevent"
 import { BreakEvent } from "../events/breakevent"
+import { Session } from "../network/client/session"
+import { EventType } from "../events/eventtype"
 
 export class Spectate extends ControllerBase {
   override get name() {
@@ -23,6 +25,9 @@ export class Spectate extends ControllerBase {
       console.log(message)
       const event = EventUtil.fromSerialised(message)
       this.messages.push(event)
+
+      this.sniffNames(event)
+
       if (
         event instanceof HitEvent ||
         event instanceof AimEvent ||
@@ -35,6 +40,30 @@ export class Spectate extends ControllerBase {
       }
     })
     console.log("Spectate")
+  }
+
+  private sniffNames(event: GameEvent) {
+    if (!Session.hasInstance()) {
+      return
+    }
+    const session = Session.getInstance()
+    if (event.clientId === session.clientId) {
+      return
+    }
+
+    let changed = false
+    if (event.type === EventType.BEGIN && !session.spectatedP1Name) {
+      session.spectatedP1Name = event.playername
+      changed = true
+    } else if (event.type === EventType.WATCHAIM && !session.spectatedP2Name) {
+      session.spectatedP2Name = event.playername
+      changed = true
+    }
+
+    if (changed) {
+      const scores = this.container.getOrderedScores()
+      this.container.updateScoreHud(scores.p1, scores.p2, 0)
+    }
   }
 
   override handleAim(event: AimEvent) {

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -9,6 +9,8 @@ export class Session {
 
   opponentName?: string
   opponentClientId?: string
+  spectatedP1Name?: string
+  spectatedP2Name?: string
   playerIndex: number = 0
   private scoreByClientId: Record<string, number> = {}
 
@@ -131,6 +133,17 @@ export class Session {
   }
 
   orderedNamesForHud(): { p1Name?: string; p2Name?: string } {
+    if (this.spectator) {
+      const names: { p1Name?: string; p2Name?: string } = {}
+      if (this.spectatedP1Name) {
+        names.p1Name = this.spectatedP1Name
+      }
+      if (this.spectatedP2Name) {
+        names.p2Name = this.spectatedP2Name
+      }
+      return names
+    }
+
     const myName = this.playername || undefined
     const theirName = this.opponentName || undefined
     if (this.playerIndex === 0) {

--- a/test/controller/spectate_sniff.spec.ts
+++ b/test/controller/spectate_sniff.spec.ts
@@ -40,7 +40,8 @@ describe("Spectate Name Sniffing", () => {
   })
 
   it("should sniff names from BEGIN and WATCHAIM events", () => {
-    new Spectate(container, messageRelay, "test-table")
+    const spectate = new Spectate(container, messageRelay, "test-table")
+    expect(spectate).to.not.be.null
     const session = Session.getInstance()
 
     // Simulate BEGIN event from P1 (Peter)
@@ -66,7 +67,8 @@ describe("Spectate Name Sniffing", () => {
   })
 
   it("should not override names once set", () => {
-    new Spectate(container, messageRelay, "test-table")
+    const spectate = new Spectate(container, messageRelay, "test-table")
+    expect(spectate).to.not.be.null
     const session = Session.getInstance()
 
     const begin1 = new BeginEvent()
@@ -83,7 +85,8 @@ describe("Spectate Name Sniffing", () => {
   })
 
   it("should ignore events from the spectator itself", () => {
-    new Spectate(container, messageRelay, "test-table")
+    const spectate = new Spectate(container, messageRelay, "test-table")
+    expect(spectate).to.not.be.null
     const session = Session.getInstance()
 
     const begin = new BeginEvent()

--- a/test/controller/spectate_sniff.spec.ts
+++ b/test/controller/spectate_sniff.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from "chai"
+import { Container } from "../../src/container/container"
+import { Ball } from "../../src/model/ball"
+import { Spectate } from "../../src/controller/spectate"
+import { Assets } from "../../src/view/assets"
+import { initDom } from "../view/dom"
+import { Session } from "../../src/network/client/session"
+import { MessageRelay } from "../../src/network/client/messagerelay"
+import { BeginEvent } from "../../src/events/beginevent"
+import { WatchEvent } from "../../src/events/watchevent"
+import { EventUtil } from "../../src/events/eventutil"
+
+initDom()
+
+describe("Spectate Name Sniffing", () => {
+  let container: Container
+  let messageRelay: MessageRelay
+  let capturedCallback: (message: string) => void
+
+  beforeEach(() => {
+    Ball.id = 0
+    // Initialize as spectator
+    Session.init("spectator-client", "Spectator", "test-table", true)
+
+    container = new Container({
+      element: undefined,
+      log: (_) => {},
+      assets: Assets.localAssets(),
+      ruletype: "nineball",
+    })
+    container.isSinglePlayer = false
+
+    messageRelay = {
+      subscribe: (channel, callback) => {
+        capturedCallback = callback
+      },
+      publish: () => {},
+      getOnlineCount: () => Promise.resolve(null),
+    }
+  })
+
+  it("should sniff names from BEGIN and WATCHAIM events", () => {
+    new Spectate(container, messageRelay, "test-table")
+    const session = Session.getInstance()
+
+    // Simulate BEGIN event from P1 (Peter)
+    const beginEvent = new BeginEvent()
+    beginEvent.clientId = "p1-id"
+    beginEvent.playername = "Peter"
+    capturedCallback(EventUtil.serialise(beginEvent))
+
+    expect(session.spectatedP1Name).to.equal("Peter")
+    expect(session.spectatedP2Name).to.be.undefined
+
+    // Simulate WATCHAIM event from P2 (Yvette)
+    const watchEvent = new WatchEvent({})
+    watchEvent.clientId = "p2-id"
+    watchEvent.playername = "Yvette"
+    capturedCallback(EventUtil.serialise(watchEvent))
+
+    expect(session.spectatedP2Name).to.equal("Yvette")
+
+    const names = session.orderedNamesForHud()
+    expect(names.p1Name).to.equal("Peter")
+    expect(names.p2Name).to.equal("Yvette")
+  })
+
+  it("should not override names once set", () => {
+    new Spectate(container, messageRelay, "test-table")
+    const session = Session.getInstance()
+
+    const begin1 = new BeginEvent()
+    begin1.clientId = "p1-id"
+    begin1.playername = "Peter"
+    capturedCallback(EventUtil.serialise(begin1))
+
+    const begin2 = new BeginEvent()
+    begin2.clientId = "other-id"
+    begin2.playername = "Imposter"
+    capturedCallback(EventUtil.serialise(begin2))
+
+    expect(session.spectatedP1Name).to.equal("Peter")
+  })
+
+  it("should ignore events from the spectator itself", () => {
+    new Spectate(container, messageRelay, "test-table")
+    const session = Session.getInstance()
+
+    const begin = new BeginEvent()
+    begin.clientId = "spectator-client"
+    begin.playername = "Spectator"
+    capturedCallback(EventUtil.serialise(begin))
+
+    expect(session.spectatedP1Name).to.be.undefined
+  })
+})


### PR DESCRIPTION
The HUD now correctly displays the names of the players being spectated instead of the spectator's own username. This is achieved by "sniffing" the player names from the first two messages in the game's event stream (BEGIN for player 1 and WATCHAIM for player 2). The names are stored in the Session and updated in the HUD as soon as they are identified.

---
*PR created automatically by Jules for task [16711094499523489556](https://jules.google.com/task/16711094499523489556) started by @tailuge*