### PR TITLE
Add image-rendering: pixelated and crisp-edges to canvas

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -337,6 +337,8 @@ p {
 }
 
 canvas {
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
   border-radius: 5px;
   -webkit-user-select: none;
   -ms-user-select: none;

--- a/src/utils/webgl.ts
+++ b/src/utils/webgl.ts
@@ -6,7 +6,7 @@ export function renderer(element: HTMLElement) {
   }
 
   const renderer = new WebGLRenderer({
-    antialias: false
+    antialias: false,
   })
   renderer.shadowMap.enabled = false
   renderer.autoClear = false


### PR DESCRIPTION
This change adds `image-rendering: pixelated;` and `image-rendering: crisp-edges;` to the global `canvas` selector in `dist/index.css`. This improves the visual quality of the game when scaled by ensuring that the browser uses a nearest-neighbor (or similar) interpolation method instead of bilinear filtering, which can make the game look blurry. 

I've verified the change through:
1. Visual inspection using a Playwright script that confirmed the computed style on the canvas.
2. Running the full test suite (`yarn test`) to ensure no regressions.
3. Formatting the file with the project's Prettier configuration (`yarn prettify`).

Although `dist/index.css` is in the `dist` directory, it is treated as a source file in this repository as there is no corresponding CSS source in `src` and the build process does not generate it.

---
*PR created automatically by Jules for task [1753713545501960704](https://jules.google.com/task/1753713545501960704) started by @tailuge*