### PR TITLE
Add autoskills suggestions to suggest.md

### DIFF
--- a/suggest.md
+++ b/suggest.md
@@ -1,0 +1,29 @@
+
+   ╔═══════════════════════════════════════╗
+   ║   autoskills                 v0.2.4   ║
+   ║   Auto-install the best AI skills     ║
+   ║   for your project                    ║
+   ╚═══════════════════════════════════════╝
+
+   Scanning project...[K   ◆ Detected technologies:
+
+     ✔ TypeScript   ✔ Three.js     ✔ Node.js
+
+   ◆ Skills to install (13)
+
+    1. wshobson › typescript-advanced-types  ← TypeScript
+    2. cloudai-x › threejs-animation         ← Three.js
+    3. cloudai-x › threejs-fundamentals      ← Three.js
+    4. cloudai-x › threejs-shaders           ← Three.js
+    5. cloudai-x › threejs-geometry          ← Three.js
+    6. cloudai-x › threejs-interaction       ← Three.js
+    7. cloudai-x › threejs-materials         ← Three.js
+    8. cloudai-x › threejs-postprocessing    ← Three.js
+    9. cloudai-x › threejs-lighting          ← Three.js
+   10. cloudai-x › threejs-textures          ← Three.js
+   11. cloudai-x › threejs-loaders           ← Three.js
+   12. wshobson › nodejs-backend-patterns    ← Node.js
+   13. sickn33 › nodejs-best-practices       ← Node.js
+
+   Agents: universal
+   --dry-run: nothing was installed.


### PR DESCRIPTION
I have run `npx autoskills --dry-run` to identify the best AI skills for this project. The output, which includes 13 suggested skills related to TypeScript, Three.js, and Node.js, has been saved to a new file named `suggest.md`. I also verified that the environment is healthy by running the full test suite (411 tests passed).

---
*PR created automatically by Jules for task [3953992446867076994](https://jules.google.com/task/3953992446867076994) started by @tailuge*