### PR TITLE
Update hit button style and timeout reset logic

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -407,16 +407,17 @@ input[type="range"].powerSlider {
   --sweep: 360deg;
   --timer-color: #10b981;
   background:
-    linear-gradient(#18181b, #18181b) padding-box,
-    conic-gradient(var(--timer-color) var(--sweep), #3f3f46 0deg) border-box;
+    linear-gradient(#f4f4f5, #f4f4f5) padding-box,
+    conic-gradient(var(--timer-color) var(--sweep), #e4e4e7 0deg) border-box;
   border: 4px solid transparent;
   border-radius: 14px;
+  color: #18181b;
 }
 
 .timeout-btn:not(:disabled):hover {
   background:
-    linear-gradient(#27272a, #27272a) padding-box,
-    conic-gradient(var(--timer-color) var(--sweep), #3f3f46 0deg) border-box;
+    linear-gradient(#ffffff, #ffffff) padding-box,
+    conic-gradient(var(--timer-color) var(--sweep), #e4e4e7 0deg) border-box;
 }
 
 

--- a/src/view/aiminputs.ts
+++ b/src/view/aiminputs.ts
@@ -63,13 +63,12 @@ export class AimInputs {
   }
 
   setDisabled(disabled: boolean) {
-    const wasDisabled = this.controlsDisabled
     this.controlsDisabled = disabled || Session.isSpectator()
     if (this.cueHitElement) {
       this.cueHitElement.disabled = this.controlsDisabled
-      if (wasDisabled && !this.controlsDisabled) {
+      if (!this.controlsDisabled) {
         this.timeoutButton?.startTimer()
-      } else if (this.controlsDisabled) {
+      } else {
         this.timeoutButton?.cancel()
       }
     }

--- a/test/view/particle-system.spec.ts
+++ b/test/view/particle-system.spec.ts
@@ -1,5 +1,5 @@
 import { ParticleSystem } from "../../src/view/particle-system"
-import { Scene, InstancedMesh, Color } from "three"
+import { Scene, InstancedMesh } from "three"
 
 describe("ParticleSystem", () => {
   let scene: Scene


### PR DESCRIPTION
The hit button's CSS style was updated to a light theme to match the camera button, while keeping the conic-gradient sweep timeout effect. The activation logic in `AimInputs.ts` was also modified to ensure the timeout resets every time the button is enabled, fulfilling the requirement for the timer to reset whenever the button becomes activated.

---
*PR created automatically by Jules for task [6638808067984259721](https://jules.google.com/task/6638808067984259721) started by @tailuge*