### PR TITLE
Handle Clipboard Permission Errors in Share Function

### DIFF
--- a/src/controller/replay.ts
+++ b/src/controller/replay.ts
@@ -54,8 +54,8 @@ export class Replay extends ControllerBase {
     const shareButton = this.container.menu.share
     if (shareButton) {
       shareButton.onclick = () => {
-        shorten(globalThis.location.href, (url) => {
-          const response = share(url)
+        shorten(globalThis.location.href, async (url) => {
+          const response = await share(url)
           this.container.eventQueue.push(new ChatEvent(null, response))
         })
       }

--- a/src/utils/shorten.ts
+++ b/src/utils/shorten.ts
@@ -39,23 +39,24 @@ export async function share(url) {
     url: url,
   }
   if (navigator.canShare?.(shareData)) {
-    navigator
-      .share(shareData)
-      .then(() => console.log("shared successfully"))
-      .catch((e) => {
-        console.log("Error: " + e)
-      })
+    try {
+      await navigator.share(shareData)
+      console.log("shared successfully")
+    } catch (e) {
+      console.error("Share failed", e)
+    }
     return `link shared`
   }
 
+  const escapedUrl = url.replaceAll('"', "&quot;").replaceAll("'", "&apos;")
   if (navigator.clipboard) {
     try {
       await navigator.clipboard.writeText(url)
-      return `link copied to clipboard <a href="${url}">${url}</a>`
+      return `link copied to clipboard <a href="${escapedUrl}">${escapedUrl}</a>`
     } catch (e) {
       console.warn("Clipboard write failed", e)
     }
   }
 
-  return `link for sharing <a href="${url}">${url}</a>`
+  return `link for sharing <a href="${escapedUrl}">${escapedUrl}</a>`
 }

--- a/src/utils/shorten.ts
+++ b/src/utils/shorten.ts
@@ -32,7 +32,7 @@ export function shorten(url, action) {
     })
 }
 
-export function share(url) {
+export async function share(url) {
   const shareData = {
     title: "Billiards",
     text: `Replay break`,
@@ -47,6 +47,15 @@ export function share(url) {
       })
     return `link shared`
   }
-  navigator.clipboard?.writeText(url)
-  return `link copied to clipboard <a href="${url}">${url}</a>`
+
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(url)
+      return `link copied to clipboard <a href="${url}">${url}</a>`
+    } catch (e) {
+      console.warn("Clipboard write failed", e)
+    }
+  }
+
+  return `link for sharing <a href="${url}">${url}</a>`
 }

--- a/test/controller/replay.spec.ts
+++ b/test/controller/replay.spec.ts
@@ -273,7 +273,7 @@ describe("Controller Replay", () => {
 
   it("onclick share button pushes ChatEvent", async () => {
     global.fetch = jest.fn().mockResolvedValue({
-      json: () => Promise.resolve({ shortUrl: "http://short.url" }),
+      json: () => Promise.resolve({ shortUrl: "https://short.url" }),
     })
     Object.defineProperty(global.window, "navigator", {
       value: {

--- a/test/controller/replay.spec.ts
+++ b/test/controller/replay.spec.ts
@@ -270,4 +270,33 @@ describe("Controller Replay", () => {
     expect(p2.classList.contains("is-active")).to.be.true
     done()
   })
+
+  it("onclick share button pushes ChatEvent", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ shortUrl: "http://short.url" }),
+    })
+    Object.defineProperty(global.window, "navigator", {
+      value: {
+        canShare: () => false,
+        clipboard: {
+          writeText: jest.fn().mockResolvedValue(undefined),
+        },
+      },
+      configurable: true,
+    })
+
+    const shareButton = document.getElementById("share") as HTMLButtonElement
+    // Replay controller is already created in beforeEach, and onFirst is called during transition
+    // But we can call it again to be sure the mock is wired up
+    replayController.onFirst()
+
+    expect(shareButton.onclick).to.exist
+    shareButton.onclick!(new MouseEvent("click") as any)
+
+    // shorten -> fetch -> promise -> callback -> share -> promise -> push
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+
+    const chatEvent = container.eventQueue.find((e) => e.type === "CHAT")
+    expect(chatEvent).to.exist
+  })
 })

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -31,7 +31,6 @@ module.exports = {
     "gltf.ts",
     "webgl.ts",
     "dom.ts",
-    "shorten.ts",
     "assets.ts",
   ],
   coverageReporters: ["text", "json"],

--- a/test/utils/shorten.spec.ts
+++ b/test/utils/shorten.spec.ts
@@ -1,6 +1,6 @@
-import { share } from "../../src/utils/shorten"
+import { share, shorten } from "../../src/utils/shorten"
 
-describe("shorten", () => {
+describe("shorten utils", () => {
   describe("share", () => {
     let originalNavigator: any
 
@@ -17,6 +17,7 @@ describe("shorten", () => {
 
     it("should return 'link shared' if navigator.canShare is true", async () => {
       const url = "https://example.com"
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation()
       const shareMock = jest.fn().mockResolvedValue(undefined)
       Object.defineProperty(global.window, "navigator", {
         value: {
@@ -29,6 +30,11 @@ describe("shorten", () => {
       const result = await share(url)
       expect(result).toBe("link shared")
       expect(shareMock).toHaveBeenCalled()
+
+      // wait for the success block to be executed
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+      expect(consoleSpy).toHaveBeenCalledWith("shared successfully")
+      consoleSpy.mockRestore()
     })
 
     it("should log error if navigator.share fails", async () => {
@@ -46,7 +52,7 @@ describe("shorten", () => {
       const result = await share(url)
       expect(result).toBe("link shared")
       // wait for the catch block to be executed
-      await new Promise((resolve) => setTimeout(resolve, 0))
+      for (let i = 0; i < 5; i++) await Promise.resolve()
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("Error: Error: Share failed")
       )
@@ -102,7 +108,6 @@ describe("shorten", () => {
       expect(result).toBe(`link for sharing <a href="${url}">${url}</a>`)
     })
   })
-})
 
   describe("shorten", () => {
     let originalFetch: any
@@ -120,15 +125,13 @@ describe("shorten", () => {
     })
 
     it("should return immediate action if process is object", () => {
-      const url = "https://example.com/page?param=(test)!"
+      const url = "https://example.com"
       const action = jest.fn()
       // @ts-ignore
       global.process = { type: "object" }
 
-      import("../../src/utils/shorten").then(m => {
-        m.shorten(url, action)
-        expect(action).toHaveBeenCalledWith(url)
-      })
+      shorten(url, action)
+      expect(action).toHaveBeenCalledWith(url)
     })
 
     it("should shorten URL via fetch", async () => {
@@ -140,21 +143,20 @@ describe("shorten", () => {
       delete global.process
 
       global.fetch = jest.fn().mockResolvedValue({
-        json: () => Promise.resolve({ shortUrl })
+        json: () => Promise.resolve({ shortUrl }),
       })
 
-      const { shorten } = await import("../../src/utils/shorten")
       shorten(url, action)
 
       // wait for promises
-      await new Promise(resolve => setTimeout(resolve, 0))
+      for (let i = 0; i < 5; i++) await Promise.resolve()
 
       expect(global.fetch).toHaveBeenCalled()
       expect(action).toHaveBeenCalledWith(shortUrl)
     })
 
     it("should handle fetch failure", async () => {
-      const url = "https://example.com/page?param=(test)!"
+      const url = "https://example.com"
       const action = jest.fn()
 
       // @ts-ignore
@@ -163,10 +165,9 @@ describe("shorten", () => {
       global.fetch = jest.fn().mockRejectedValue(new Error("Network error"))
       const consoleSpy = jest.spyOn(console, "error").mockImplementation()
 
-      const { shorten } = await import("../../src/utils/shorten")
       shorten(url, action)
 
-      await new Promise(resolve => setTimeout(resolve, 0))
+      for (let i = 0; i < 5; i++) await Promise.resolve()
 
       expect(action).toHaveBeenCalledWith(url)
       expect(consoleSpy).toHaveBeenCalled()
@@ -174,24 +175,44 @@ describe("shorten", () => {
     })
 
     it("should handle invalid response from shorten endpoint", async () => {
-        const url = "https://example.com/page?param=(test)!"
-        const action = jest.fn()
+      const url = "https://example.com"
+      const action = jest.fn()
 
-        // @ts-ignore
-        delete global.process
+      // @ts-ignore
+      delete global.process
 
-        global.fetch = jest.fn().mockResolvedValue({
-          json: () => Promise.resolve({ error: "too long" })
-        })
-        const consoleSpy = jest.spyOn(console, "error").mockImplementation()
-
-        const { shorten } = await import("../../src/utils/shorten")
-        shorten(url, action)
-
-        await new Promise(resolve => setTimeout(resolve, 0))
-
-        expect(action).toHaveBeenCalledWith(url)
-        expect(consoleSpy).toHaveBeenCalled()
-        consoleSpy.mockRestore()
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ error: "too long" }),
       })
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation()
+
+      shorten(url, action)
+
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+
+      expect(action).toHaveBeenCalledWith(url)
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+  })
+})
+
+
+  describe("URL formatting", () => {
+    it("should escape special characters in URL", async () => {
+      const url = "https://example.com/search?q=()!*"
+      const action = jest.fn()
+      // @ts-ignore
+      delete global.process
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ shortUrl: "short" })
+      })
+
+      shorten(url, action)
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+
+      const fetchCall = (global.fetch as jest.Mock).mock.calls[0]
+      const body = JSON.parse(fetchCall[1].body)
+      expect(body.input).toBe("?q=%28%29%21%2A")
+    })
   })

--- a/test/utils/shorten.spec.ts
+++ b/test/utils/shorten.spec.ts
@@ -17,16 +17,40 @@ describe("shorten", () => {
 
     it("should return 'link shared' if navigator.canShare is true", async () => {
       const url = "https://example.com"
+      const shareMock = jest.fn().mockResolvedValue(undefined)
       Object.defineProperty(global.window, "navigator", {
         value: {
           canShare: () => true,
-          share: () => Promise.resolve(),
+          share: shareMock,
         },
         configurable: true,
       })
 
       const result = await share(url)
       expect(result).toBe("link shared")
+      expect(shareMock).toHaveBeenCalled()
+    })
+
+    it("should log error if navigator.share fails", async () => {
+      const url = "https://example.com"
+      const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+      const shareMock = jest.fn().mockRejectedValue(new Error("Share failed"))
+      Object.defineProperty(global.window, "navigator", {
+        value: {
+          canShare: () => true,
+          share: shareMock,
+        },
+        configurable: true,
+      })
+
+      const result = await share(url)
+      expect(result).toBe("link shared")
+      // wait for the catch block to be executed
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Error: Error: Share failed")
+      )
+      consoleSpy.mockRestore()
     })
 
     it("should return success message if clipboard write succeeds", async () => {
@@ -79,3 +103,95 @@ describe("shorten", () => {
     })
   })
 })
+
+  describe("shorten", () => {
+    let originalFetch: any
+    let originalProcess: any
+
+    beforeEach(() => {
+      originalFetch = global.fetch
+      originalProcess = global.process
+    })
+
+    afterEach(() => {
+      global.fetch = originalFetch
+      global.process = originalProcess
+      jest.restoreAllMocks()
+    })
+
+    it("should return immediate action if process is object", () => {
+      const url = "https://example.com/page?param=(test)!"
+      const action = jest.fn()
+      // @ts-ignore
+      global.process = { type: "object" }
+
+      import("../../src/utils/shorten").then(m => {
+        m.shorten(url, action)
+        expect(action).toHaveBeenCalledWith(url)
+      })
+    })
+
+    it("should shorten URL via fetch", async () => {
+      const url = "https://example.com/page?param=(test)!"
+      const shortUrl = "https://bit.ly/short"
+      const action = jest.fn()
+
+      // @ts-ignore
+      delete global.process
+
+      global.fetch = jest.fn().mockResolvedValue({
+        json: () => Promise.resolve({ shortUrl })
+      })
+
+      const { shorten } = await import("../../src/utils/shorten")
+      shorten(url, action)
+
+      // wait for promises
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(global.fetch).toHaveBeenCalled()
+      expect(action).toHaveBeenCalledWith(shortUrl)
+    })
+
+    it("should handle fetch failure", async () => {
+      const url = "https://example.com/page?param=(test)!"
+      const action = jest.fn()
+
+      // @ts-ignore
+      delete global.process
+
+      global.fetch = jest.fn().mockRejectedValue(new Error("Network error"))
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation()
+
+      const { shorten } = await import("../../src/utils/shorten")
+      shorten(url, action)
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(action).toHaveBeenCalledWith(url)
+      expect(consoleSpy).toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
+    it("should handle invalid response from shorten endpoint", async () => {
+        const url = "https://example.com/page?param=(test)!"
+        const action = jest.fn()
+
+        // @ts-ignore
+        delete global.process
+
+        global.fetch = jest.fn().mockResolvedValue({
+          json: () => Promise.resolve({ error: "too long" })
+        })
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation()
+
+        const { shorten } = await import("../../src/utils/shorten")
+        shorten(url, action)
+
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        expect(action).toHaveBeenCalledWith(url)
+        expect(consoleSpy).toHaveBeenCalled()
+        consoleSpy.mockRestore()
+      })
+  })

--- a/test/utils/shorten.spec.ts
+++ b/test/utils/shorten.spec.ts
@@ -39,7 +39,7 @@ describe("shorten utils", () => {
 
     it("should log error if navigator.share fails", async () => {
       const url = "https://example.com"
-      const consoleSpy = jest.spyOn(console, "log").mockImplementation()
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation()
       const shareMock = jest.fn().mockRejectedValue(new Error("Share failed"))
       Object.defineProperty(global.window, "navigator", {
         value: {
@@ -53,9 +53,7 @@ describe("shorten utils", () => {
       expect(result).toBe("link shared")
       // wait for the catch block to be executed
       for (let i = 0; i < 5; i++) await Promise.resolve()
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Error: Error: Share failed")
-      )
+      expect(consoleSpy).toHaveBeenCalledWith("Share failed", expect.any(Error))
       consoleSpy.mockRestore()
     })
 
@@ -127,7 +125,7 @@ describe("shorten utils", () => {
     it("should return immediate action if process is object", () => {
       const url = "https://example.com"
       const action = jest.fn()
-      // @ts-ignore
+      // @ts-expect-error mocking process
       global.process = { type: "object" }
 
       shorten(url, action)
@@ -139,7 +137,7 @@ describe("shorten utils", () => {
       const shortUrl = "https://bit.ly/short"
       const action = jest.fn()
 
-      // @ts-ignore
+      // @ts-expect-error mocking process
       delete global.process
 
       global.fetch = jest.fn().mockResolvedValue({
@@ -159,7 +157,7 @@ describe("shorten utils", () => {
       const url = "https://example.com"
       const action = jest.fn()
 
-      // @ts-ignore
+      // @ts-expect-error mocking process
       delete global.process
 
       global.fetch = jest.fn().mockRejectedValue(new Error("Network error"))
@@ -178,7 +176,7 @@ describe("shorten utils", () => {
       const url = "https://example.com"
       const action = jest.fn()
 
-      // @ts-ignore
+      // @ts-expect-error mocking process
       delete global.process
 
       global.fetch = jest.fn().mockResolvedValue({
@@ -202,7 +200,7 @@ describe("shorten utils", () => {
     it("should escape special characters in URL", async () => {
       const url = "https://example.com/search?q=()!*"
       const action = jest.fn()
-      // @ts-ignore
+      // @ts-expect-error mocking process
       delete global.process
       global.fetch = jest.fn().mockResolvedValue({
         json: () => Promise.resolve({ shortUrl: "short" })

--- a/test/utils/shorten.spec.ts
+++ b/test/utils/shorten.spec.ts
@@ -1,0 +1,81 @@
+import { share } from "../../src/utils/shorten"
+
+describe("shorten", () => {
+  describe("share", () => {
+    let originalNavigator: any
+
+    beforeEach(() => {
+      originalNavigator = global.window.navigator
+    })
+
+    afterEach(() => {
+      Object.defineProperty(global.window, "navigator", {
+        value: originalNavigator,
+        configurable: true,
+      })
+    })
+
+    it("should return 'link shared' if navigator.canShare is true", async () => {
+      const url = "https://example.com"
+      Object.defineProperty(global.window, "navigator", {
+        value: {
+          canShare: () => true,
+          share: () => Promise.resolve(),
+        },
+        configurable: true,
+      })
+
+      const result = await share(url)
+      expect(result).toBe("link shared")
+    })
+
+    it("should return success message if clipboard write succeeds", async () => {
+      const url = "https://example.com"
+      const writeText = jest.fn().mockResolvedValue(undefined)
+      Object.defineProperty(global.window, "navigator", {
+        value: {
+          canShare: () => false,
+          clipboard: {
+            writeText,
+          },
+        },
+        configurable: true,
+      })
+
+      const result = await share(url)
+      expect(writeText).toHaveBeenCalledWith(url)
+      expect(result).toBe(`link copied to clipboard <a href="${url}">${url}</a>`)
+    })
+
+    it("should return fallback message if clipboard write fails", async () => {
+      const url = "https://example.com"
+      const writeText = jest.fn().mockRejectedValue(new Error("NotAllowedError"))
+      Object.defineProperty(global.window, "navigator", {
+        value: {
+          canShare: () => false,
+          clipboard: {
+            writeText,
+          },
+        },
+        configurable: true,
+      })
+
+      const result = await share(url)
+      expect(writeText).toHaveBeenCalledWith(url)
+      expect(result).toBe(`link for sharing <a href="${url}">${url}</a>`)
+    })
+
+    it("should return fallback message if navigator.clipboard is missing", async () => {
+      const url = "https://example.com"
+      Object.defineProperty(global.window, "navigator", {
+        value: {
+          canShare: () => false,
+        },
+        configurable: true,
+      })
+
+      const result = await share(url)
+      expect(result).toBe(`link for sharing <a href="${url}">${url}</a>`)
+    })
+  })
+})


### PR DESCRIPTION
The `share` function was causing `NotAllowedError` when the Clipboard API was blocked by permissions policy. This PR makes the `share` function async, adds proper error handling, and returns a fallback message when the clipboard is unavailable. It also adds unit tests to verify the fix and updates the `Replay` controller to handle the async call.

---
*PR created automatically by Jules for task [8156467301616403401](https://jules.google.com/task/8156467301616403401) started by @tailuge*