### PR TITLE
Coordinate UI Overlay Styles

### DIFF
--- a/dist/index.css
+++ b/dist/index.css
@@ -523,15 +523,17 @@ input[type="range"].powerSlider {
 
 a.pill {
   outline: none;
-  background: linear-gradient(#888686, #b0b0b3);
-  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 8px;
   text-decoration: none;
-  border-color: white;
-  border-width: 1px;
-  margin: 1px;
-  padding: 1px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  margin: 0;
+  padding: 0 8px;
   font-size: smaller;
-  border-top-style: groove;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
 }
 
 a {
@@ -567,8 +569,8 @@ label {
   left: 10px;
   width: 320px;
   max-height: 400px;
-  background: rgba(0, 0, 0, 0.6);
-  border: 1px solid #444;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: 8px;
   padding: 10px;
   font-family: "Consolas", "Monaco", monospace;
@@ -583,9 +585,9 @@ label {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid #444;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 #botDebugOverlay header button {
@@ -634,6 +636,11 @@ label {
 /* Compact mode */
 #botDebugOverlay.compact {
   width: 50px;
+  height: 30px;
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
 }
 
 #botDebugOverlay.compact #botDebugLog {

--- a/dist/tray.css
+++ b/dist/tray.css
@@ -9,7 +9,7 @@
   display: flex;
   align-items: center;
   background: rgba(0, 0, 0, 0.4);
-  border-radius: 15px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.15);
   z-index: 1500;
   overflow: hidden;


### PR DESCRIPTION
This change unifies the visual appearance of the top-level UI components: the Lobby Indicator, the Ball Tray, and the Bot Debug Overlay. 

Key modifications:
1. **Visual Style**: All three components now use the Ball Tray's `rgba(0, 0, 0, 0.4)` background and `1px solid rgba(255, 255, 255, 0.15)` border.
2. **Dimensions**: Established a consistent 30px height across the "top bar" elements. The Bot Debug Overlay specifically adheres to this height when in its `.compact` (collapsed) state.
3. **Geometry**: Standardized corner radii to 8px (reducing the Ball Tray's radius and increasing the Lobby Indicator's radius).
4. **Alignment**: Implemented flexbox centering on the Lobby Indicator (`a.pill`) and the compact Bot Overlay header to ensure icons and text are perfectly aligned within the 30px height.

Verified via Playwright screenshot and existing test suite.

---
*PR created automatically by Jules for task [9207427368497350599](https://jules.google.com/task/9207427368497350599) started by @tailuge*