### PR TITLE
Refactor controller name checks to use instanceof

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -31,7 +31,13 @@ import { ScoreEvent } from "../events/scoreevent"
 import { ContainerConfig } from "./containerconfig"
 import { Controller } from "../controller/controller"
 import { ParticleSystem } from "../view/particle-system"
-//import { End } from "../controller/end"
+import { End } from "../controller/end"
+import { Replay } from "../controller/replay"
+import { Aim } from "../controller/aim"
+import { PlaceBall } from "../controller/placeball"
+import { PlayShot } from "../controller/playshot"
+import { WatchAim } from "../controller/watchaim"
+import { WatchShot } from "../controller/watchshot"
 
 type ActivePlayer = 0 | 1 | 2
 
@@ -144,18 +150,18 @@ export class Container {
     return this.myHudSlot() === 1 ? 2 : 1
   }
 
-  inferActivePlayerFromControllerName(name: string): ActivePlayer {
-    if (name === "Aim" || name === "PlaceBall" || name === "PlayShot") {
+  inferActivePlayer(controller: Controller = this.controller): ActivePlayer {
+    if (
+      controller instanceof Aim ||
+      controller instanceof PlaceBall ||
+      controller instanceof PlayShot
+    ) {
       return this.myHudSlot()
     }
-    if (name === "WatchAim" || name === "WatchShot") {
+    if (controller instanceof WatchAim || controller instanceof WatchShot) {
       return this.opponentHudSlot()
     }
     return 0
-  }
-
-  inferActivePlayerFromController(controller = this.controller): ActivePlayer {
-    return this.inferActivePlayerFromControllerName(controller?.name ?? "")
   }
 
   setHudActivePlayer(active: ActivePlayer) {
@@ -176,11 +182,11 @@ export class Container {
       orderedNames.p2Name,
       b
     )
-    this.setHudActivePlayer(active ?? this.inferActivePlayerFromController())
+    this.setHudActivePlayer(active ?? this.inferActivePlayer())
   }
 
   sendScoreUpdate(p1: number, p2: number, b: number, active?: ActivePlayer) {
-    const activePlayer = active ?? this.inferActivePlayerFromController()
+    const activePlayer = active ?? this.inferActivePlayer()
     const changed =
       this.hudScores.p1 !== p1 ||
       this.hudScores.p2 !== p2 ||
@@ -266,23 +272,22 @@ export class Container {
     })
   }
 
-  updateController(controller) {
-    this.wasReplay = this.wasReplay || controller.name === "Replay"
+  updateController(controller: Controller) {
+    this.wasReplay = this.wasReplay || controller instanceof Replay
     if (controller !== this.controller) {
       const playerName = Session.getInstance().playername
       this.log(`${playerName}: Transition to ${controller.name}`)
       this.controller = controller
-      const active = this.inferActivePlayerFromController(controller)
+      const active = this.inferActivePlayer(controller)
       if (
         active !== 0 ||
-        controller.name === "Init" ||
-        controller.name === "End"
+        controller instanceof Init ||
+        controller instanceof End
       ) {
         this.setHudActivePlayer(active)
       }
       this.menu?.setShareVisible(
-        controller.name === "Replay" ||
-          (this.wasReplay && controller.name === "End")
+        controller instanceof Replay || (this.wasReplay && controller instanceof End)
       )
       this.menu?.setConcedeVisible(!this.isSinglePlayer && !this.replayMode)
       this.controller.onFirst()

--- a/src/controller/playshot.ts
+++ b/src/controller/playshot.ts
@@ -22,9 +22,7 @@ export class PlayShot extends ControllerBase {
     const { p1: s1, p2: s2 } = Session.getInstance().orderedScoresForHud()
 
     const b = this.container.rules.currentBreak
-    const active = this.container.inferActivePlayerFromControllerName(
-      nextController.name
-    )
+    const active = this.container.inferActivePlayer(nextController)
     this.container.sendScoreUpdate(s1, s2, b, active)
 
     const isPartOfBreak = this.container.rules.isPartOfBreak(outcome)

--- a/src/network/bot/eventhandler.ts
+++ b/src/network/bot/eventhandler.ts
@@ -129,7 +129,7 @@ export class BotEventHandler {
       Session.getInstance().addOpponentScore(pots)
       const { p1: s1, p2: s2 } = Session.getInstance().orderedScoresForHud()
 
-      const active = this.container.inferActivePlayerFromController()
+      const active = this.container.inferActivePlayer()
       this.container.sendScoreUpdate(s1, s2, 0, active)
 
       // pot success, send watch event to other player


### PR DESCRIPTION
The refactoring improves type safety and maintainability by moving away from string-based type checks for controller states. The logic in `Container` for managing HUD updates and UI visibility now directly uses the controller class types. Build and tests were verified to ensure no circular dependency issues or regressions were introduced.

---
*PR created automatically by Jules for task [11658346439729761989](https://jules.google.com/task/11658346439729761989) started by @tailuge*