### PR TITLE
Snooker Cue Vertical Power Slider

### DIFF
--- a/dist/aiminputs.css
+++ b/dist/aiminputs.css
@@ -7,7 +7,7 @@
   grid-template-areas:
     "ball power"
     "hit power";
-  grid-template-columns: 100px 32px;
+  grid-template-columns: 100px 60px;
   gap: 8px;
   pointer-events: auto;
   width: auto;
@@ -71,73 +71,6 @@
   z-index: 10;
   position: relative;
   pointer-events: none;
-}
-
-.powerSlider {
-  grid-area: power;
-  width: 32px;
-  height: 100%;
-  margin: 0;
-}
-
-input[type="range"].powerSlider.is-disabled,
-input[type="range"].powerSlider:disabled {
-  opacity: 0.5;
-  filter: saturate(0.2) brightness(0.85);
-}
-
-input[type="range"].powerSlider {
-  appearance: none;
-  -webkit-appearance: none;
-  writing-mode: vertical-lr;
-  direction: rtl;
-  background: transparent;
-  cursor: pointer;
-}
-
-input[type="range"].powerSlider::-webkit-slider-runnable-track {
-  width: 24px;
-  background: linear-gradient(180deg, #6d6d6d, #4b4b4b);
-  border: 1px solid #1e1e1e;
-  border-radius: 999px;
-  height: 100%;
-}
-
-input[type="range"].powerSlider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 22px;
-  height: 22px;
-  margin-left: -1px;
-  background: linear-gradient(180deg, #f5f5f5, #bdbdbd);
-  border: 1px solid #2c2c2c;
-  border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-}
-
-input[type="range"].powerSlider::-moz-range-track {
-  width: 24px;
-  background: linear-gradient(180deg, #6d6d6d, #4b4b4b);
-  border: 1px solid #1e1e1e;
-  border-radius: 999px;
-  height: 100%;
-}
-
-input[type="range"].powerSlider::-moz-range-progress {
-  width: 24px;
-  background: linear-gradient(180deg, #007bff, #0056b3);
-  border: 1px solid #004a99;
-  border-radius: 999px;
-  height: 100%;
-}
-
-input[type="range"].powerSlider::-moz-range-thumb {
-  width: 22px;
-  height: 22px;
-  background: linear-gradient(180deg, #f5f5f5, #bdbdbd);
-  border: 1px solid #2c2c2c;
-  border-radius: 50%;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .hitButton {

--- a/dist/index.html
+++ b/dist/index.html
@@ -66,6 +66,7 @@
     </script>
     <link rel="stylesheet" type="text/css" href="index.css" />
     <link rel="stylesheet" type="text/css" href="aiminputs.css" />
+    <link rel="stylesheet" type="text/css" href="powerinput.css" />
     <link rel="stylesheet" type="text/css" href="notification.css" />
     <link rel="stylesheet" type="text/css" href="tray.css" />
     <link rel="stylesheet" type="text/css" href="chat.css" />
@@ -132,16 +133,18 @@
           <div id="cueTip" class="cueTip"></div>
         </div>
       </div>
-      <input
-        class="powerSlider"
-        type="range"
-        min="0"
-        max="1"
-        step="0.01"
-        value="0.75"
-        id="cuePower"
-        aria-label="power slider"
-      />
+      <div class="powerSliderContainer">
+        <input
+          class="powerSlider"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value="0.75"
+          id="cuePower"
+          aria-label="power slider"
+        />
+      </div>
     </div>
     <div class="outerMenu">
       <button

--- a/dist/powerinput.css
+++ b/dist/powerinput.css
@@ -1,0 +1,106 @@
+.powerSliderContainer {
+  height: 400px;
+  width: 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  grid-area: power;
+}
+
+input[type="range"].powerSlider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 400px;
+  height: 48px;
+  background: transparent;
+  cursor: pointer;
+  transform: rotate(-90deg);
+  transform-origin: center;
+  margin: 0;
+  --progress: 75%;
+  position: absolute;
+}
+
+input[type="range"].powerSlider.is-disabled,
+input[type="range"].powerSlider:disabled {
+  opacity: 0.5;
+  filter: saturate(0.2) brightness(0.85);
+}
+
+/* Track - Webkit (Chrome/Safari) */
+input[type="range"].powerSlider::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 27px;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px solid #111;
+  box-sizing: border-box;
+  background: linear-gradient(
+    to right,
+    #e3c9a6 0%,
+    #d2b48c var(--progress),
+    #2a1e17 var(--progress),
+    #1a110d 100%
+  );
+}
+
+/* Track - Firefox */
+input[type="range"].powerSlider::-moz-range-track {
+  width: 100%;
+  height: 27px;
+  cursor: pointer;
+  border-radius: 4px;
+  border: 1px solid #111;
+  background: #1a110d;
+  box-sizing: border-box;
+}
+
+input[type="range"].powerSlider::-moz-range-progress {
+  background: linear-gradient(to right, #e3c9a6, #d2b48c);
+  height: 27px;
+  border-radius: 4px;
+}
+
+/* THUMB: Cue Tip (25px) */
+input[type="range"].powerSlider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 25px;
+  width: 48px;
+  border-radius: 3px;
+  border: none;
+  margin-top: 0px;
+  background: linear-gradient(
+    to left,
+    #4a90e2 0%,
+    #357abd 12%,
+    #ffffff 12%,
+    #cccccc 30%,
+    #e3c9a6 30%,
+    #d2b48c 100%
+  );
+  box-shadow: 2px 0 6px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+}
+
+input[type="range"].powerSlider::-moz-range-thumb {
+  height: 25px;
+  width: 48px;
+  border-radius: 3px;
+  border: none;
+  background: linear-gradient(
+    to left,
+    #4a90e2 0%,
+    #357abd 12%,
+    #ffffff 12%,
+    #cccccc 30%,
+    #e3c9a6 30%,
+    #d2b48c 100%
+  );
+  box-shadow: 2px 0 6px rgba(0, 0, 0, 0.4);
+  cursor: grab;
+}
+
+input[type="range"].powerSlider:active::-webkit-slider-thumb {
+  cursor: grabbing;
+}

--- a/src/view/aiminputs.ts
+++ b/src/view/aiminputs.ts
@@ -47,6 +47,7 @@ export class AimInputs {
     if (this.cuePowerElement) {
       this.container.table.cue.aim.power =
         Number(this.cuePowerElement.value) * this.container.table.cue.maxPower
+      this.updatePowerProgress()
     }
     this.addListeners()
     if (Session.isSpectator()) {
@@ -60,7 +61,7 @@ export class AimInputs {
       this.adjustSpin(e)
     })
     this.cueHitElement?.addEventListener("click", this.hit)
-    this.cuePowerElement?.addEventListener("change", this.powerChanged)
+    this.cuePowerElement?.addEventListener("input", this.powerChanged)
     if (!("ontouchstart" in globalThis)) {
       id("viewP1")?.addEventListener("dblclick", this.hit)
     }
@@ -185,16 +186,25 @@ export class AimInputs {
     }
   }
 
+  private updatePowerProgress() {
+    if (this.cuePowerElement) {
+      const percent = Number(this.cuePowerElement.value) * 100
+      this.cuePowerElement.style.setProperty("--progress", percent + "%")
+    }
+  }
+
   powerChanged = (_) => {
     if (this.controlsDisabled) {
       return
     }
     this.container.table.cue.setPower(Number(this.cuePowerElement.value))
+    this.updatePowerProgress()
   }
 
   updatePowerSlider(power) {
     if (this.cuePowerElement) {
       this.cuePowerElement.value = power
+      this.updatePowerProgress()
     }
   }
 
@@ -211,9 +221,12 @@ export class AimInputs {
       return
     }
     if (this.cuePowerElement) {
-      this.cuePowerElement.value =
-        Number(this.cuePowerElement.value) - Math.sign(e.deltaY) / 10
+      this.cuePowerElement.value = (
+        Number(this.cuePowerElement.value) -
+        Math.sign(e.deltaY) / 10
+      ).toString()
       this.container.table.cue.setPower(Number(this.cuePowerElement.value))
+      this.updatePowerProgress()
       this.container.lastEventTime = performance.now()
     }
   }

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -33,9 +33,11 @@ describe("AimInput", () => {
 
   it("adjust power", (done) => {
     aiminputs.setDisabled(false)
-    aiminputs.cuePowerElement.value = 1
-    fireEvent.change(aiminputs.cuePowerElement, { target: { value: 1 } })
+    aiminputs.cuePowerElement.value = "1"
+    fireEvent.input(aiminputs.cuePowerElement, { target: { value: "1" } })
     expect(container.table.cue.aim.power).to.be.greaterThan(0)
+    expect(aiminputs.cuePowerElement.style.getPropertyValue("--progress")).to
+      .equal("100%")
     done()
   })
 
@@ -48,8 +50,11 @@ describe("AimInput", () => {
 
   it("mouse wheel updates power", (done) => {
     aiminputs.setDisabled(false)
+    const initialPower = Number(aiminputs.cuePowerElement.value)
     aiminputs.mousewheel({ deltaY: 10 })
-    expect(aiminputs.container.table.cue.aim.power).to.greaterThan(0)
+    expect(Number(aiminputs.cuePowerElement.value)).to.not.equal(initialPower)
+    expect(aiminputs.cuePowerElement.style.getPropertyValue("--progress")).to
+      .not.be.empty
     done()
   })
 


### PR DESCRIPTION
This change replaces the default power slider with a custom-styled vertical snooker cue slider. It includes a wooden shaft, a blue tip, and a ferrule. The slider's track fill (power level) is updated in real-time via a CSS variable. Layout adjustments were made to the aiming area to accommodate the new vertical orientation and dimensions.

---
*PR created automatically by Jules for task [17606792468660579748](https://jules.google.com/task/17606792468660579748) started by @tailuge*