### PR TITLE
Refactor consecutive push calls in recorder tests

### DIFF
--- a/test/events/recorder.spec.ts
+++ b/test/events/recorder.spec.ts
@@ -50,8 +50,10 @@ describe("Recorder", () => {
     const event: HitEvent = new HitEvent(container.table.serialise())
     recorder.record(event)
     const outcome = container.table.outcome
-    outcome.push(Outcome.pot(container.table.balls[1], 1))
-    outcome.push(Outcome.pot(container.table.balls[2], 1))
+    outcome.push(
+      Outcome.pot(container.table.balls[1], 1),
+      Outcome.pot(container.table.balls[2], 1)
+    )
     recorder.updateBreak(
       outcome,
       container.rules.isPartOfBreak(outcome),


### PR DESCRIPTION
Combined two consecutive `outcome.push()` calls into a single call with multiple arguments in `test/events/recorder.spec.ts`. This improves code maintainability and satisfies the linting-like rule mentioned in the task.

---
*PR created automatically by Jules for task [13945326761758769501](https://jules.google.com/task/13945326761758769501) started by @tailuge*