### PR TITLE
Improve bot concession logic and unify game end notifications

### DIFF
--- a/src/network/bot/eventhandler.ts
+++ b/src/network/bot/eventhandler.ts
@@ -11,7 +11,6 @@ import { PlaceBallEvent, RespotBody } from "../../events/placeballevent"
 import { WatchEvent } from "../../events/watchevent"
 import { EventUtil } from "../../events/eventutil"
 import { Respot } from "../../utils/respot"
-import { gameOverButtons } from "../../utils/gameover"
 import { zero } from "../../utils/three-utils"
 
 export class BotEventHandler {
@@ -61,17 +60,7 @@ export class BotEventHandler {
   private handleStationary(): void {
     const outcome = this.container.table.outcome
     if (this.container.rules.isEndOfGame(outcome)) {
-      // bot has won, notify player
-      this.container.notifyLocal({
-        type: "GameOver",
-        title: "YOU LOST",
-        subtext: "Lostber 🦞",
-        icon: "🥈",
-        extraClass: "is-loser",
-        extra: gameOverButtons.forMode(true),
-        duration: 0,
-      })
-      this.container.recorder.wholeGameLink()
+      this.container.updateController(this.container.rules.handleGameEnd(false))
       return
     }
 

--- a/src/network/client/matchresult.ts
+++ b/src/network/client/matchresult.ts
@@ -32,7 +32,7 @@ export class MatchResultHelper {
     const playerIndex = session?.playerIndex ?? 0
     const amIWinner = forcedAmIWinner ?? winnerIndex === playerIndex
 
-    const subtext = this.getScoreSubtext(container)
+    const subtext = this.getScoreSubtext(container, amIWinner)
 
     if (amIWinner) {
       this.notifyWin(container, subtext)
@@ -60,7 +60,9 @@ export class MatchResultHelper {
       subtext: subtext,
       icon: "🏆",
       extraClass: "is-winner",
-      extra: gameOverButtons.forMode(container.isSinglePlayer),
+      extra: gameOverButtons.forMode(
+        container.isSinglePlayer || Session.isBotMode()
+      ),
       duration: 0,
     })
   }
@@ -72,7 +74,9 @@ export class MatchResultHelper {
       subtext: subtext,
       icon: "🥈",
       extraClass: "is-loser",
-      extra: gameOverButtons.forMode(container.isSinglePlayer),
+      extra: gameOverButtons.forMode(
+        container.isSinglePlayer || Session.isBotMode()
+      ),
       duration: 0,
     })
   }
@@ -103,7 +107,14 @@ export class MatchResultHelper {
     )
   }
 
-  private static getScoreSubtext(container: Container): string {
+  private static getScoreSubtext(
+    container: Container,
+    amIWinner?: boolean
+  ): string {
+    if (Session.isBotMode() && amIWinner === false) {
+      return "Lostber 🦞"
+    }
+
     if (container.isSinglePlayer) {
       return `Score: ${container.getMyScore()}`
     }

--- a/src/network/client/matchresult.ts
+++ b/src/network/client/matchresult.ts
@@ -32,7 +32,7 @@ export class MatchResultHelper {
     const playerIndex = session?.playerIndex ?? 0
     const amIWinner = forcedAmIWinner ?? winnerIndex === playerIndex
 
-    const subtext = this.getScoreSubtext(container, amIWinner)
+    const subtext = this.getScoreSubtext(container)
 
     if (amIWinner) {
       this.notifyWin(container, subtext)
@@ -71,7 +71,7 @@ export class MatchResultHelper {
     container.notifyLocal({
       type: "GameOver",
       title: "YOU LOST",
-      subtext: subtext,
+      subtext: Session.isBotMode() ? "Lostber 🦞" : subtext,
       icon: "🥈",
       extraClass: "is-loser",
       extra: gameOverButtons.forMode(
@@ -107,14 +107,7 @@ export class MatchResultHelper {
     )
   }
 
-  private static getScoreSubtext(
-    container: Container,
-    amIWinner?: boolean
-  ): string {
-    if (Session.isBotMode() && amIWinner === false) {
-      return "Lostber 🦞"
-    }
-
+  private static getScoreSubtext(container: Container): string {
     if (container.isSinglePlayer) {
       return `Score: ${container.getMyScore()}`
     }

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -1,5 +1,6 @@
 import { Container } from "../container/container"
 import { getButton } from "../utils/dom"
+import { Session } from "../network/client/session"
 
 export class Menu {
   container: Container
@@ -35,7 +36,14 @@ export class Menu {
           },
           0,
           {
-            "concede-confirm": () => this.container.notification.clear(),
+            "concede-confirm": () => {
+              this.container.notification.clear()
+              if (Session.isBotMode()) {
+                this.container.updateController(
+                  this.container.rules.handleGameEnd(false)
+                )
+              }
+            },
             "concede-cancel": () => this.container.notification.clear(),
           }
         )

--- a/test/rules/matchresult.spec.ts
+++ b/test/rules/matchresult.spec.ts
@@ -187,4 +187,14 @@ describe("MatchResult Construction", () => {
     expect(result.winner).to.equal("TestPlayer")
     expect(result.winnerScore).to.equal(7)
   })
+
+  it("MatchResultHelper should show Lostber subtext in bot mode loss", () => {
+    Session.init("test-client", "TestPlayer", "test-table", false, true)
+    container = createNineBallContainer()
+    const result = (container.rules as any).handleGameEnd(false)
+    expect(result.name).to.equal("End")
+    const notification = document.getElementById("notification")
+    expect(notification?.innerHTML).to.contain("Lostber 🦞")
+    expect(notification?.innerHTML).to.contain("New Game")
+  })
 })

--- a/test/view/menu.spec.ts
+++ b/test/view/menu.spec.ts
@@ -4,6 +4,7 @@ import { fireEvent } from "@testing-library/dom"
 import { Container } from "../../src/container/container"
 import { Menu } from "../../src/view/menu"
 import { Assets } from "../../src/view/assets"
+import { Session } from "../../src/network/client/session"
 
 initDom()
 
@@ -45,6 +46,25 @@ describe("Menu", () => {
     fireEvent.click(playOn)
 
     expect(notification?.innerHTML).to.equal("")
+    done()
+  })
+
+  it("concede confirm in bot mode triggers game over", (done) => {
+    Session.init("test-client", "TestPlayer", "test-table", false, true)
+    const concede = document.getElementById("concede") as HTMLButtonElement
+    fireEvent.click(concede)
+
+    const confirm = document.querySelector(
+      "[data-notification-action='concede-confirm']"
+    ) as HTMLButtonElement
+    fireEvent.click(confirm)
+
+    expect(container.controller.name).to.equal("End")
+    const notification = document.getElementById("notification")
+    expect(notification?.innerHTML).to.contain("YOU LOST")
+    expect(notification?.innerHTML).to.contain("Lostber 🦞")
+
+    Session.reset()
     done()
   })
 })


### PR DESCRIPTION
This PR improves the behavior of the "Concede" button in bot mode and unifies the game end notification logic.

Key changes:
- In `src/view/menu.ts`, clicking "Concede" while in bot mode now triggers the standard bot win/player loss sequence.
- `src/network/client/matchresult.ts` was updated to handle bot-mode specifics, such as the "Lostber 🦞" subtext and ensuring the "New Game" button is displayed.
- Manual notification logic in `src/network/bot/eventhandler.ts` was replaced with the unified `handleGameEnd` call to reduce duplication and ensure UI consistency.
- Visual verification was performed using a Playwright script to confirm the "YOU LOST" screen looks correct with the bot-specific elements.

---
*PR created automatically by Jules for task [14479868769128915370](https://jules.google.com/task/14479868769128915370) started by @tailuge*