### PR TITLE
Mark class members as readonly where applicable

### DIFF
--- a/src/network/voice/voicecontroller.ts
+++ b/src/network/voice/voicecontroller.ts
@@ -21,8 +21,8 @@ const SYMBOLS: Record<VoiceState, string> = {
 
 export class VoiceController {
   private state: VoiceState = "idle"
-  private voice: VoiceManager
-  private container: Container
+  private readonly voice: VoiceManager
+  private readonly container: Container
   private ringingTimeout: any
 
   onStateChange: (symbol: string) => void = () => {}

--- a/src/network/voice/voicemanager.ts
+++ b/src/network/voice/voicemanager.ts
@@ -4,7 +4,7 @@ export class VoiceManager {
   private peer: SimplePeer.Instance | null = null
   private localStream: MediaStream | null = null
   private audio: HTMLAudioElement | null = null
-  private pendingSignals: any[] = []
+  private readonly pendingSignals: any[] = []
 
   onSignal: (data: any) => void = () => {}
   onConnect: () => void = () => {}

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -15,7 +15,7 @@ export class LobbyIndicator {
   private readonly ruleType: string
   private static readonly NCHAN_URL = "https://billiards-network.onrender.com"
   private currentTableId: string | null = null
-  private replayMode: boolean
+  private readonly replayMode: boolean
   constructor(botMode: boolean, replayMode: boolean, rules: Rules) {
     this.rules = rules
     this.replayMode = replayMode


### PR DESCRIPTION
Updated `VoiceController`, `VoiceManager`, and `LobbyIndicator` to mark class members that are never reassigned after initialization as `readonly`. This change improves code maintainability and enforces intent at compile-time without affecting runtime behavior. Verified with existing tests.

---
*PR created automatically by Jules for task [4434542978389558852](https://jules.google.com/task/4434542978389558852) started by @tailuge*