### PR TITLE
Fix maintainability code smells in desync-tripwire and tests

### DIFF
--- a/src/utils/desync-tripwire.ts
+++ b/src/utils/desync-tripwire.ts
@@ -20,7 +20,7 @@ export function statesDiffer(
   remoteStateCheck: number[] | undefined,
   localStateCheck: number[]
 ): boolean {
-  if (!remoteStateCheck || remoteStateCheck.length !== localStateCheck.length) {
+  if (remoteStateCheck?.length !== localStateCheck.length) {
     return true
   }
 

--- a/test/network/client/nchanmessagerelay.spec.ts
+++ b/test/network/client/nchanmessagerelay.spec.ts
@@ -91,7 +91,7 @@ describe("NchanMessageRelay", () => {
         onclose: jest.fn(),
         close: jest.fn(),
       }))
-      globalThis.WebSocket = mockWS as any
+      globalThis.WebSocket = mockWS
       jest.useFakeTimers()
     })
 


### PR DESCRIPTION
This PR addresses two maintainability issues:
1. Simplifies the `statesDiffer` function in `src/utils/desync-tripwire.ts` by replacing an explicit null/undefined check with an optional chaining expression.
2. Cleans up a redundant type assertion in `test/network/client/nchanmessagerelay.spec.ts` where a variable already typed as `any` was being cast to `any`.

Verification:
- Ran the full test suite using `yarn jest -c test/jest.config.js`. All 59 test suites (412 tests) passed.
- Logic in `statesDiffer` was confirmed to be equivalent: if `remoteStateCheck` is undefined, `remoteStateCheck?.length` is `undefined`, and `undefined !== localStateCheck.length` (where length is a number) correctly returns `true`.

---
*PR created automatically by Jules for task [5432675365052078707](https://jules.google.com/task/5432675365052078707) started by @tailuge*