### PR TITLE
Synchronize aim UI on HitEvent and allow 0 power

### DIFF
--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -84,6 +84,7 @@ export class Spectate extends ControllerBase {
   override handleHit(event: HitEvent) {
     console.log("Spectate Hit")
     this.container.table.updateFromSerialised(event.tablejson)
+    this.container.table.cue.updateAimInput()
     this.container.table.outcome = []
     this.container.table.hit()
     return this

--- a/src/view/aiminputs.ts
+++ b/src/view/aiminputs.ts
@@ -157,9 +157,9 @@ export class AimInputs {
   }
 
   updatePowerSlider(power) {
-    power > 0 &&
-      this.cuePowerElement?.value &&
-      (this.cuePowerElement.value = power)
+    if (this.cuePowerElement) {
+      this.cuePowerElement.value = power
+    }
   }
 
   hit = (_) => {

--- a/test/controller/spectate.spec.ts
+++ b/test/controller/spectate.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai"
+import { HitEvent } from "../../src/controller/controller"
 import { Container } from "../../src/container/container"
 import { Ball, State } from "../../src/model/ball"
 import { Spectate } from "../../src/controller/spectate"
@@ -64,5 +65,37 @@ describe("Spectate Controller", () => {
     const result = spectate.handlePlaceBall(event)
 
     expect(result).to.equal(spectate)
+  })
+
+  it("handleHit should update aim input UI", () => {
+    const messageRelay: MessageRelay = {
+      subscribe: () => {},
+      publish: () => {},
+      getOnlineCount: () => Promise.resolve(null),
+    }
+    const spectate = new Spectate(container, messageRelay, "test-table")
+    const powerSpy = jest.spyOn(
+      container.table.cue.aimInputs,
+      "updatePowerSlider"
+    )
+    const visualSpy = jest.spyOn(
+      container.table.cue.aimInputs,
+      "updateVisualState"
+    )
+
+    const tablejson = container.table.serialise()
+    tablejson.aim.offset.x = 0.05
+    tablejson.aim.offset.y = -0.2
+    tablejson.aim.power = container.table.cue.maxPower * 0.25
+
+    spectate.handleHit(new HitEvent(tablejson))
+
+    expect(powerSpy.mock.calls).to.not.be.empty
+    expect(visualSpy.mock.calls).to.not.be.empty
+    const powerArgs = powerSpy.mock.calls[powerSpy.mock.calls.length - 1]
+    const visualArgs = visualSpy.mock.calls[visualSpy.mock.calls.length - 1]
+    expect(powerArgs[0]).to.be.approximately(0.25, 0.0001)
+    expect(visualArgs[0]).to.be.approximately(0.05, 0.0001)
+    expect(visualArgs[1]).to.be.approximately(-0.2, 0.0001)
   })
 })


### PR DESCRIPTION
This change ensures that spectators and remote players see the final aim, power, and spin parameters on their UI when a shot is taken. Previously, the `Spectate` controller missed the UI update call in `handleHit`. Additionally, the power slider now correctly reflects a value of 0 by removing an unnecessary guard in `AimInputs`.

---
*PR created automatically by Jules for task [13058438366178762811](https://jules.google.com/task/13058438366178762811) started by @tailuge*