### PR TITLE
Restrict Chat and Concede buttons to 2-player games

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -117,6 +117,7 @@ export class BrowserContainer {
       scoreReporter: scoreReporter,
       replayMode: !!this.replay,
       botMode: this.botMode,
+      isSinglePlayer: !this.wss && !this.botMode && !this.replay,
     }
     return new Container(config)
   }
@@ -131,7 +132,6 @@ export class BrowserContainer {
   private initBotMode(scoreReporter: ScoreReporter) {
     this.container = this.createContainer(scoreReporter)
     this.container.init()
-    this.container.isSinglePlayer = false
     const logs = new Logger()
     this.messageRelay = new BotRelay(logs, this.container)
     this.messageRelay.subscribe(this.tableId, (e) => {
@@ -202,7 +202,6 @@ export class BrowserContainer {
 
   private initGameLoop() {
     if (this.wss) {
-      this.container.isSinglePlayer = false
       this.messageRelay?.subscribe(this.tableId, (e) => {
         this.netEvent(e)
       })

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -108,9 +108,11 @@ export class Container {
       relay = null,
       scoreReporter = null,
       replayMode = false,
+      isSinglePlayer = true,
     } = config
     this.log = log
     this.replayMode = replayMode
+    this.isSinglePlayer = isSinglePlayer
     this.rules = RuleFactory.create(ruletype, this)
     this.table = this.rules.table()
     this.view = new View(element, this.table, assets)
@@ -465,10 +467,13 @@ export class Container {
         controller instanceof Replay ||
           (this.wasReplay && controller instanceof End)
       )
-      this.menu?.setConcedeVisible(!this.isSinglePlayer && !this.replayMode)
-
-      // Update comment button visibility based on player mode
-      this.comment?.updateButtonVisibility()
+      const isTwoPlayer =
+        !this.isSinglePlayer &&
+        !this.replayMode &&
+        !Session.isBotMode() &&
+        !Session.isSpectator()
+      this.menu?.setConcedeVisible(isTwoPlayer)
+      this.comment?.setVisible(isTwoPlayer)
 
       this.controller.onFirst()
     }

--- a/src/container/containerconfig.ts
+++ b/src/container/containerconfig.ts
@@ -13,4 +13,5 @@ export interface ContainerConfig {
   scoreReporter?: ScoreReporter | null
   replayMode?: boolean
   botMode?: boolean
+  isSinglePlayer?: boolean
 }

--- a/src/view/comment.ts
+++ b/src/view/comment.ts
@@ -16,9 +16,6 @@ export class Comment {
       return
     }
 
-    // Initially hide the button, we'll show it only in multiplayer mode
-    this.updateButtonVisibility()
-
     this.button.onclick = (_) => {
       this.toggleMenu()
     }
@@ -34,11 +31,10 @@ export class Comment {
     })
   }
 
-  updateButtonVisibility() {
-    // Show button only in 2-player or bot mode (not single-player/replay)
+  setVisible(visible: boolean) {
     if (this.button) {
-      this.button.hidden =
-        this.container.isSinglePlayer || this.container.replayMode
+      this.button.hidden = !visible
+      this.button.disabled = !visible
     }
   }
 

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -75,9 +75,9 @@ export class Menu {
   }
 
   setConcedeVisible(visible: boolean) {
-    if (!this.concede) {
-      return
+    if (this.concede) {
+      this.concede.hidden = !visible
+      this.concede.disabled = !visible
     }
-    this.concede.hidden = !visible
   }
 }

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -36,8 +36,9 @@ describe("AimInput", () => {
     aiminputs.cuePowerElement.value = "1"
     fireEvent.input(aiminputs.cuePowerElement, { target: { value: "1" } })
     expect(container.table.cue.aim.power).to.be.greaterThan(0)
-    expect(aiminputs.cuePowerElement.style.getPropertyValue("--progress")).to
-      .equal("100%")
+    expect(
+      aiminputs.cuePowerElement.style.getPropertyValue("--progress")
+    ).to.equal("100%")
     done()
   })
 


### PR DESCRIPTION
Restricted the visibility of the "Chat" (🗨) and "Concede" (🏳️) buttons so they only appear during human-vs-human multiplayer matches. They are now correctly hidden in single-player, bot matches, replays, and for spectators. The logic was simplified by centralizing the 2-player check in the main game container's controller transition flow.

---
*PR created automatically by Jules for task [7977745203366018209](https://jules.google.com/task/7977745203366018209) started by @tailuge*