### PR TITLE
Add orbital camera mode to game-end state

### DIFF
--- a/src/controller/end.ts
+++ b/src/controller/end.ts
@@ -20,6 +20,7 @@ export class End extends Controller {
   }
 
   override onFirst(): void {
+    this.container.view.camera.forceMode(this.container.view.camera.orbitView)
     this.container.menu?.setConcedeVisible(false)
     console.log("result:", this.result)
     if (this.result && this.container.scoreReporter) {

--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -19,10 +19,24 @@ export class Camera {
   private readonly tempVec = new Vector3()
 
   elapsed: number
+  private t = 0
 
   update(elapsed, aim: AimEvent) {
     this.elapsed = elapsed
+    this.t += elapsed
     this.mode(aim)
+  }
+
+  orbitView(_: AimEvent) {
+    this.camera.fov = 45
+    this.target.set(
+      Math.sin(this.t / 20) * R * 22,
+      Math.cos(this.t / 20) * R * 22,
+      R * 2
+    )
+    this.camera.position.lerp(this.target, 0.02)
+    this.camera.up = up
+    this.camera.lookAt(zero)
   }
 
   topView(_: AimEvent) {

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai"
+import { Camera } from "../../src/view/camera"
+import { AimEvent } from "../../src/events/aimevent"
+import { R } from "../../src/model/physics/constants"
+import { Vector3 } from "three"
+
+describe("Camera", () => {
+  it("increments t in update", () => {
+    const camera = new Camera(1)
+    const aim = new AimEvent(0, new Vector3(), 0, 0, 0)
+    camera.update(0.1, aim)
+    expect((camera as any).t).to.be.closeTo(0.1, 0.001)
+    camera.update(0.2, aim)
+    expect((camera as any).t).to.be.closeTo(0.3, 0.001)
+  })
+
+  it("orbitView sets target correctly", () => {
+    const camera = new Camera(1)
+    const aim = new AimEvent(0, new Vector3(), 0, 0, 0)
+
+    // Set t to a known value
+    const t = 20 * Math.PI / 2 // sin(t/20) = 1, cos(t/20) = 0
+    camera.update(t, aim)
+
+    camera.orbitView(aim)
+
+    // target is internal but we can check camera position after lerp
+    // If we want to check target directly we might need to cast to any
+    const target = (camera as any).target
+    expect(target.x).to.be.closeTo(22 * R, 0.001)
+    expect(target.y).to.be.closeTo(0, 0.001)
+    expect(target.z).to.be.closeTo(2 * R, 0.001)
+  })
+})


### PR DESCRIPTION
This change introduces a new camera mode that orbits the table when the game reaches the 'End' state. 

Key changes:
1. **Camera Class Updates**:
   - Added a private property `t` to track accumulated time.
   - Updated `update()` to increment `t` by the elapsed frame time.
   - Implemented `orbitView()`, which calculates a circular path around the table (radius 22R, height 2R) and uses `lerp` for a smooth entry from the previous camera position.
2. **End Controller Integration**:
   - Updated `onFirst()` in `End.ts` to switch the camera to `orbitView` using the `forceMode` API.
3. **Verification**:
   - Added unit tests in `test/view/camera.spec.ts` to verify time accumulation and orbit target calculation.
   - Confirmed that starting a new game (via `PlaceBall` or `Replay`) correctly resets the camera to standard views.
   - Verified the build succeeds with `yarn build`.

---
*PR created automatically by Jules for task [4440795086625582219](https://jules.google.com/task/4440795086625582219) started by @tailuge*