### PR TITLE
Add CONCEDE event type

### DIFF
--- a/src/controller/controller.ts
+++ b/src/controller/controller.ts
@@ -14,8 +14,17 @@ import { StartAimEvent } from "../events/startaimevent"
 import { NotificationEvent } from "../events/notificationevent"
 import { ScoreEvent } from "../events/scoreevent"
 import { RerackEvent } from "../events/rerackevent"
+import { ConcedeEvent } from "../events/concedeevent"
 
-export { BeginEvent, AimEvent, HitEvent, Input, AbortEvent, StationaryEvent }
+export {
+  BeginEvent,
+  AimEvent,
+  HitEvent,
+  Input,
+  AbortEvent,
+  StationaryEvent,
+  ConcedeEvent,
+}
 
 /**
  * Controller manages the state of the system reacting to input and network events in the animation loop.
@@ -74,6 +83,9 @@ export abstract class Controller {
     return this
   }
   handleRerack(_: RerackEvent): Controller {
+    return this
+  }
+  handleConcede(_: ConcedeEvent): Controller {
     return this
   }
   onFirst() {}

--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -3,6 +3,7 @@ import { exportGltf } from "../utils/gltf"
 import { ChatEvent } from "../events/chatevent"
 import { NotificationEvent } from "../events/notificationevent"
 import { ScoreEvent } from "../events/scoreevent"
+import { ConcedeEvent } from "../events/concedeevent"
 import { Outcome } from "../model/outcome"
 import { Vector3 } from "three"
 
@@ -23,6 +24,10 @@ export abstract class ControllerBase extends Controller {
 
   override handleScore(event: ScoreEvent): Controller {
     this.container.updateScoreHud(event.p1, event.p2, event.b, event.active)
+    return this
+  }
+
+  override handleConcede(_: ConcedeEvent): Controller {
     return this
   }
 

--- a/src/events/concedeevent.ts
+++ b/src/events/concedeevent.ts
@@ -1,0 +1,14 @@
+import { GameEvent } from "./gameevent"
+import { EventType } from "./eventtype"
+import { Controller } from "../controller/controller"
+
+export class ConcedeEvent extends GameEvent {
+  constructor() {
+    super()
+    this.type = EventType.CONCEDE
+  }
+
+  applyToController(controller: Controller): Controller {
+    return controller.handleConcede(this)
+  }
+}

--- a/src/events/eventtype.ts
+++ b/src/events/eventtype.ts
@@ -13,4 +13,5 @@ export enum EventType {
   STARTAIM = "STARTAIM",
   NOTIFICATION = "NOTIFICATION",
   SCORE = "SCORE",
+  CONCEDE = "CONCEDE",
 }

--- a/src/events/eventutil.ts
+++ b/src/events/eventutil.ts
@@ -14,6 +14,7 @@ import { StartAimEvent } from "./startaimevent"
 import { NotificationEvent } from "./notificationevent"
 import { ScoreEvent } from "./scoreevent"
 import { StationaryEvent } from "./stationaryevent"
+import { ConcedeEvent } from "./concedeevent"
 
 export class EventUtil {
   static serialise(event: GameEvent) {
@@ -50,6 +51,8 @@ export class EventUtil {
         return NotificationEvent.fromJson(parsed)
       case EventType.SCORE:
         return ScoreEvent.fromJson(parsed)
+      case EventType.CONCEDE:
+        return new ConcedeEvent()
       default:
         throw new Error(`Unknown GameEvent: ${EventUtil.safeStringify(parsed)}`)
     }

--- a/test/controller/controller.spec.ts
+++ b/test/controller/controller.spec.ts
@@ -16,6 +16,7 @@ import { Outcome } from "../../src/model/outcome"
 import { PlaceBall } from "../../src/controller/placeball"
 import { ChatEvent } from "../../src/events/chatevent"
 import { NotificationEvent } from "../../src/events/notificationevent"
+import { ConcedeEvent } from "../../src/events/concedeevent"
 import { PlaceBallEvent } from "../../src/events/placeballevent"
 import { zero } from "../../src/utils/utils"
 import { BreakEvent } from "../../src/events/breakevent"
@@ -463,6 +464,23 @@ describe("Controller", () => {
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(WatchShot)
     expect(showSpy.mock.calls[0]).to.deep.equal(["test", 100])
+    done()
+  })
+
+  it("ConcedeEvent handled with no change of state", (done) => {
+    const watchShot = new WatchShot(container)
+    container.controller = watchShot
+    container.eventQueue.push(new ConcedeEvent())
+    container.processEvents()
+    expect(container.controller).to.be.an.instanceof(WatchShot)
+    done()
+  })
+
+  it("End handles ConcedeEvent", (done) => {
+    container.controller = new End(container)
+    container.eventQueue.push(new ConcedeEvent())
+    container.processEvents()
+    expect(container.controller).to.be.an.instanceof(End)
     done()
   })
 })

--- a/test/events/concedeevent.spec.ts
+++ b/test/events/concedeevent.spec.ts
@@ -1,0 +1,29 @@
+import { ConcedeEvent } from "../../src/events/concedeevent"
+import { EventType } from "../../src/events/eventtype"
+import { EventUtil } from "../../src/events/eventutil"
+import { Controller } from "../../src/controller/controller"
+
+describe("ConcedeEvent", () => {
+  it("should create a ConcedeEvent", () => {
+    const event = new ConcedeEvent()
+    expect(event.type).toBe(EventType.CONCEDE)
+  })
+
+  it("should serialise and deserialise", () => {
+    const event = new ConcedeEvent()
+    const serialised = EventUtil.serialise(event)
+    const deserialised = EventUtil.fromSerialised(serialised) as ConcedeEvent
+
+    expect(deserialised.type).toBe(EventType.CONCEDE)
+  })
+
+  it("should apply to controller", () => {
+    const event = new ConcedeEvent()
+    const mockController = {
+      handleConcede: jest.fn().mockReturnThis(),
+    } as unknown as Controller
+
+    event.applyToController(mockController)
+    expect(mockController.handleConcede).toHaveBeenCalledWith(event)
+  })
+})

--- a/test/events/eventutil.spec.ts
+++ b/test/events/eventutil.spec.ts
@@ -13,6 +13,7 @@ import { ChatEvent } from "../../src/events/chatevent"
 import { BeginEvent } from "../../src/events/beginevent"
 import { HitEvent } from "../../src/events/hitevent"
 import { ScoreEvent } from "../../src/events/scoreevent"
+import { ConcedeEvent } from "../../src/events/concedeevent"
 
 describe("EventUtil", () => {
   it("Serialise and deserialise AimEvent", (done) => {
@@ -71,6 +72,13 @@ describe("EventUtil", () => {
     const serialised = EventUtil.serialise(new BeginEvent())
     const deserialised = EventUtil.fromSerialised(serialised)
     expect(deserialised.type).to.equal(EventType.BEGIN)
+    done()
+  })
+
+  it("Serialise and deserialise ConcedeEvent", (done) => {
+    const serialised = EventUtil.serialise(new ConcedeEvent())
+    const deserialised = EventUtil.fromSerialised(serialised)
+    expect(deserialised.type).to.equal(EventType.CONCEDE)
     done()
   })
 


### PR DESCRIPTION
This change introduces a new `CONCEDE` event type to the game's event system. While the current implementation in the controller is a no-op, the event is fully integrated, supporting serialization, deserialization, and handling within the controller architecture. A unit test has been added to ensure correct event processing.

---
*PR created automatically by Jules for task [17816767370490407744](https://jules.google.com/task/17816767370490407744) started by @tailuge*