### PR TITLE
Fix CSS linting errors across multiple files

### DIFF
--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -19,12 +19,10 @@
   padding: 2px;
   font-size: 16px;
   color: #ccc;
-  word-break: break-word;
   overflow-wrap: anywhere;
 }
 
 .chatoutput a {
-  word-break: break-word;
   overflow-wrap: anywhere;
 }
 

--- a/dist/css/notification.css
+++ b/dist/css/notification.css
@@ -299,14 +299,6 @@
   --notification-score-value-clr: var(--notification-text-clr-inv);
 }
 
-#notification.is-winner .notification-actions button,
-#notification.is-winner .notification-actions .button,
-#notification.is-loser .notification-actions button,
-#notification.is-loser .notification-actions .button {
-  background: var(--notification-black-15);
-  border-color: var(--notification-black-30);
-}
-
 /* ==========================================================================
    5. Interaction & Extras
    ========================================================================== */
@@ -411,4 +403,12 @@
   outline: 2px solid var(--notification-white);
   outline-offset: 4px;
   background: var(--notification-white-25);
+}
+
+#notification.is-winner .notification-actions button,
+#notification.is-winner .notification-actions .button,
+#notification.is-loser .notification-actions button,
+#notification.is-loser .notification-actions .button {
+  background: var(--notification-black-15);
+  border-color: var(--notification-black-30);
 }

--- a/dist/css/tray.css
+++ b/dist/css/tray.css
@@ -100,13 +100,13 @@
   background: rgb(255 255 255 / 5%);
 }
 
-.tray-container:hover .nav-btn {
-  opacity: 1;
-}
-
 .nav-btn:hover {
   background: rgb(255 255 255 / 20%);
   color: white;
+}
+
+.tray-container:hover .nav-btn {
+  opacity: 1;
 }
 
 .ball-item {


### PR DESCRIPTION
I have resolved the CSS linting errors identified in the project.

Key changes include:
- **chat.css**: Removed the deprecated `word-break: break-word` property. The existing `overflow-wrap: anywhere` provides the necessary line-breaking behavior.
- **notification.css**: Reordered action button selectors to ensure that general base styles appear before more specific state-based overrides (`.is-winner`, `.is-loser`), satisfying the `no-descending-specificity` rule.
- **tray.css**: Swapped the order of `.nav-btn:hover` and its more specific parent-hover context to resolve descending specificity.

I verified the changes by running `yarn lint:css`, which now passes with zero errors, and by conducting visual verification using Playwright to ensure no regressions in UI layout or behavior.

---
*PR created automatically by Jules for task [17155244068084511039](https://jules.google.com/task/17155244068084511039) started by @tailuge*