### PR TITLE
Optimize ball material shader performance

### DIFF
--- a/src/view/ballmaterialfactory.ts
+++ b/src/view/ballmaterialfactory.ts
@@ -50,38 +50,32 @@ export class BallMaterialFactory {
 
     material.onBeforeCompile = (shader: any) => {
       shader.uniforms.numberTex = { value: numberTexture }
-      shader.uniforms.projSize = { value: 2 }
+      shader.uniforms.invScale = { value: 1 / (R * 2) }
 
       shader.vertexShader = shader.vertexShader.replace(
         "#include <common>",
         `#include <common>
-         varying vec3 vLocalPosition;
-         varying vec3 vNormalVar;`
+         varying vec3 vLocalPosition;`
       )
       shader.vertexShader = shader.vertexShader.replace(
         "#include <begin_vertex>",
         `#include <begin_vertex>
-         vLocalPosition = position;
-         vNormalVar = normal;`
+         vLocalPosition = position;`
       )
 
       shader.fragmentShader = shader.fragmentShader.replace(
         "#include <common>",
         `#include <common>
         uniform sampler2D numberTex;
-        uniform float projSize;
-        varying vec3 vLocalPosition;
-        varying vec3 vNormalVar;`
+        uniform float invScale;
+        varying vec3 vLocalPosition;`
       )
 
       shader.fragmentShader = shader.fragmentShader.replace(
         "#include <color_fragment>",
         `#include <color_fragment>
-         float r = ${R.toFixed(3)};
-         vec3 locPos = vLocalPosition;
-
          // planar projection
-         vec2 projUv = locPos.xz / (r * projSize) + 0.5;
+         vec2 projUv = vLocalPosition.xz * invScale + 0.5;
          projUv = clamp(projUv, 0.0, 1.0);
 
          // sample & blend

--- a/test/view/ballmaterialfactory.spec.ts
+++ b/test/view/ballmaterialfactory.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai"
+import { Color, MeshStandardMaterial } from "three"
+import { BallMaterialFactory } from "../../src/view/ballmaterialfactory"
+import { R } from "../../src/model/physics/constants"
+
+describe("BallMaterialFactory", () => {
+  it("creates a projected material with correct uniforms", () => {
+    const color = new Color(0xff0000)
+    const label = 8
+    const material = BallMaterialFactory.createProjectedMaterial(label, color) as MeshStandardMaterial
+
+    expect(material).to.be.an.instanceOf(MeshStandardMaterial)
+    expect(material.color.getHex()).to.equal(color.getHex())
+
+    // Mock shader object for onBeforeCompile
+    const shader = {
+      uniforms: {} as any,
+      vertexShader: "#include <common>\n#include <begin_vertex>",
+      fragmentShader: "#include <common>\n#include <color_fragment>"
+    }
+
+    if (material.onBeforeCompile) {
+      material.onBeforeCompile(shader)
+    }
+
+    expect(shader.uniforms.numberTex).to.exist
+    expect(shader.uniforms.invScale.value).to.equal(1 / (R * 2))
+
+    expect(shader.vertexShader).to.contain("varying vec3 vLocalPosition;")
+    expect(shader.vertexShader).to.not.contain("varying vec3 vNormalVar;")
+
+    expect(shader.fragmentShader).to.contain("uniform float invScale;")
+    expect(shader.fragmentShader).to.contain("vLocalPosition.xz * invScale + 0.5")
+    expect(shader.fragmentShader).to.not.contain("float r =")
+  })
+
+  it("caches materials", () => {
+    const color = new Color(0x00ff00)
+    const label = 9
+    const mat1 = BallMaterialFactory.createProjectedMaterial(label, color)
+    const mat2 = BallMaterialFactory.createProjectedMaterial(label, color)
+    expect(mat1).to.equal(mat2)
+  })
+})


### PR DESCRIPTION
This change optimizes the projected ball material shader in `src/view/ballmaterialfactory.ts`. It reduces GPU arithmetic by moving a division to a pre-calculated uniform (`invScale`) on the CPU. It also reduces data bandwidth and interpolation overhead by removing the unused `vNormalVar` varying. Code cleanup was performed by removing redundant local assignments in the fragment shader. All tests passed and visual verification confirmed correct rendering.

---
*PR created automatically by Jules for task [4439018576904011392](https://jules.google.com/task/4439018576904011392) started by @tailuge*