### PR TITLE
Fix all CSS linting errors across the project

### DIFF
--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -19,12 +19,12 @@
   padding: 2px;
   font-size: 16px;
   color: #ccc;
-  word-break: break-word;
+  overflow-wrap: break-word;
   overflow-wrap: anywhere;
 }
 
 .chatoutput a {
-  word-break: break-word;
+  overflow-wrap: break-word;
   overflow-wrap: anywhere;
 }
 

--- a/dist/css/menu.css
+++ b/dist/css/menu.css
@@ -68,10 +68,11 @@
 
 @keyframes voice-throb {
   0%, 100% {
-    background-color: rgba(220, 0, 0, 0.3);
+    background-color: rgb(220 0 0 / 30%);
   }
+
   50% {
-    background-color: rgba(220, 0, 0, 0.9);
+    background-color: rgb(220 0 0 / 90%);
   }
 }
 

--- a/dist/css/notification.css
+++ b/dist/css/notification.css
@@ -261,6 +261,51 @@
   letter-spacing: 0.5px;
 }
 
+/* 5.3 Action Buttons */
+.notification-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--notification-space-2);
+  width: 100%;
+}
+
+.notification-actions button,
+.notification-actions .button {
+  display: inline-block;
+  padding: var(--notification-space-1) var(--notification-space-2); /* 4px 8px */
+  cursor: pointer;
+  color: var(--notification-white);
+  text-decoration: none;
+  font-family: inherit;
+  font-size: var(--notification-size-m);
+  font-weight: var(--notification-weight-bold);
+  background: var(--notification-white-15);
+  border: 1px solid var(--notification-white-30);
+  border-radius: var(--notification-radius-s);
+  box-shadow: var(--notification-shadow-sm);
+  transition:
+    transform var(--notification-dur-fast) var(--notification-ease-elastic),
+    box-shadow var(--notification-dur-fast) var(--notification-ease-out),
+    background var(--notification-dur-fast) var(--notification-ease-out);
+}
+
+.notification-actions button:hover,
+.notification-actions .button:hover {
+  background: var(--notification-white-25);
+  border-color: var(--notification-white-50);
+  box-shadow: var(--notification-shadow-md);
+  transform: translateY(-4px) scale(1.05);
+}
+
+.notification-actions button:focus-visible,
+.notification-actions .button:focus-visible {
+  outline: 2px solid var(--notification-white);
+  outline-offset: 4px;
+  background: var(--notification-white-25);
+}
+
 /* ==========================================================================
    4. Theme Variants (States)
    ========================================================================== */
@@ -366,49 +411,4 @@
 .notification-high-break-icon,
 .notification-high-break-upload {
   color: var(--notification-white);
-}
-
-/* 5.3 Action Buttons */
-.notification-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: var(--notification-space-2);
-  width: 100%;
-}
-
-.notification-actions button,
-.notification-actions .button {
-  display: inline-block;
-  padding: var(--notification-space-1) var(--notification-space-2); /* 4px 8px */
-  cursor: pointer;
-  color: var(--notification-white);
-  text-decoration: none;
-  font-family: inherit;
-  font-size: var(--notification-size-m);
-  font-weight: var(--notification-weight-bold);
-  background: var(--notification-white-15);
-  border: 1px solid var(--notification-white-30);
-  border-radius: var(--notification-radius-s);
-  box-shadow: var(--notification-shadow-sm);
-  transition:
-    transform var(--notification-dur-fast) var(--notification-ease-elastic),
-    box-shadow var(--notification-dur-fast) var(--notification-ease-out),
-    background var(--notification-dur-fast) var(--notification-ease-out);
-}
-
-.notification-actions button:hover,
-.notification-actions .button:hover {
-  background: var(--notification-white-25);
-  border-color: var(--notification-white-50);
-  box-shadow: var(--notification-shadow-md);
-  transform: translateY(-4px) scale(1.05);
-}
-
-.notification-actions button:focus-visible,
-.notification-actions .button:focus-visible {
-  outline: 2px solid var(--notification-white);
-  outline-offset: 4px;
-  background: var(--notification-white-25);
 }

--- a/dist/css/tray.css
+++ b/dist/css/tray.css
@@ -100,13 +100,13 @@
   background: rgb(255 255 255 / 5%);
 }
 
-.tray-container:hover .nav-btn {
-  opacity: 1;
-}
-
 .nav-btn:hover {
   background: rgb(255 255 255 / 20%);
   color: white;
+}
+
+.tray-container:hover .nav-btn {
+  opacity: 1;
 }
 
 .ball-item {


### PR DESCRIPTION
This PR addresses all CSS linting errors identified by `stylelint`. Key changes include:

1. **Deprecated Syntax**: Replaced `word-break: break-word` with `overflow-wrap: break-word` and `overflow-wrap: anywhere` in `chat.css` to satisfy the linter while maintaining broad compatibility for word-breaking.
2. **Specificity Ordering**: Reordered rules in `notification.css` and `tray.css` to ensure that base component styles precede more specific context overrides, resolving `no-descending-specificity` violations.
3. **Modern Color Notation**: Updated `menu.css` to use the modern space-separated `rgb()` syntax and percentage-based alpha values.
4. **Verification**: Verified that `yarn lint:css` now passes with no errors and that existing functional tests for the notification and tray systems remain green. Visual verification was performed via Playwright screenshots.

---
*PR created automatically by Jules for task [13223160366482806244](https://jules.google.com/task/13223160366482806244) started by @tailuge*