### PR TITLE
Address maintainability and reliability code smells

### DIFF
--- a/src/network/bot/aimcalculator.ts
+++ b/src/network/bot/aimcalculator.ts
@@ -51,8 +51,8 @@ export class AimCalculator {
   public generateShot(
     table: Table,
     noise: number,
-    targetPos: Vector3 = new Vector3().random(),
     power: number,
+    targetPos: Vector3 = new Vector3().random(),
     spinOffset: Vector3 = AimCalculator.randomSpin()
   ): HitEvent {
     const { cueball, cue, balls } = table

--- a/src/network/bot/eventhandler.ts
+++ b/src/network/bot/eventhandler.ts
@@ -182,8 +182,8 @@ export class BotEventHandler {
     const hitEvent = this.calculator.generateShot(
       table,
       0,
-      aimPoint ?? undefined,
-      AimCalculator.DEFAULT_SHOT_POWER
+      AimCalculator.DEFAULT_SHOT_POWER,
+      aimPoint ?? undefined
     )
     const aimEvent = AimEvent.fromJson(hitEvent.tablejson.aim)
     return [aimEvent, hitEvent]

--- a/src/view/dom/aiminputs.ts
+++ b/src/view/dom/aiminputs.ts
@@ -249,7 +249,7 @@ export class AimInputs {
   animateSliderHit() {
     if (this.sliderAnimId !== null) return // Prevent multiple concurrent animations
 
-    const target = parseFloat(this.cuePowerElement.value)
+    const target = Number.parseFloat(this.cuePowerElement.value)
     const duration = 2000 // Increased to 2s to allow for the 1s delay
     let start: number | null = null
 

--- a/test/network/bot/aimcalculator.spec.ts
+++ b/test/network/bot/aimcalculator.spec.ts
@@ -59,8 +59,8 @@ describe("AimCalculator", () => {
       const hitEvent = calculator.generateShot(
         table,
         0,
-        targetPos,
-        AimCalculator.DEFAULT_SHOT_POWER
+        AimCalculator.DEFAULT_SHOT_POWER,
+        targetPos
       ) as any
 
       const aimData = hitEvent.tablejson.aim
@@ -79,8 +79,8 @@ describe("AimCalculator", () => {
       const hitEvent = calculator.generateShot(
         table,
         0,
-        targetPos,
-        AimCalculator.DEFAULT_SHOT_POWER
+        AimCalculator.DEFAULT_SHOT_POWER,
+        targetPos
       ) as any
 
       const aimData = hitEvent.tablejson.aim

--- a/test/network/client/clienterrorreporter.spec.ts
+++ b/test/network/client/clienterrorreporter.spec.ts
@@ -11,8 +11,8 @@ describe("ClientErrorReporter", () => {
 
     reporter = new ClientErrorReporter(endpoint)
     // Mock fetch and sendBeacon
-    global.fetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
-    global.navigator.sendBeacon = jest.fn(() => true)
+    globalThis.fetch = jest.fn(() => Promise.resolve({ ok: true })) as jest.Mock
+    globalThis.navigator.sendBeacon = jest.fn(() => true)
   })
 
   afterEach(() => {
@@ -28,9 +28,9 @@ describe("ClientErrorReporter", () => {
     // Force flush
     ;(reporter as any).flush()
 
-    expect(global.navigator.sendBeacon).toHaveBeenCalled()
+    expect(globalThis.navigator.sendBeacon).toHaveBeenCalled()
     const payload = JSON.parse(
-      (global.navigator.sendBeacon as jest.Mock).mock.calls[0][1]
+      (globalThis.navigator.sendBeacon as jest.Mock).mock.calls[0][1]
     )
     expect(payload[0].message).toBe("Test error")
     expect(payload[0].type).toBe("error")
@@ -42,6 +42,6 @@ describe("ClientErrorReporter", () => {
     console.warn(backpackMsg)
     ;(reporter as any).flush()
 
-    expect(global.navigator.sendBeacon).not.toHaveBeenCalled()
+    expect(globalThis.navigator.sendBeacon).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
This PR addresses several code smells identified in the project:
1. **Maintainability**: Reordered parameters in `src/network/bot/aimcalculator.ts` so that default parameters come last.
2. **Reliability**: Replaced global `parseFloat` with `Number.parseFloat` in `src/view/dom/aiminputs.ts`.
3. **Portability**: Replaced Node-specific `global` with environment-agnostic `globalThis` in `test/network/client/clienterrorreporter.spec.ts`.
All changes have been verified with existing tests and a new Playwright verification script for UI consistency.

---
*PR created automatically by Jules for task [2418087144301678788](https://jules.google.com/task/2418087144301678788) started by @tailuge*