### PR TITLE
Use newline separator for match score in notifications

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -138,6 +138,7 @@ p {
   font-size: 1em;
   font-weight: 500;
   margin: 0;
+  white-space: pre-wrap;
 }
 
 .notification-badge {

--- a/src/network/client/matchresult.ts
+++ b/src/network/client/matchresult.ts
@@ -203,7 +203,7 @@ export class MatchResultHelper {
     if (!session?.rematchInfo) return subtext
     const names = container.getOrderedNames()
     const scores = session.orderedRematchScores()
-    return `${subtext} | Match Score: ${names.p1Name || "Player 1"} ${scores.p1} - ${scores.p2} ${names.p2Name || "Player 2"}`
+    return `${subtext}\nMatch Score: ${names.p1Name || "Player 1"} ${scores.p1} - ${scores.p2} ${names.p2Name || "Player 2"}`
   }
 
   private static createMatchResult(

--- a/test/rules/matchresult.spec.ts
+++ b/test/rules/matchresult.spec.ts
@@ -197,4 +197,32 @@ describe("MatchResult Construction", () => {
     expect(notification?.innerHTML).to.contain("Lostber 🦞")
     expect(notification?.innerHTML).to.contain("New Game")
   })
+
+  it("MatchResultHelper should use newline separator for Match Score in subtext", () => {
+    container = createNineBallContainer()
+    const session = Session.getInstance()
+    session.opponentName = "TestOpponent"
+    session.opponentClientId = "test-opponent"
+    session.rematchInfo = {
+      opponentId: "test-opponent",
+      opponentName: "TestOpponent",
+      ruleType: "nineball",
+      lastScores: [
+        { userId: "test-client", score: 1 },
+        { userId: "test-opponent", score: 0 },
+      ],
+      nextTurnId: "test-opponent",
+    }
+    setupNineBallTable(container)
+
+    const nineball = container.rules as NineBall
+    const outcome = getNineBallOutcome(container)
+    const endController = nineball.update(outcome) as End
+    endController.onFirst()
+
+    const notification = document.getElementById("notification")
+    const subtextElement = notification?.querySelector(".notification-subtext")
+    expect(subtextElement?.textContent).to.contain("\nMatch Score:")
+    expect(subtextElement?.textContent).to.not.contain(" | Match Score:")
+  })
 })

--- a/test/rules/nineball.spec.ts
+++ b/test/rules/nineball.spec.ts
@@ -257,7 +257,7 @@ describe("NineBall Rules", () => {
       type: "GameOver",
       title: "YOU WON",
       subtext:
-        "TestPlayer 1 - 0 Opponent | Match Score: TestPlayer 1 - 0 Player 2",
+        "TestPlayer 1 - 0 Opponent\nMatch Score: TestPlayer 1 - 0 Player 2",
       extra: `<button data-notification-action="rematch">Rematch</button><button data-notification-action="lobby">Lobby</button>`,
       icon: "🏆",
       extraClass: "is-winner",

--- a/test/rules/snooker.spec.ts
+++ b/test/rules/snooker.spec.ts
@@ -460,7 +460,7 @@ describe("Snooker", () => {
     expect(notifySpy.mock.calls[0][0]).to.deep.include({
       title: "YOU LOST",
       subtext:
-        "Player A 10 - 20 Player B | Match Score: Player A 0 - 1 Player B",
+        "Player A 10 - 20 Player B\nMatch Score: Player A 0 - 1 Player B",
     })
 
     Session.reset()
@@ -485,7 +485,7 @@ describe("Snooker", () => {
     expect(notifySpy.mock.calls[0][0]).to.deep.include({
       title: "YOU WON",
       subtext:
-        "Player A 30 - 20 Player B | Match Score: Player A 1 - 0 Player B",
+        "Player A 30 - 20 Player B\nMatch Score: Player A 1 - 0 Player B",
     })
 
     Session.reset()
@@ -509,7 +509,7 @@ describe("Snooker", () => {
     expect(notifySpy.mock.calls[0][0]).to.deep.include({
       title: "YOU WON",
       subtext:
-        "Player A 20 - 20 Player B | Match Score: Player A 1 - 0 Player B",
+        "Player A 20 - 20 Player B\nMatch Score: Player A 1 - 0 Player B",
     })
 
     Session.reset()


### PR DESCRIPTION
This change improves the readability of the game-over notification by placing the Match Score on a new line instead of separating it with a pipe symbol. 

Key changes:
- In `src/network/client/matchresult.ts`, the `getFullSubtext` method now uses `\n` as a separator.
- In `dist/index.css`, the `.notification-subtext` class now includes `white-space: pre-wrap;` to support multi-line text.
- Test expectations in `test/rules/snooker.spec.ts` and `test/rules/nineball.spec.ts` have been updated.
- A new test case has been added to `test/rules/matchresult.spec.ts` to explicitly check for the newline separator.

---
*PR created automatically by Jules for task [17723274623171182362](https://jules.google.com/task/17723274623171182362) started by @tailuge*