### PR TITLE
Silence own event logs

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -182,18 +182,17 @@ export class BrowserContainer {
 
   netEvent(e: string) {
     const event = EventUtil.fromSerialised(e)
-    logNetEvent(this.playername, event, "receive")
     if (event.clientId === Session.getInstance().clientId) {
-      console.log("Ignoring own event")
-    } else {
-      if (event.clientId) {
-        Session.getInstance().setOpponentClientId(event.clientId)
-      }
-      if (event.playername) {
-        Session.getInstance().opponentName = event.playername
-      }
-      this.container.eventQueue.push(event)
+      return
     }
+    logNetEvent(this.playername, event, "receive")
+    if (event.clientId) {
+      Session.getInstance().setOpponentClientId(event.clientId)
+    }
+    if (event.playername) {
+      Session.getInstance().opponentName = event.playername
+    }
+    this.container.eventQueue.push(event)
   }
 
   broadcast(event: GameEvent) {


### PR DESCRIPTION
Silenced the "Ignoring own event" console logs in `BrowserContainer` and moved the `logNetEvent` call to only trigger for events from other clients, addressing the request to avoid printing anything for self-events and adjusting the receive log point.

---
*PR created automatically by Jules for task [6107391953056582075](https://jules.google.com/task/6107391953056582075) started by @tailuge*