### PR TITLE
Add alpha 0.25 shadow polygon beneath the cue

### DIFF
--- a/src/model/table.ts
+++ b/src/model/table.ts
@@ -199,6 +199,7 @@ export class Table {
     scene.add(this.cue.mesh)
     scene.add(this.cue.helperMesh)
     scene.add(this.cue.placerMesh)
+    scene.add(this.cue.shadowMesh)
   }
 
   showTraces(bool) {

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -15,6 +15,7 @@ export class Cue {
   mesh: Object3D
   helperMesh: Mesh
   placerMesh: Mesh
+  shadowMesh: Mesh
   readonly offCenterLimit = 0.3
   readonly maxPower = 160 * R
   t = 0
@@ -35,6 +36,7 @@ export class Cue {
     )
     this.helperMesh = CueMesh.createHelper()
     this.placerMesh = CueMesh.createPlacer()
+    this.shadowMesh = CueMesh.createShadow(this.length)
   }
 
   rotateAim(angle, table: Table) {
@@ -44,6 +46,7 @@ export class Cue {
     this.aim.angle = Math.fround(this.aim.angle + angle)
     this.mesh.rotation.z = this.aim.angle
     this.helperMesh.rotation.z = this.aim.angle
+    this.shadowMesh.rotation.z = this.aim.angle
     this.aimInputs.showOverlap()
     this.avoidCueTouchingOtherBall(table)
   }
@@ -127,6 +130,7 @@ export class Cue {
     this.aim.pos.copy(pos)
     this.mesh.rotation.z = this.aim.angle
     this.helperMesh.rotation.z = this.aim.angle
+    this.shadowMesh.rotation.z = this.aim.angle
     const offset = this.spinOffset()
     const swing =
       (sin(this.t + Math.PI / 2) - 1) * 2 * R * (this.aim.power / this.maxPower)
@@ -135,6 +139,14 @@ export class Cue {
       this.tempVec
     ).multiplyScalar(swing)
     this.mesh.position.copy(pos).add(offset).add(distanceToBall)
+
+    const horizontalOffset = this.tempVec2.set(offset.x, offset.y, 0)
+    this.shadowMesh.position
+      .copy(pos)
+      .add(horizontalOffset)
+      .add(distanceToBall)
+    this.shadowMesh.position.z = -R * 0.99
+
     this.helperMesh.position.copy(pos)
     this.placerMesh.position.copy(pos)
     this.placerMesh.rotation.z = this.t
@@ -147,12 +159,14 @@ export class Cue {
 
   placeBallMode() {
     this.mesh.visible = false
+    this.shadowMesh.visible = false
     this.placerMesh.visible = true
     this.aim.angle = 0
   }
 
   aimMode() {
     this.mesh.visible = true
+    this.shadowMesh.visible = true
     this.placerMesh.visible = false
   }
 

--- a/src/view/cuemesh.ts
+++ b/src/view/cuemesh.ts
@@ -8,6 +8,8 @@ import {
   Vector3,
   ShaderMaterial,
   Group,
+  PlaneGeometry,
+  MeshBasicMaterial,
 } from "three"
 
 export class CueMesh {
@@ -82,6 +84,22 @@ export class CueMesh {
         new Matrix4().identity().makeTranslation(0, 0, (R * 0.7) / 0.5)
       )
     mesh.visible = false
+    return mesh
+  }
+
+  static createShadow(length: number) {
+    const geometry = new PlaneGeometry(length, R * 0.4)
+    geometry.applyMatrix4(
+      new Matrix4().identity().makeTranslation(-length / 2 - R, 0, 0)
+    )
+    const material = new MeshBasicMaterial({
+      color: 0x000000,
+      opacity: 0.25,
+      transparent: true,
+      depthWrite: false,
+    })
+    const mesh = new Mesh(geometry, material)
+    mesh.visible = true
     return mesh
   }
 


### PR DESCRIPTION
Implemented a semi-transparent rectangular shadow (alpha 0.25) for the cue stick that accurately follows its position, rotation, and stroke translation at table level. This enhancement improves the visual depth and placement of the cue in the 3D environment.

---
*PR created automatically by Jules for task [11388720315456407911](https://jules.google.com/task/11388720315456407911) started by @tailuge*