### PR TITLE
Enable presence system in all modes and refactor Session handling

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -147,15 +147,16 @@ export class BrowserContainer {
     this.container.init()
 
     const session = Session.getInstance()
-    if (session.rematchInfo) {
+    const rematchInfo = session.rematchInfo
+    if (rematchInfo) {
       const getName = (uid: string) =>
         uid === session.clientId
           ? session.playername
-          : session.opponentName || session.rematchInfo?.opponentName
+          : session.opponentName || rematchInfo.opponentName
 
       const matchScoreText = Rematch.getMatchScoreText(session, {
-        p1Name: getName(session.rematchInfo.lastScores[0].userId),
-        p2Name: getName(session.rematchInfo.lastScores[1].userId),
+        p1Name: getName(rematchInfo.lastScores[0].userId),
+        p2Name: getName(rematchInfo.lastScores[1].userId),
       })
 
       this.container.notify({

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -60,10 +60,6 @@ export class Container {
   stayActive: boolean = false
   frame: (timestamp: number) => void
 
-  private readonly localScores = {
-    my: 0,
-    opponent: 0,
-  }
   private hudScores = {
     p1: 0,
     p2: 0,
@@ -118,9 +114,7 @@ export class Container {
   }
 
   init() {
-    if (!this.replayMode) {
-      this.lobbyIndicator.init()
-    }
+    this.lobbyIndicator.init()
   }
 
   sendChat = (msg) => {
@@ -137,33 +131,19 @@ export class Container {
   }
 
   getMyScore(): number {
-    if (Session.hasInstance()) {
-      return Session.getInstance().myScore()
-    }
-    return this.localScores.my
+    return Session.getInstance().myScore()
   }
 
   getOpponentScore(): number {
-    if (Session.hasInstance()) {
-      return Session.getInstance().opponentScore()
-    }
-    return this.localScores.opponent
+    return Session.getInstance().opponentScore()
   }
 
   setMyScore(score: number): void {
-    if (Session.hasInstance()) {
-      Session.getInstance().setMyScore(score)
-      return
-    }
-    this.localScores.my = score
+    Session.getInstance().setMyScore(score)
   }
 
   setOpponentScore(score: number): void {
-    if (Session.hasInstance()) {
-      Session.getInstance().setOpponentScore(score)
-      return
-    }
-    this.localScores.opponent = score
+    Session.getInstance().setOpponentScore(score)
   }
 
   addMyScore(delta: number): void {
@@ -175,21 +155,15 @@ export class Container {
   }
 
   getOrderedScores(): { p1: number; p2: number } {
-    if (Session.hasInstance()) {
-      return Session.getInstance().orderedScoresForHud()
-    }
-    return { p1: this.localScores.my, p2: this.localScores.opponent }
+    return Session.getInstance().orderedScoresForHud()
   }
 
   getOrderedNames(): { p1Name?: string; p2Name?: string } {
-    if (Session.hasInstance()) {
-      return Session.getInstance().orderedNamesForHud()
-    }
-    return {}
+    return Session.getInstance().orderedNamesForHud()
   }
 
   setScoresFromNetwork(p1: number, p2: number, breakScore: number): void {
-    if (Session.hasInstance() && Session.getInstance().playerIndex === 1) {
+    if (Session.getInstance().playerIndex === 1) {
       this.setMyScore(p2)
       this.setOpponentScore(p1)
     } else {
@@ -200,9 +174,7 @@ export class Container {
   }
 
   private myHudSlot(): 1 | 2 {
-    return Session.hasInstance() && Session.getInstance().playerIndex === 1
-      ? 2
-      : 1
+    return Session.getInstance().playerIndex === 1 ? 2 : 1
   }
 
   private opponentHudSlot(): 1 | 2 {
@@ -329,9 +301,7 @@ export class Container {
   updateController(controller) {
     this.wasReplay = this.wasReplay || controller.name === "Replay"
     if (controller !== this.controller) {
-      const playerName = Session.hasInstance()
-        ? Session.getInstance().playername
-        : "_"
+      const playerName = Session.getInstance().playername
       this.log(`${playerName}: Transition to ${controller.name}`)
       this.controller = controller
       const active = this.inferActivePlayerFromController(controller)

--- a/src/controller/end.ts
+++ b/src/controller/end.ts
@@ -39,11 +39,7 @@ export class End extends Controller {
       return
     }
 
-    if (
-      !this.result ||
-      !Session.hasInstance() ||
-      MatchResultHelper.isWinner(this.result)
-    ) {
+    if (!this.result || MatchResultHelper.isWinner(this.result)) {
       this.container.particles.initParticles(this.container.view.scene)
     }
   }

--- a/src/controller/init.ts
+++ b/src/controller/init.ts
@@ -38,22 +38,18 @@ export class Init extends ControllerBase {
     this.container.chat.showMessage("Opponent to break")
     this.container.rules.secondToPlay()
     this.container.table.updateFromSerialised(event.json)
-    if (Session.hasInstance()) {
-      Session.getInstance().playerIndex = 1
-    }
+    Session.getInstance().playerIndex = 1
     return new WatchAim(this.container)
   }
 
   override handleBreak(event: BreakEvent): Controller {
     if (event.init) {
       this.container.table.updateFromShortSerialised(event.init)
-      if (Session.hasInstance()) {
-        const player = Session.getInstance().playername ?? "Player"
-        const opponent = Session.getInstance().opponentClientId
-          ? ` vs ${Session.getInstance().opponentName}`
-          : ""
-        this.container.chat.showMessage(`Replay of ${player}${opponent}`)
-      }
+      const player = Session.getInstance().playername || "Player"
+      const opponent = Session.getInstance().opponentClientId
+        ? ` vs ${Session.getInstance().opponentName}`
+        : ""
+      this.container.chat.showMessage(`Replay of ${player}${opponent}`)
       return new Replay(this.container, event.init, event.shots)
     }
     return new PlaceBall(this.container)

--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -47,9 +47,6 @@ export class Spectate extends ControllerBase {
   }
 
   private sniffNames(event: GameEvent) {
-    if (!Session.hasInstance()) {
-      return
-    }
     const session = Session.getInstance()
 
     let changed = false

--- a/src/events/recorder.ts
+++ b/src/events/recorder.ts
@@ -61,10 +61,7 @@ export class Recorder {
     return last
   }
 
-  getPlayerNames(): { player1: string; player2: string } | undefined {
-    if (!Session.hasInstance()) {
-      return undefined
-    }
+  getPlayerNames(): { player1: string; player2: string } {
     const orderedNames = Session.getInstance().orderedNamesForHud()
     return {
       player1: orderedNames.p1Name || "Player",

--- a/src/network/bot/logger.ts
+++ b/src/network/bot/logger.ts
@@ -20,8 +20,7 @@ export class Logger {
     this.logElement = id("botDebugLog") as HTMLPreElement
     this.hide()
 
-    const botMode = Session.hasInstance() && Session.isBotMode()
-    if (botMode) {
+    if (Session.isBotMode()) {
       this.info("Bot mode activated")
     }
 

--- a/src/network/client/matchresult.ts
+++ b/src/network/client/matchresult.ts
@@ -28,13 +28,13 @@ export class MatchResultHelper {
     container.eventQueue.push(new ChatEvent(null, "game over"))
     container.recorder.wholeGameLink()
 
-    const session = Session.hasInstance() ? Session.getInstance() : null
+    const session = Session.getInstance()
     const amIWinner = this.determineWinner(container, session, forcedAmIWinner)
     const subtext = endSubtext ?? this.getScoreSubtext(container)
 
     this.updateRematchInfo(container, session, rulename, amIWinner)
 
-    const hasRematch = !!session?.rematchInfo
+    const hasRematch = !!session.rematchInfo
 
     this.notifyEndState(container, amIWinner, subtext, hasRematch)
 
@@ -50,7 +50,7 @@ export class MatchResultHelper {
 
   private static determineWinner(
     container: Container,
-    session: Session | null,
+    session: Session,
     forcedAmIWinner?: boolean
   ): boolean {
     if (forcedAmIWinner !== undefined) {
@@ -59,17 +59,16 @@ export class MatchResultHelper {
 
     const { p1, p2 } = container.getOrderedScores()
     const winnerIndex = p1 >= p2 ? 0 : 1
-    const playerIndex = session?.playerIndex ?? 0
+    const playerIndex = session.playerIndex
     return winnerIndex === playerIndex
   }
 
   private static updateRematchInfo(
     container: Container,
-    session: Session | null,
+    session: Session,
     rulename: string,
     amIWinner: boolean
   ): void {
-    if (!session) return
     Rematch.update(session, rulename, amIWinner, container.isSinglePlayer)
   }
 
@@ -96,7 +95,7 @@ export class MatchResultHelper {
   }
 
   static isWinner(result: MatchResult): boolean {
-    return result.winner === Session.getInstance()?.playername
+    return result.winner === Session.getInstance().playername
   }
 
   private static notifyWin(
@@ -190,17 +189,17 @@ export class MatchResultHelper {
   private static createMatchResult(
     container: Container,
     rulename: string,
-    session: Session | null,
+    session: Session,
     iWon: boolean
   ): MatchResult {
     const myScore = container.getMyScore()
     const opponentScore = container.getOpponentScore()
     const winnerName = iWon
-      ? session?.playername || "Anon"
-      : session?.opponentName || "Opponent"
+      ? session.playername || "Anon"
+      : session.opponentName || "Opponent"
     const loserName = iWon
-      ? session?.opponentName || "Opponent"
-      : session?.playername || "Anon"
+      ? session.opponentName || "Opponent"
+      : session.playername || "Anon"
     const winnerScore = iWon ? myScore : opponentScore
     const loserScore = iWon ? opponentScore : myScore
 
@@ -210,7 +209,7 @@ export class MatchResultHelper {
       ruleType: rulename,
     }
 
-    if (session?.opponentName) {
+    if (session.opponentName) {
       result.loser = loserName
       result.loserScore = loserScore
     }

--- a/src/network/client/rematch.ts
+++ b/src/network/client/rematch.ts
@@ -27,7 +27,7 @@ export class Rematch {
     amIWinner: boolean,
     isSinglePlayer: boolean
   ) {
-    if (!session?.clientId) return
+    if (!session.clientId) return
     if (isSinglePlayer || session.botMode) return
 
     const opponentId = session.opponentClientId || "opponent"

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -27,20 +27,17 @@ export class Session {
     return Session.instance
   }
 
-  static hasInstance(): boolean {
-    return Session.instance !== undefined
-  }
 
   static playerIndex(): number {
-    return Session.instance ? Session.instance.playerIndex : 0
+    return Session.getInstance().playerIndex
   }
 
   static isSpectator(): boolean {
-    return Session.instance !== undefined && Session.getInstance().spectator
+    return Session.getInstance().spectator
   }
 
   static isBotMode(): boolean {
-    return Session.instance !== undefined && Session.getInstance().botMode
+    return Session.getInstance().botMode
   }
 
   static reset() {

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -144,10 +144,8 @@ export class LobbyIndicator {
     url.searchParams.set("opponentName", this.challenger.userName)
 
     const session = Session.getInstance()
-    if (session) {
-      url.searchParams.set("userName", session.playername)
-      url.searchParams.set("userId", session.clientId)
-    }
+    url.searchParams.set("userName", session.playername)
+    url.searchParams.set("userId", session.clientId)
 
     return url.toString()
   }

--- a/src/view/notification.ts
+++ b/src/view/notification.ts
@@ -153,16 +153,10 @@ export class Notification {
         globalThis.location.reload()
         break
       case "rematch":
-        if (Session.hasInstance()) {
-          Rematch.navigate(Session.getInstance())
-        }
+        Rematch.navigate(Session.getInstance())
         break
       case "lobby":
-        if (Session.hasInstance()) {
-          Rematch.redirectToLobby(undefined, Session.getInstance())
-        } else {
-          Rematch.redirectToLobby()
-        }
+        Rematch.redirectToLobby(undefined, Session.getInstance())
         break
     }
   }

--- a/test/rules/snooker.spec.ts
+++ b/test/rules/snooker.spec.ts
@@ -43,6 +43,7 @@ describe("Snooker", () => {
 
   beforeEach(function (done) {
     Ball.id = 0
+    Session.init("1", "Player A", "table", false)
     container = new Container({
       element: undefined,
       log: (_) => {},
@@ -117,9 +118,9 @@ describe("Snooker", () => {
     setupTableWithPot(table.balls[7])
     playShotWaitForOutcome()
 
-    const { p1, p2 } = container.getOrderedScores()
-    expect(p1).to.be.equal(1)
-    expect(p2).to.be.equal(0)
+    const orderedScores = container.getOrderedScores()
+    expect(orderedScores.p1).to.be.equal(1)
+    expect(orderedScores.p2).to.be.equal(0)
     done()
   })
 
@@ -371,6 +372,10 @@ describe("Snooker", () => {
     expect(snooker.targetIsRed).to.be.true
     expect(broadcastEvents).to.be.length(3)
     done()
+  })
+
+  afterEach(() => {
+    Session.reset()
   })
 
   it("should trigger foul notification when white potted", () => {

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -13,6 +13,7 @@ describe("AimInput", () => {
   let aiminputs: AimInputs
 
   beforeEach(function (done) {
+    initDom()
     container = new Container({
       element: canvas3d,
       log: (_) => {},

--- a/test/view/dom.ts
+++ b/test/view/dom.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs"
 import path from "node:path"
+import { Session } from "../../src/network/client/session"
 jest.dontMock("fs")
 
 const html = fs.readFileSync(
@@ -9,6 +10,7 @@ const html = fs.readFileSync(
 
 export function initDom() {
   document.body.innerHTML = html
+  Session.init("test-client", "TestPlayer", "test-table", false)
 }
 
 export const canvas3d = document.getElementById("viewP1") as HTMLCanvasElement


### PR DESCRIPTION
This PR enables the presence system (online users count and challenges) for bot and replay modes, which were previously excluded. It also performs a comprehensive refactoring of session management across the application. Since the `Session` is guaranteed to be initialized at startup, all redundant `hasInstance()` checks, optional chaining on the session object, and nullable session types have been removed to reduce code clutter and improve maintainability. Unit tests have been updated to reflect these architectural guarantees.

---
*PR created automatically by Jules for task [6395625655809941329](https://jules.google.com/task/6395625655809941329) started by @tailuge*