### PR TITLE
Ignore Backpack extension warning in ClientErrorReporter

### DIFF
--- a/dist/css/fonts.css
+++ b/dist/css/fonts.css
@@ -1,11 +1,11 @@
 /* Global Font Configuration */
 /* Import Exo from Google Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Exo:wght@200&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Exo:wght@200&display=swap");
 
 /* Central font custom property - change --font-family-primary to update fonts globally */
 :root {
-  --font-family-primary: 'Exo', sans-serif;
-  --font-family-mono: 'Exo', monospace;
+  --font-family-primary: "Exo", sans-serif;
+  --font-family-mono: "Exo", monospace;
 }
 
 /* Apply primary font to body and common elements */

--- a/src/diagram/real/realoverlay.ts
+++ b/src/diagram/real/realoverlay.ts
@@ -158,7 +158,6 @@ export class RealOverlay {
       new BeginEvent(),
       new BreakEvent(state.init, state.shots)
     )
-
   }
 
   advance(elapsed: number) {

--- a/src/network/client/clienterrorreporter.ts
+++ b/src/network/client/clienterrorreporter.ts
@@ -158,6 +158,10 @@ export class ClientErrorReporter {
         stack = args[0].stack
       }
 
+      if (message.includes("Backpack couldn't override `window.ethereum`.")) {
+        return
+      }
+
       const key = type + ":" + message
       const count = (this.seen.get(key) ?? 0) + 1
       this.seen.set(key, count)

--- a/test/network/client/clienterrorreporter.spec.ts
+++ b/test/network/client/clienterrorreporter.spec.ts
@@ -1,0 +1,47 @@
+import { ClientErrorReporter } from "../../../src/network/client/clienterrorreporter"
+
+describe("ClientErrorReporter", () => {
+  let reporter: ClientErrorReporter
+  const endpoint = "https://example.com/api/error"
+
+  beforeEach(() => {
+    // Set NODE_ENV to something other than "test" to allow start() to work
+    // Or we can mock the check in start()
+    process.env.NODE_ENV = "development"
+
+    reporter = new ClientErrorReporter(endpoint)
+    // Mock fetch and sendBeacon
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    global.navigator.sendBeacon = jest.fn(() => true)
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = "test"
+    jest.restoreAllMocks()
+    reporter.stop()
+  })
+
+  it("should capture and flush errors", async () => {
+    reporter.start()
+    console.error("Test error")
+
+    // Force flush
+    ;(reporter as any).flush()
+
+    expect(global.navigator.sendBeacon).toHaveBeenCalled()
+    const payload = JSON.parse(
+      (global.navigator.sendBeacon as jest.Mock).mock.calls[0][1]
+    )
+    expect(payload[0].message).toBe("Test error")
+    expect(payload[0].type).toBe("error")
+  })
+
+  it("should skip 'Backpack' warning if configured or hardcoded", () => {
+    reporter.start()
+    const backpackMsg = "Backpack couldn't override `window.ethereum`."
+    console.warn(backpackMsg)
+    ;(reporter as any).flush()
+
+    expect(global.navigator.sendBeacon).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
I have modified the `ClientErrorReporter` to filter out the common "Backpack couldn't override `window.ethereum`." warning message. This message is typically generated by a browser extension and is not related to the application's functionality, so reporting it creates unnecessary noise in the error logs.

Key changes:
- Added a check in `ClientErrorReporter.capture` to skip reporting if the message contains the Backpack warning string.
- Created a new test file `test/network/client/clienterrorreporter.spec.ts` to verify that the warning is correctly ignored while other errors are still reported.
- Verified that all existing tests pass.

---
*PR created automatically by Jules for task [8802013763554876233](https://jules.google.com/task/8802013763554876233) started by @tailuge*