### PR TITLE
Nest score and version inside state in high score URI

### DIFF
--- a/src/view/link-formatter.ts
+++ b/src/view/link-formatter.ts
@@ -19,7 +19,11 @@ export class LinkFormatter {
   getHiScoreUri(state: any, score: number): string {
     const payload = {
       v: 1,
-      state,
+      state: {
+        ...state,
+        v: 1,
+        score,
+      },
       score,
     }
     const compressed = ReplayEncoder.crush(JSON.stringify(payload))

--- a/test/view/link-formatter.spec.ts
+++ b/test/view/link-formatter.spec.ts
@@ -45,4 +45,21 @@ describe("LinkFormatter", () => {
     expect(uri).toContain("hiscore.html")
     expect(uri).toContain("ruletype=")
   })
+
+  it("getHiScoreUri should include score and v at top level and inside state object", () => {
+    const state = { test: 1 }
+    const score = 10
+    const uri = container.linkFormatter.getHiScoreUri(state, score)
+
+    const url = new URL(uri)
+    const compressed = url.searchParams.get("state")!
+    const uncrushed = require("jsoncrush").default.uncrush(compressed)
+    const payload = JSON.parse(uncrushed)
+
+    expect(payload.score).toBe(10)
+    expect(payload.v).toBe(1)
+    expect(payload.state.test).toBe(1)
+    expect(payload.state.score).toBe(10)
+    expect(payload.state.v).toBe(1)
+  })
 })


### PR DESCRIPTION
Reverted the flattening of the high score URI payload and ensured that 'score' and version 'v' are correctly set both at the top level of the payload and within the nested 'state' object, as required by the scoreboard service and replay worker.

---
*PR created automatically by Jules for task [18444905734225811843](https://jules.google.com/task/18444905734225811843) started by @tailuge*