### PR TITLE
Fix maintainability issues in rematch, particle-system, and tests

### DIFF
--- a/src/network/client/rematch.ts
+++ b/src/network/client/rematch.ts
@@ -27,14 +27,21 @@ export class Rematch {
     amIWinner: boolean,
     isSinglePlayer: boolean,
   ) {
-    if (!session || !session.clientId) return;
+    if (!session?.clientId) return;
     if (isSinglePlayer || session.botMode) return;
 
     const opponentId = session.opponentClientId || "opponent";
     const winnerId = amIWinner ? session.clientId : opponentId;
     const loserId = amIWinner ? opponentId : session.clientId;
 
-    if (!session.rematchInfo) {
+    if (session.rematchInfo) {
+      session.rematchInfo.lastScores.forEach((s) => {
+        if (s.userId === winnerId) {
+          s.score++;
+        }
+      });
+      session.rematchInfo.nextTurnId = loserId;
+    } else {
       const opponentName = session.opponentName || "Opponent";
       session.rematchInfo = {
         opponentId,
@@ -46,13 +53,6 @@ export class Rematch {
         ],
         nextTurnId: loserId,
       };
-    } else {
-      session.rematchInfo.lastScores.forEach((s) => {
-        if (s.userId === winnerId) {
-          s.score++;
-        }
-      });
-      session.rematchInfo.nextTurnId = loserId;
     }
   }
 

--- a/src/view/particle-system.ts
+++ b/src/view/particle-system.ts
@@ -31,7 +31,7 @@ const DEFAULT_CONFIG: Required<ParticleSystemConfig> = {
   scaleX: 0.99 * R,
   scaleY: 0.98 * R,
   stopThreshold: 0.25,
-  gravity: -1.0,
+  gravity: -1,
   baseRestitution: 0.45,
   restitutionVariance: 0.25,
   backgroundColor: "#040b9f",

--- a/test/rules/rematch_bug.spec.ts
+++ b/test/rules/rematch_bug.spec.ts
@@ -38,7 +38,7 @@ describe("Rematch Bug Reproduction", () => {
     // Stub onAssetsReady/createContainer to avoid full game loop
     bc1["createContainer"] = function(scoreReporter: any) {
         return new Container({
-            element: bc1.canvas3d as any,
+            element: bc1.canvas3d,
             log: () => {},
             assets: Assets.localAssets("nineball"),
             ruletype: "nineball",


### PR DESCRIPTION
I have addressed several maintainability issues and code smells identified in the project. Specifically, I:
1. Refactored `src/network/client/rematch.ts` to use optional chaining (`session?.clientId`) and simplified the control flow by inverting a negated condition.
2. Formatted the `gravity` constant in `src/view/particle-system.ts` by removing the redundant zero fraction (`-1.0` to `-1`).
3. Cleaned up `test/rules/rematch_bug.spec.ts` by removing an unnecessary `as any` type assertion.
4. Verified that all tests pass (after ensuring `src/utils/version.ts` was generated).


---
*PR created automatically by Jules for task [11352475554164481016](https://jules.google.com/task/11352475554164481016) started by @tailuge*