### PR TITLE
Lock Aim and Purge Inputs After Hit Event

### DIFF
--- a/src/controller/aim.ts
+++ b/src/controller/aim.ts
@@ -56,6 +56,8 @@ export class Aim extends ControllerBase {
   }
 
   playShot() {
+    this.container.inputQueue.length = 0
+    this.container.table.cue.aimInputs.setDisabled(true)
     const hitEvent = new HitEvent(this.container.table.serialiseHit())
     this.container.sendEvent(hitEvent)
     return new PlayShot(this.container)

--- a/src/view/aiminputs.ts
+++ b/src/view/aiminputs.ts
@@ -149,7 +149,7 @@ export class AimInputs {
     if (this.controlsDisabled) {
       return
     }
-    this.container.table.cue.setPower(this.cuePowerElement.value)
+    this.container.table.cue.setPower(Number(this.cuePowerElement.value))
   }
 
   updatePowerSlider(power) {
@@ -162,7 +162,7 @@ export class AimInputs {
     if (this.controlsDisabled) {
       return
     }
-    this.container.table.cue.setPower(this.cuePowerElement?.value)
+    this.container.table.cue.setPower(Number(this.cuePowerElement?.value))
     this.container.inputQueue.push(new Input(0, "SpaceUp"))
   }
 
@@ -171,8 +171,9 @@ export class AimInputs {
       return
     }
     if (this.cuePowerElement) {
-      this.cuePowerElement.value -= Math.sign(e.deltaY) / 10
-      this.container.table.cue.setPower(this.cuePowerElement.value)
+      this.cuePowerElement.value =
+        Number(this.cuePowerElement.value) - Math.sign(e.deltaY) / 10
+      this.container.table.cue.setPower(Number(this.cuePowerElement.value))
       this.container.lastEventTime = performance.now()
     }
   }

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -38,7 +38,7 @@ export class Cue {
   }
 
   rotateAim(angle, table: Table) {
-    if (this.aimInputs.isDisabled()) {
+    if (!this.aimInputs || this.aimInputs.isDisabled()) {
       return
     }
     this.aim.angle = this.aim.angle + angle
@@ -49,11 +49,17 @@ export class Cue {
   }
 
   adjustPower(delta) {
+    if (!this.aimInputs || this.aimInputs.isDisabled()) {
+      return
+    }
     this.aim.power = Math.min(this.maxPower, this.aim.power + delta)
     this.updateAimInput()
   }
 
   setPower(value: number) {
+    if (!this.aimInputs || this.aimInputs.isDisabled()) {
+      return
+    }
     this.aim.power = value * this.maxPower
   }
 
@@ -76,11 +82,17 @@ export class Cue {
   }
 
   adjustSpin(delta: Vector3, table: Table) {
+    if (!this.aimInputs || this.aimInputs.isDisabled()) {
+      return
+    }
     const newOffset = this.tempVec3.copy(this.aim.offset).add(delta)
     this.setSpin(newOffset, table)
   }
 
   setSpin(offset: Vector3, table: Table) {
+    if (!this.aimInputs || this.aimInputs.isDisabled()) {
+      return
+    }
     if (offset.length() > this.offCenterLimit) {
       offset.normalize().multiplyScalar(this.offCenterLimit)
     }

--- a/test/model/cue.spec.ts
+++ b/test/model/cue.spec.ts
@@ -49,6 +49,78 @@ describe("Cue", () => {
     expect(table.balls[0].rvel.y).to.be.greaterThan(0)
   })
 
+  test("adjustPower increases power when enabled", () => {
+    const { cue } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = {
+      isDisabled: () => false,
+      updateVisualState: () => {},
+      updatePowerSlider: () => {},
+      showOverlap: () => {},
+    } as any
+    const powerBefore = cue.aim.power
+    cue.adjustPower(10 * R)
+    expect(cue.aim.power).to.equal(powerBefore + 10 * R)
+  })
+
+  test("adjustPower returns early when disabled", () => {
+    const { cue } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = { isDisabled: () => true } as any
+    const powerBefore = cue.aim.power
+    cue.adjustPower(10 * R)
+    expect(cue.aim.power).to.equal(powerBefore)
+  })
+
+  test("setPower updates power when enabled", () => {
+    const { cue } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = { isDisabled: () => false } as any
+    cue.setPower(0.5)
+    expect(cue.aim.power).to.equal(0.5 * cue.maxPower)
+  })
+
+  test("setPower returns early when disabled", () => {
+    const { cue } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = { isDisabled: () => true } as any
+    const powerBefore = cue.aim.power
+    cue.setPower(0.5)
+    expect(cue.aim.power).to.equal(powerBefore)
+  })
+
+  test("adjustSpin updates offset when enabled", () => {
+    const { cue, table } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = {
+      isDisabled: () => false,
+      updateVisualState: () => {},
+      updatePowerSlider: () => {},
+      showOverlap: () => {},
+    } as any
+    const offsetBefore = cue.aim.offset.clone()
+    cue.adjustSpin(new Vector3(0.1, 0.1), table)
+    expect(cue.aim.offset.x).to.equal(offsetBefore.x + 0.1)
+  })
+
+  test("adjustSpin returns early when disabled", () => {
+    const { cue, table } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = { isDisabled: () => true } as any
+    const offsetBefore = cue.aim.offset.clone()
+    cue.adjustSpin(new Vector3(0.1, 0.1), table)
+    expect(cue.aim.offset.equals(offsetBefore)).to.be.true
+  })
+
+  test("setSpin returns early when disabled", () => {
+    const { cue, table } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = { isDisabled: () => true } as any
+    const offsetBefore = cue.aim.offset.clone()
+    cue.setSpin(new Vector3(0.1, 0.1), table)
+    expect(cue.aim.offset.equals(offsetBefore)).to.be.true
+  })
+
+  test("toggleHelper toggles helper visibility", () => {
+    const cue = new Cue()
+    const visibleBefore = cue.helperMesh.visible
+    cue.toggleHelper()
+    expect(cue.helperMesh.visible).to.equal(!visibleBefore)
+  })
+
   test("rotateAim calls showOverlap if aimInputs present", () => {
     const { cue, table } = createCueAndTable(new Vector3(0, 1, 0))
     let called = false

--- a/test/model/cue.spec.ts
+++ b/test/model/cue.spec.ts
@@ -37,6 +37,12 @@ describe("Cue", () => {
 
   test("topspin applied", () => {
     const { cue, table } = createCueAndTable(new Vector3(0, 1, 0))
+    cue.aimInputs = {
+      isDisabled: () => false,
+      updateVisualState: () => {},
+      updatePowerSlider: () => {},
+      showOverlap: () => {},
+    } as any
     cue.setPower(1)
     cue.setSpin(new Vector3(0, 0.4), table)
     cue.hit(table.balls[0])

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -18,7 +18,7 @@ describe("AimInput", () => {
       log: (_) => {},
       assets: Assets.localAssets(),
     })
-    aiminputs = new AimInputs(container)
+    aiminputs = container.table.cue.aimInputs
     done()
   })
 


### PR DESCRIPTION
This change ensures that once a shot is initiated (the "Hit" button is clicked or "Space" is released), the state of the cue (angle, power, spin) is locked and any pending input events in the queue are discarded. This prevents late-arriving events or rapid user interactions from causing discrepancies between the serialized hit state and the actual physics simulation.

Key changes:
- `src/view/cue.ts`: `rotateAim`, `adjustPower`, `setPower`, `adjustSpin`, and `setSpin` now return early if `aimInputs` is disabled or missing.
- `src/controller/aim.ts`: `playShot()` now clears `this.container.inputQueue` and calls `setDisabled(true)` on `aimInputs` before transitioning to the `PlayShot` controller.
- `src/view/aiminputs.ts`: Added explicit `Number()` casting for power values to ensure correct type handling.
- `test/model/cue.spec.ts` & `test/view/aiminput.spec.ts`: Updated tests to properly initialize `aimInputs` mocks and handle numeric values.

---
*PR created automatically by Jules for task [2695790374718383936](https://jules.google.com/task/2695790374718383936) started by @tailuge*