### PR TITLE
Prevent artifact upload during PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
         run: rm -rf coverage dist/models/*.blend dist/models/d-snooker.gltf dist/models/p8.gltf dist/models/snooker.gltf dist/models/d-snooker.bin dist/models/p8.bin dist/models/snooker.bin
 
       - name: upload build artifact
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: dist-artifact
@@ -98,6 +99,7 @@ jobs:
           du -a * | sort -n
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v4
         with:
           path: "./"


### PR DESCRIPTION
This change adds `if: github.ref == 'refs/heads/master' && github.event_name == 'push'` to all artifact upload steps in the `.github/workflows/main.yml` file. This ensures that artifacts are only uploaded when a push is made to the master branch, effectively disabling artifact uploads for pull requests.

---
*PR created automatically by Jules for task [14208665817746267323](https://jules.google.com/task/14208665817746267323) started by @tailuge*