### PR TITLE
Update desync threshold and refactor check

### DIFF
--- a/src/utils/desync-tripwire.ts
+++ b/src/utils/desync-tripwire.ts
@@ -1,6 +1,6 @@
 import { VERSION } from "./version"
 
-const DESYNC_THRESHOLD = 1e-12
+const DESYNC_THRESHOLD = 1e-9
 
 export function checkDesyncTripwire(
   label: string,
@@ -8,7 +8,7 @@ export function checkDesyncTripwire(
   localStateCheck: number[],
   extra: Record<string, unknown> = {}
 ) {
-  if (!remoteStateCheck || remoteStateCheck.length !== localStateCheck.length) {
+  if (remoteStateCheck?.length !== localStateCheck.length) {
     return
   }
 


### PR DESCRIPTION
Updated `DESYNC_THRESHOLD` from `1e-12` to `1e-9` in `src/utils/desync-tripwire.ts`.
Refactored the initial check in `checkDesyncTripwire` to use optional chaining: `remoteStateCheck?.length !== localStateCheck.length`.

---
*PR created automatically by Jules for task [8664709101622095185](https://jules.google.com/task/8664709101622095185) started by @tailuge*