### PR TITLE
Refactor to fix code smells in ClientErrorReporter and tests

### DIFF
--- a/src/network/client/clienterrorreporter.ts
+++ b/src/network/client/clienterrorreporter.ts
@@ -37,17 +37,17 @@ export interface ErrorReport {
 }
 
 export class ClientErrorReporter {
-  private endpoint: string
-  private sid: string
+  private readonly endpoint: string
+  private readonly sid: string
   private queue: ErrorReport[] = []
-  private seen = new Map<string, number>()
+  private readonly seen = new Map<string, number>()
 
   private readonly maxPerKey: number
   private readonly flushIntervalMs: number
   private readonly maxQueueSize: number
 
   private intervalId: ReturnType<typeof setInterval> | undefined
-  private boundFlush: () => void
+  private readonly boundFlush: () => void
   private originalConsoleError?: typeof console.error
   private originalConsoleWarn?: typeof console.warn
 
@@ -73,7 +73,7 @@ export class ClientErrorReporter {
       return crypto.randomUUID()
     } catch {
       return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
-        const r = (Math.random() * 16) | 0
+        const r = Math.trunc(Math.random() * 16)
         const v = c === "x" ? r : (r & 0x3) | 0x8
         return v.toString(16)
       })
@@ -86,7 +86,7 @@ export class ClientErrorReporter {
 
     this.intervalId = setInterval(this.boundFlush, this.flushIntervalMs)
 
-    window.addEventListener("pagehide", this.boundFlush)
+    globalThis.addEventListener("pagehide", this.boundFlush)
   }
 
   stop() {
@@ -97,7 +97,7 @@ export class ClientErrorReporter {
       this.intervalId = undefined
     }
 
-    window.removeEventListener("pagehide", this.boundFlush)
+    globalThis.removeEventListener("pagehide", this.boundFlush)
 
     if (this.originalConsoleError) {
       console.error = this.originalConsoleError
@@ -123,18 +123,18 @@ export class ClientErrorReporter {
   }
 
   private patchGlobalErrors() {
-    window.addEventListener("error", (e) => {
+    globalThis.addEventListener("error", (e) => {
       this.capture("uncaught", [e.error || e.message])
     })
 
-    window.addEventListener("unhandledrejection", (e) => {
+    globalThis.addEventListener("unhandledrejection", (e) => {
       this.capture("promise", [e.reason])
     })
   }
 
   private capture(type: string, args: unknown[]) {
     try {
-      let message = args.map((a) => String(a)).join(" ")
+      let message = args.map(String).join(" ")
       let stack: string | undefined
 
       if (args[0] instanceof Error) {

--- a/test/network/bot/eventhandler.spec.ts
+++ b/test/network/bot/eventhandler.spec.ts
@@ -211,7 +211,7 @@ describe("BotEventHandler Respot Logic", () => {
 
     // Verify result is PlaceBall controller with correct position
     expect(resultController).toBeInstanceOf(PlaceBall)
-    const placeBallController = resultController as PlaceBall
+    const placeBallController = resultController
 
     // Cue ball position should be in kitchen (negative x)
     expect((placeBallController as any).startPos.x).toBeLessThan(0)

--- a/test/rules/snooker.spec.ts
+++ b/test/rules/snooker.spec.ts
@@ -11,7 +11,6 @@ import { Ball, State } from "../../src/model/ball"
 import { Vector3 } from "three"
 import { PlayShot } from "../../src/controller/playshot"
 import { Aim } from "../../src/controller/aim"
-import { StationaryEvent } from "../../src/events/stationaryevent"
 import { AimEvent } from "../../src/events/aimevent"
 import { HitEvent } from "../../src/events/hitevent"
 import { PlaceBall } from "../../src/controller/placeball"
@@ -522,7 +521,6 @@ describe("Snooker", () => {
     container.recorder.record(hit)
 
     // Mock not first shot
-    const recorder = container.recorder
 
     // reds on table
     expect(snooker.nextCandidateBall()).to.not.be.undefined


### PR DESCRIPTION
This PR addresses several code smells identified by static analysis:
- In `src/network/client/clienterrorreporter.ts`, it marks `endpoint`, `sid`, `seen`, and `boundFlush` as `readonly` since they are not reassigned. It also replaces `window` with `globalThis`, uses `Math.trunc` instead of `| 0`, and simplifies a `.map()` call.
- In `test/network/bot/eventhandler.spec.ts`, a redundant type assertion was removed.
- In `test/rules/snooker.spec.ts`, an unused import of `StationaryEvent` and an unused `recorder` variable were removed.

These changes improve code quality, maintainability, and alignment with modern JavaScript/TypeScript standards without changing application logic.

---
*PR created automatically by Jules for task [1805669078933891087](https://jules.google.com/task/1805669078933891087) started by @tailuge*