### PR TITLE
Remove "lowp" precision from ball materials

### DIFF
--- a/src/view/ballmaterialfactory.ts
+++ b/src/view/ballmaterialfactory.ts
@@ -23,7 +23,6 @@ export class BallMaterialFactory {
       specular: 0x555533,
       transparent: false,
       depthWrite: true,
-      precision: "lowp",
     })
     this.materialCache.set(key, material)
     return material
@@ -53,7 +52,6 @@ export class BallMaterialFactory {
       flatShading: true,
       transparent: false,
       depthWrite: true,
-      precision: "lowp",
     })
 
     material.onBeforeCompile = (shader: any) => {


### PR DESCRIPTION
Removed the explicit "lowp" precision setting from both dotted and projected ball materials in the BallMaterialFactory to revert to default precision.

---
*PR created automatically by Jules for task [4041985554734696716](https://jules.google.com/task/4041985554734696716) started by @tailuge*