### PR TITLE
Improve Network Error Logging Context

### DIFF
--- a/src/diagram/real/realoverlay.ts
+++ b/src/diagram/real/realoverlay.ts
@@ -88,7 +88,7 @@ export class RealOverlay {
       })
       .then((shotsData) => this.processShots(shotsData))
       .catch((error) => {
-        console.error(`Error loading default data from ${filename}:`, error)
+        console.error("Error loading default data from", filename, error)
       })
   }
 

--- a/src/diagram/real/realoverlay.ts
+++ b/src/diagram/real/realoverlay.ts
@@ -78,7 +78,8 @@ export class RealOverlay {
   }
 
   loadDefaultData() {
-    fetch("simple_shots.json")
+    const filename = "simple_shots.json"
+    fetch(filename)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`)
@@ -86,6 +87,9 @@ export class RealOverlay {
         return response.json()
       })
       .then((shotsData) => this.processShots(shotsData))
+      .catch((error) => {
+        console.error(`Error loading default data from ${filename}:`, error)
+      })
   }
 
   processShots(shotsData: any[]) {

--- a/src/network/client/nchanmessagerelay.ts
+++ b/src/network/client/nchanmessagerelay.ts
@@ -77,22 +77,21 @@ export class NchanMessageRelay implements MessageRelay {
       },
       body: message,
     }).catch((error) => {
-      console.error("Publication error:", error)
+      console.error(`Publication error for ${url}:`, error)
     })
   }
 
   async getOnlineCount(): Promise<number | null> {
+    const url = `https://${this.baseURL}/publish/presence/lobby`
     try {
-      const response = await fetch(
-        `https://${this.baseURL}/publish/presence/lobby`,
-        {
-          method: "POST",
-          headers: { Accept: "application/json" },
-        }
-      )
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      })
       const data = await response.json()
       return typeof data.subscribers === "number" ? data.subscribers : null
-    } catch {
+    } catch (error) {
+      console.warn(`Failed to fetch online count from ${url}:`, error)
       return null
     }
   }

--- a/src/network/client/nchanmessagerelay.ts
+++ b/src/network/client/nchanmessagerelay.ts
@@ -77,7 +77,7 @@ export class NchanMessageRelay implements MessageRelay {
       },
       body: message,
     }).catch((error) => {
-      console.error(`Publication error for ${url}:`, error)
+      console.error("Publication error for", url, error)
     })
   }
 
@@ -91,7 +91,7 @@ export class NchanMessageRelay implements MessageRelay {
       const data = await response.json()
       return typeof data.subscribers === "number" ? data.subscribers : null
     } catch (error) {
-      console.warn(`Failed to fetch online count from ${url}:`, error)
+      console.warn("Failed to fetch online count from", url, error)
       return null
     }
   }

--- a/src/network/client/scorereporter.ts
+++ b/src/network/client/scorereporter.ts
@@ -40,7 +40,7 @@ export class ScoreReporter {
         )
       }
     } catch (error) {
-      console.error(`Error submitting match result to ${url}:`, error)
+      console.error("Error submitting match result to", url, error)
     }
   }
 }

--- a/src/network/client/scorereporter.ts
+++ b/src/network/client/scorereporter.ts
@@ -40,7 +40,7 @@ export class ScoreReporter {
         )
       }
     } catch (error) {
-      console.error("Error submitting match result:", error)
+      console.error(`Error submitting match result to ${url}:`, error)
     }
   }
 }

--- a/src/utils/shorten.ts
+++ b/src/utils/shorten.ts
@@ -22,12 +22,12 @@ export function shorten(url, action) {
       if ("shortUrl" in data) {
         action(data.shortUrl)
       } else {
-        console.error(`Could not shorten url ${url} via ${endpoint}:`, data)
+        console.error("Could not shorten url", url, "via", endpoint, data)
         action(url)
       }
     })
     .catch((e) => {
-      console.error(`Error shortening url ${url} via ${endpoint}:`, e)
+      console.error("Error shortening url", url, "via", endpoint, e)
       action(url)
     })
 }

--- a/src/utils/shorten.ts
+++ b/src/utils/shorten.ts
@@ -10,7 +10,8 @@ export function shorten(url, action) {
       .replaceAll("*", "%2A")
   ).search
   console.log("Shortening url")
-  fetch("https://scoreboard-tailuge.vercel.app/api/shorten", {
+  const endpoint = "https://scoreboard-tailuge.vercel.app/api/shorten"
+  fetch(endpoint, {
     method: "POST",
     mode: "cors",
     headers: { "Content-Type": "application/json" },
@@ -21,14 +22,12 @@ export function shorten(url, action) {
       if ("shortUrl" in data) {
         action(data.shortUrl)
       } else {
-        console.log("Could not shorten url:")
-        console.log(data)
+        console.error(`Could not shorten url ${url} via ${endpoint}:`, data)
         action(url)
       }
     })
     .catch((e) => {
-      console.log("Error shortening url:")
-      console.log(e)
+      console.error(`Error shortening url ${url} via ${endpoint}:`, e)
       action(url)
     })
 }

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -19,6 +19,6 @@ export function logusage() {
       }
     })
     .catch((error) => {
-      console.error(`Fetch error for ${url}:`, error)
+      console.error("Fetch error for", url, error)
     })
 }

--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -19,6 +19,6 @@ export function logusage() {
       }
     })
     .catch((error) => {
-      console.error("Fetch error:", error)
+      console.error(`Fetch error for ${url}:`, error)
     })
 }

--- a/test/network/client/nchanmessagerelay.spec.ts
+++ b/test/network/client/nchanmessagerelay.spec.ts
@@ -72,7 +72,8 @@ describe("NchanMessageRelay", () => {
       // wait for the promise in publish to settle
       await new Promise((resolve) => setTimeout(resolve, 0))
       expect(spy).toHaveBeenCalledWith(
-        "Publication error for https://billiards-network.onrender.com/publish/table/chan1:",
+        "Publication error for",
+        "https://billiards-network.onrender.com/publish/table/chan1",
         error
       )
       spy.mockRestore()

--- a/test/network/client/nchanmessagerelay.spec.ts
+++ b/test/network/client/nchanmessagerelay.spec.ts
@@ -71,7 +71,10 @@ describe("NchanMessageRelay", () => {
 
       // wait for the promise in publish to settle
       await new Promise((resolve) => setTimeout(resolve, 0))
-      expect(spy).toHaveBeenCalledWith("Publication error:", error)
+      expect(spy).toHaveBeenCalledWith(
+        "Publication error for https://billiards-network.onrender.com/publish/table/chan1:",
+        error
+      )
       spy.mockRestore()
     })
   })

--- a/test/network/client/scorereporter.spec.ts
+++ b/test/network/client/scorereporter.spec.ts
@@ -95,7 +95,8 @@ describe("ScoreReporter", () => {
     await reporter.submitMatchResult(sampleMatchResult)
 
     expect(console.error).toHaveBeenCalledWith(
-      "Error submitting match result to https://scoreboard-tailuge.vercel.app/api/match-results:",
+      "Error submitting match result to",
+      "https://scoreboard-tailuge.vercel.app/api/match-results",
       networkError
     )
   })

--- a/test/network/client/scorereporter.spec.ts
+++ b/test/network/client/scorereporter.spec.ts
@@ -95,7 +95,7 @@ describe("ScoreReporter", () => {
     await reporter.submitMatchResult(sampleMatchResult)
 
     expect(console.error).toHaveBeenCalledWith(
-      "Error submitting match result:",
+      "Error submitting match result to https://scoreboard-tailuge.vercel.app/api/match-results:",
       networkError
     )
   })


### PR DESCRIPTION
This change improves the observability of network-related errors by ensuring that all `fetch` calls across the codebase log the target URL or filename when they fail. This addresses the issue where generic "Failed to fetch" errors lacked enough detail for effective debugging. Specific improvements were made in `ScoreReporter`, `NchanMessageRelay`, `shorten` utility, `logusage` utility, and `RealOverlay`. Corresponding unit tests were also updated to match the improved log formats.

---
*PR created automatically by Jules for task [9811066207135967674](https://jules.google.com/task/9811066207135967674) started by @tailuge*