### PR TITLE
Implement Eightball Rules

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -190,11 +190,10 @@ export class Container {
     p2: number,
     b: number,
     active?: ActivePlayer,
-    p1a?: number,
-    p2a?: number
+    p1type?: number
   ) {
     const session = Session.getInstance()
-    session.updateScoresFromNetwork(p1, p2, b, p1a, p2a)
+    session.updateScoresFromNetwork(p1, p2, b, p1type)
     const orderedScores = session.orderedScoresForHud()
     this.hudScores = orderedScores
     const orderedNames = session.orderedNamesForHud()
@@ -204,8 +203,7 @@ export class Container {
       orderedNames.p1Name,
       orderedNames.p2Name,
       b,
-      orderedScores.p1a,
-      orderedScores.p2a
+      orderedScores.p1type
     )
     this.setHudActivePlayer(active ?? this.inferActivePlayer())
   }
@@ -215,8 +213,7 @@ export class Container {
     p2: number,
     b: number,
     active?: ActivePlayer,
-    p1a?: number,
-    p2a?: number
+    p1type?: number
   ) {
     const activePlayer = active ?? this.inferActivePlayer()
     const changed =
@@ -224,11 +221,10 @@ export class Container {
       this.hudScores.p2 !== p2 ||
       Session.getInstance().currentBreak !== b ||
       this.hudActivePlayer !== activePlayer ||
-      p1a !== undefined ||
-      p2a !== undefined
-    this.updateScoreHud(p1, p2, b, activePlayer, p1a, p2a)
+      p1type !== undefined
+    this.updateScoreHud(p1, p2, b, activePlayer, p1type)
     if (changed) {
-      this.sendEvent(new ScoreEvent(p1, p2, b, activePlayer, p1a, p2a))
+      this.sendEvent(new ScoreEvent(p1, p2, b, activePlayer, p1type))
     }
   }
 

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -185,9 +185,16 @@ export class Container {
     this.hud.setActivePlayer(active)
   }
 
-  updateScoreHud(p1: number, p2: number, b: number, active?: ActivePlayer) {
+  updateScoreHud(
+    p1: number,
+    p2: number,
+    b: number,
+    active?: ActivePlayer,
+    p1a?: number,
+    p2a?: number
+  ) {
     const session = Session.getInstance()
-    session.updateScoresFromNetwork(p1, p2, b)
+    session.updateScoresFromNetwork(p1, p2, b, p1a, p2a)
     const orderedScores = session.orderedScoresForHud()
     this.hudScores = orderedScores
     const orderedNames = session.orderedNamesForHud()
@@ -196,21 +203,32 @@ export class Container {
       orderedScores.p2,
       orderedNames.p1Name,
       orderedNames.p2Name,
-      b
+      b,
+      orderedScores.p1a,
+      orderedScores.p2a
     )
     this.setHudActivePlayer(active ?? this.inferActivePlayer())
   }
 
-  sendScoreUpdate(p1: number, p2: number, b: number, active?: ActivePlayer) {
+  sendScoreUpdate(
+    p1: number,
+    p2: number,
+    b: number,
+    active?: ActivePlayer,
+    p1a?: number,
+    p2a?: number
+  ) {
     const activePlayer = active ?? this.inferActivePlayer()
     const changed =
       this.hudScores.p1 !== p1 ||
       this.hudScores.p2 !== p2 ||
       Session.getInstance().currentBreak !== b ||
-      this.hudActivePlayer !== activePlayer
-    this.updateScoreHud(p1, p2, b, activePlayer)
+      this.hudActivePlayer !== activePlayer ||
+      p1a !== undefined ||
+      p2a !== undefined
+    this.updateScoreHud(p1, p2, b, activePlayer, p1a, p2a)
     if (changed) {
-      this.sendEvent(new ScoreEvent(p1, p2, b, activePlayer))
+      this.sendEvent(new ScoreEvent(p1, p2, b, activePlayer, p1a, p2a))
     }
   }
 

--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -36,7 +36,7 @@ export abstract class ControllerBase extends Controller {
   }
 
   override handleScore(event: ScoreEvent): Controller {
-    this.container.updateScoreHud(event.p1, event.p2, event.b, event.active)
+    this.container.rules.handleScore(event)
     return this
   }
 

--- a/src/controller/rules/eightball.ts
+++ b/src/controller/rules/eightball.ts
@@ -1,43 +1,20 @@
-import { Vector3 } from "three"
-import { Container } from "../../container/container"
-import { Aim } from "../../controller/aim"
-import { Controller } from "../../controller/controller"
-import { PlaceBall } from "../../controller/placeball"
-import { WatchAim } from "../../controller/watchaim"
-import { PlaceBallEvent } from "../../events/placeballevent"
-import { WatchEvent } from "../../events/watchevent"
 import { Ball } from "../../model/ball"
 import { Outcome, OutcomeType } from "../../model/outcome"
 import { Table } from "../../model/table"
 import { Rack } from "../../utils/rack"
-import { Rules } from "./rules"
-import { TableGeometry } from "../../view/tablegeometry"
-import { StartAimEvent } from "../../events/startaimevent"
-import { MatchResultHelper } from "../../network/client/matchresult"
+import { PoolRules } from "./poolrules"
 import { Session } from "../../network/client/session"
 import { ScoreEvent } from "../../events/scoreevent"
-import { roundVec } from "../../utils/three-utils"
-import { R } from "../../model/physics/constants"
-import { isFirstShot } from "../../utils/utils"
+import { Controller } from "../controller"
 
-export class EightBall implements Rules {
-  readonly container: Container
-
-  cueball: Ball
-  currentBreak = 0
-  previousBreak = 0
+export class EightBall extends PoolRules {
   rulename = "eightball"
   openTable = true
   p1Assignment = 0 // 0: None, 1: Solids, 2: Stripes
   p2Assignment = 0
 
-  constructor(container: Container) {
-    this.container = container
-  }
-
-  startTurn(): void {
-    this.previousBreak = this.currentBreak
-    this.currentBreak = 0
+  override startTurn(): void {
+    super.startTurn()
     // Sync local state from Session on turn start
     const session = Session.getInstance()
     this.p1Assignment = session.p1type
@@ -47,7 +24,7 @@ export class EightBall implements Rules {
     }
   }
 
-  nextCandidateBall(): Ball | undefined {
+  override nextCandidateBall(): Ball | undefined {
     const table = this.container.table
     const active = this.container.inferActivePlayer()
     const assignment = active === 1 ? this.p1Assignment : this.p2Assignment
@@ -69,39 +46,11 @@ export class EightBall implements Rules {
     return table.balls.find(b => (b.label || 0) === 8)
   }
 
-  placeBall(target?: Vector3): Vector3 {
-    const baulkline = (-R * 11) / 0.5
-    if (target) {
-      const max = new Vector3(TableGeometry.tableX, TableGeometry.tableY)
-      const min = new Vector3(-TableGeometry.tableX, -TableGeometry.tableY)
-      if (isFirstShot(this.container.recorder)) {
-        max.setX(baulkline)
-        min.setX(baulkline)
-      }
-      return target.clone().clamp(min, max)
-    }
-    return new Vector3(baulkline, 0, 0)
-  }
-
-  asset(): string {
-    return "models/p8.min.gltf"
-  }
-
-  tableGeometry(): void {
-    TableGeometry.hasPockets = true
-  }
-
-  table(): Table {
-    const table = new Table(this.rack())
-    this.cueball = table.cueball
-    return table
-  }
-
-  rack(): Ball[] {
+  override rack(): Ball[] {
     return Rack.eightBall()
   }
 
-  update(outcome: Outcome[]): Controller {
+  override update(outcome: Outcome[]): Controller {
     const reason = this.eightBallFoulReason(this.container.table, outcome)
 
     if (reason) {
@@ -109,6 +58,7 @@ export class EightBall implements Rules {
       if (ballsPotted.some((b) => (b.label || 0) === 8)) {
         return this.handleGameEnd(false, "8-ball pocketed on foul")
       }
+      this.startTurn()
       return this.handleFoul(outcome, reason)
     }
 
@@ -140,80 +90,6 @@ export class EightBall implements Rules {
     }
 
     return this.handleMiss()
-  }
-
-  private handleFoul(outcome: Outcome[], reason: string): Controller {
-    this.container.notify({
-      type: "Foul",
-      title: "FOUL",
-      subtext: reason,
-      extra: "Ball in hand",
-    })
-    this.startTurn()
-    const cueball = this.container.table.cueball
-    const startPos = cueball.onTable() ? cueball.pos.clone() : this.placeBall()
-    roundVec(startPos)
-    this.container.sendEvent(new PlaceBallEvent(startPos, undefined, true))
-
-    if (this.container.isSinglePlayer) {
-      return new PlaceBall(this.container, startPos)
-    }
-    return new WatchAim(this.container)
-  }
-
-  private handlePot(outcome: Outcome[]): Controller {
-    const table = this.container.table
-    const pots = Outcome.potCount(outcome)
-    this.currentBreak += pots
-    Session.getInstance().addMyScore(pots)
-
-    this.container.sound.playSuccess(table.inPockets())
-    if (this.isEndOfGame(outcome)) {
-      return this.handleGameEnd(true)
-    }
-
-    this.container.sendEvent(new WatchEvent(table.serialise()))
-    return new Aim(this.container)
-  }
-
-  handleGameEnd(isWinner: boolean, endSubtext?: string): Controller {
-    return MatchResultHelper.presentGameEnd(
-      this.container,
-      this.rulename,
-      isWinner,
-      endSubtext
-    )
-  }
-
-  private handleMiss(): Controller {
-    const table = this.container.table
-    this.container.sendEvent(new StartAimEvent())
-    if (this.container.isSinglePlayer) {
-      this.container.sendEvent(new WatchEvent(table.serialise()))
-      this.startTurn()
-      return new Aim(this.container)
-    }
-    return new WatchAim(this.container)
-  }
-
-  isPartOfBreak(outcome: Outcome[]): boolean {
-    return Outcome.isBallPottedNoFoul(this.container.table.cueball, outcome)
-  }
-
-  isEndOfGame(outcome: Outcome[]): boolean {
-    const eightBall = this.container.table.balls.find(b => (b.label || 0) === 8)
-    return !eightBall || !eightBall.onTable()
-  }
-
-  otherPlayersCueBall(): Ball {
-    return this.cueball
-  }
-
-  secondToPlay(): void {
-  }
-
-  allowsPlaceBall(): boolean {
-    return true
   }
 
   private eightBallFoulReason(table: Table, outcome: Outcome[]): string | null {
@@ -293,7 +169,12 @@ export class EightBall implements Rules {
     })
   }
 
-  handleScore(event: ScoreEvent): Controller {
+  override isEndOfGame(outcome: Outcome[]): boolean {
+    const eightBall = this.container.table.balls.find(b => (b.label || 0) === 8)
+    return !eightBall || !eightBall.onTable()
+  }
+
+  override handleScore(event: ScoreEvent): void {
     if (event.p1type !== undefined) {
       this.p1Assignment = event.p1type
       this.p2Assignment = event.p1type === 0 ? 0 : (event.p1type === 1 ? 2 : 1)
@@ -301,7 +182,6 @@ export class EightBall implements Rules {
         this.openTable = false
       }
     }
-    this.container.updateScoreHud(event.p1, event.p2, event.b, event.active, event.p1type)
-    return this.container.controller
+    super.handleScore(event)
   }
 }

--- a/src/controller/rules/eightball.ts
+++ b/src/controller/rules/eightball.ts
@@ -1,46 +1,107 @@
+import { Vector3 } from "three"
 import { Container } from "../../container/container"
+import { Aim } from "../../controller/aim"
 import { Controller } from "../../controller/controller"
-import { ScoreEvent } from "../../events/scoreevent"
+import { PlaceBall } from "../../controller/placeball"
+import { WatchAim } from "../../controller/watchaim"
+import { PlaceBallEvent } from "../../events/placeballevent"
+import { WatchEvent } from "../../events/watchevent"
 import { Ball } from "../../model/ball"
 import { Outcome, OutcomeType } from "../../model/outcome"
-import { Rack } from "../../utils/rack"
-import { NineBall } from "./nineball"
-import { Rules } from "./rules"
 import { Table } from "../../model/table"
+import { Rack } from "../../utils/rack"
+import { Rules } from "./rules"
+import { TableGeometry } from "../../view/tablegeometry"
+import { StartAimEvent } from "../../events/startaimevent"
+import { MatchResultHelper } from "../../network/client/matchresult"
 import { Session } from "../../network/client/session"
+import { ScoreEvent } from "../../events/scoreevent"
+import { roundVec } from "../../utils/three-utils"
+import { R } from "../../model/physics/constants"
+import { isFirstShot } from "../../utils/utils"
 
-export class EightBall extends NineBall implements Rules {
+export class EightBall implements Rules {
+  readonly container: Container
+
+  cueball: Ball
+  currentBreak = 0
+  previousBreak = 0
+  rulename = "eightball"
   openTable = true
   p1Assignment = 0 // 0: None, 1: Solids, 2: Stripes
   p2Assignment = 0
 
   constructor(container: Container) {
-    super(container)
-    this.rulename = "eightball"
+    this.container = container
   }
 
-  override rack(): Ball[] {
-    const balls = Rack.triangle()
-    // Rack.triangle() already puts cueball at index 0.
-    // Balls 1-15 are at indices 1-15.
-    // We want ball 8 (at triangle[8]) to be in the center (position tp[4]).
-    // tp[4] corresponds to the 5th object ball, which is at triangle[5].
-    Rack.swapBallPositions(balls[8], balls[5])
-    return balls
-  }
-
-  override startTurn(): void {
-    super.startTurn()
+  startTurn(): void {
+    this.previousBreak = this.currentBreak
+    this.currentBreak = 0
     // Sync local state from Session on turn start
     const session = Session.getInstance()
-    this.p1Assignment = session.p1a
-    this.p2Assignment = session.p2a
-    if (this.p1Assignment !== 0 || this.p2Assignment !== 0) {
+    this.p1Assignment = session.p1type
+    this.p2Assignment = session.p1type === 0 ? 0 : (session.p1type === 1 ? 2 : 1)
+    if (this.p1Assignment !== 0) {
       this.openTable = false
     }
   }
 
-  override update(outcome: Outcome[]): Controller {
+  nextCandidateBall(): Ball | undefined {
+    const table = this.container.table
+    const active = this.container.inferActivePlayer()
+    const assignment = active === 1 ? this.p1Assignment : this.p2Assignment
+
+    const candidates = table.balls.filter(b => b !== this.cueball && b.onTable())
+    if (this.openTable || assignment === 0) {
+      return candidates.filter(b => (b.label || 0) !== 8).sort((a, b) => (a.label || 0) - (b.label || 0))[0]
+    }
+
+    const myBalls = candidates.filter(b => {
+      const l = b.label || 0
+      return assignment === 1 ? (l >= 1 && l <= 7) : (l >= 9 && l <= 15)
+    })
+
+    if (myBalls.length > 0) {
+      return myBalls.sort((a, b) => (a.label || 0) - (b.label || 0))[0]
+    }
+
+    return table.balls.find(b => (b.label || 0) === 8)
+  }
+
+  placeBall(target?: Vector3): Vector3 {
+    const baulkline = (-R * 11) / 0.5
+    if (target) {
+      const max = new Vector3(TableGeometry.tableX, TableGeometry.tableY)
+      const min = new Vector3(-TableGeometry.tableX, -TableGeometry.tableY)
+      if (isFirstShot(this.container.recorder)) {
+        max.setX(baulkline)
+        min.setX(baulkline)
+      }
+      return target.clone().clamp(min, max)
+    }
+    return new Vector3(baulkline, 0, 0)
+  }
+
+  asset(): string {
+    return "models/p8.min.gltf"
+  }
+
+  tableGeometry(): void {
+    TableGeometry.hasPockets = true
+  }
+
+  table(): Table {
+    const table = new Table(this.rack())
+    this.cueball = table.cueball
+    return table
+  }
+
+  rack(): Ball[] {
+    return Rack.eightBall()
+  }
+
+  update(outcome: Outcome[]): Controller {
     const reason = this.eightBallFoulReason(this.container.table, outcome)
 
     if (reason) {
@@ -58,9 +119,7 @@ export class EightBall extends NineBall implements Rules {
 
       if (hasEight) {
         const strikerAssignment = this.getStrikerAssignment()
-        if (
-          this.hasRemainingGroupBalls(this.container.table, strikerAssignment)
-        ) {
+        if (this.hasRemainingGroupBalls(this.container.table, strikerAssignment)) {
           return this.handleGameEnd(false, "8-ball pocketed early")
         }
         return this.handleGameEnd(true)
@@ -83,43 +142,88 @@ export class EightBall extends NineBall implements Rules {
     return this.handleMiss()
   }
 
-  private assignGroups(assignment: number) {
-    this.openTable = false
-    const active = this.container.inferActivePlayer()
-    if (active === 1) {
-      this.p1Assignment = assignment
-      this.p2Assignment = assignment === 1 ? 2 : 1
-    } else {
-      this.p2Assignment = assignment
-      this.p1Assignment = assignment === 1 ? 2 : 1
+  private handleFoul(outcome: Outcome[], reason: string): Controller {
+    this.container.notify({
+      type: "Foul",
+      title: "FOUL",
+      subtext: reason,
+      extra: "Ball in hand",
+    })
+    this.startTurn()
+    const cueball = this.container.table.cueball
+    const startPos = cueball.onTable() ? cueball.pos.clone() : this.placeBall()
+    roundVec(startPos)
+    this.container.sendEvent(new PlaceBallEvent(startPos, undefined, true))
+
+    if (this.container.isSinglePlayer) {
+      return new PlaceBall(this.container, startPos)
     }
-    const { p1: s1, p2: s2 } = Session.getInstance().orderedScoresForHud()
-    this.container.sendScoreUpdate(
-      s1,
-      s2,
-      this.currentBreak,
-      undefined,
-      this.p1Assignment,
-      this.p2Assignment
+    return new WatchAim(this.container)
+  }
+
+  private handlePot(outcome: Outcome[]): Controller {
+    const table = this.container.table
+    const pots = Outcome.potCount(outcome)
+    this.currentBreak += pots
+    Session.getInstance().addMyScore(pots)
+
+    this.container.sound.playSuccess(table.inPockets())
+    if (this.isEndOfGame(outcome)) {
+      return this.handleGameEnd(true)
+    }
+
+    this.container.sendEvent(new WatchEvent(table.serialise()))
+    return new Aim(this.container)
+  }
+
+  handleGameEnd(isWinner: boolean, endSubtext?: string): Controller {
+    return MatchResultHelper.presentGameEnd(
+      this.container,
+      this.rulename,
+      isWinner,
+      endSubtext
     )
   }
 
-  protected override isFoul(outcome: Outcome[]): boolean {
-    return this.eightBallFoulReason(this.container.table, outcome) !== null
+  private handleMiss(): Controller {
+    const table = this.container.table
+    this.container.sendEvent(new StartAimEvent())
+    if (this.container.isSinglePlayer) {
+      this.container.sendEvent(new WatchEvent(table.serialise()))
+      this.startTurn()
+      return new Aim(this.container)
+    }
+    return new WatchAim(this.container)
+  }
+
+  isPartOfBreak(outcome: Outcome[]): boolean {
+    return Outcome.isBallPottedNoFoul(this.container.table.cueball, outcome)
+  }
+
+  isEndOfGame(outcome: Outcome[]): boolean {
+    const eightBall = this.container.table.balls.find(b => (b.label || 0) === 8)
+    return !eightBall || !eightBall.onTable()
+  }
+
+  otherPlayersCueBall(): Ball {
+    return this.cueball
+  }
+
+  secondToPlay(): void {
+  }
+
+  allowsPlaceBall(): boolean {
+    return true
   }
 
   private eightBallFoulReason(table: Table, outcome: Outcome[]): string | null {
     const cueball = table.cueball
 
-    // 1. Cue ball potted
     if (Outcome.isCueBallPotted(cueball, outcome)) {
       return "Cue ball potted"
     }
 
-    // 2. Wrong ball hit first
-    const firstCollision = Outcome.firstCollision(
-      Outcome.cueBallFirst(cueball, outcome)
-    )
+    const firstCollision = Outcome.firstCollision(Outcome.cueBallFirst(cueball, outcome))
 
     if (!firstCollision) {
       return "No ball hit"
@@ -148,12 +252,9 @@ export class EightBall extends NineBall implements Rules {
       }
     }
 
-    // 3. No cushion after contact
     if (Outcome.potCount(outcome) === 0) {
       const firstCollisionIndex = outcome.indexOf(firstCollision)
-      const cushionsAfter = outcome
-        .slice(firstCollisionIndex + 1)
-        .some((o) => o.type === OutcomeType.Cushion)
+      const cushionsAfter = outcome.slice(firstCollisionIndex + 1).some((o) => o.type === OutcomeType.Cushion)
       if (!cushionsAfter) {
         return "No cushion after contact"
       }
@@ -164,17 +265,21 @@ export class EightBall extends NineBall implements Rules {
 
   private getStrikerAssignment(): number {
     const active = this.container.inferActivePlayer()
-    // if active is 1 (p1), return p1Assignment, if 2 (p2) return p2Assignment
     return active === 1 ? this.p1Assignment : this.p2Assignment
   }
 
-  override handleScore(event: ScoreEvent): Controller {
-    if (event.p1a !== undefined) this.p1Assignment = event.p1a
-    if (event.p2a !== undefined) this.p2Assignment = event.p2a
-    if (this.p1Assignment !== 0 || this.p2Assignment !== 0) {
-      this.openTable = false
+  private assignGroups(assignment: number) {
+    this.openTable = false
+    const active = this.container.inferActivePlayer()
+    if (active === 1) {
+      this.p1Assignment = assignment
+      this.p2Assignment = assignment === 1 ? 2 : 1
+    } else {
+      this.p2Assignment = assignment
+      this.p1Assignment = assignment === 1 ? 2 : 1
     }
-    return super.handleScore(event)
+    const { p1: s1, p2: s2 } = Session.getInstance().orderedScoresForHud()
+    this.container.sendScoreUpdate(s1, s2, this.currentBreak, undefined, this.p1Assignment)
   }
 
   private hasRemainingGroupBalls(table: Table, assignment: number): boolean {
@@ -186,5 +291,17 @@ export class EightBall extends NineBall implements Rules {
       if (assignment === 2) return label >= 9 && label <= 15
       return false
     })
+  }
+
+  handleScore(event: ScoreEvent): Controller {
+    if (event.p1type !== undefined) {
+      this.p1Assignment = event.p1type
+      this.p2Assignment = event.p1type === 0 ? 0 : (event.p1type === 1 ? 2 : 1)
+      if (this.p1Assignment !== 0) {
+        this.openTable = false
+      }
+    }
+    this.container.updateScoreHud(event.p1, event.p2, event.b, event.active, event.p1type)
+    return this.container.controller
   }
 }

--- a/src/controller/rules/eightball.ts
+++ b/src/controller/rules/eightball.ts
@@ -1,0 +1,190 @@
+import { Container } from "../../container/container"
+import { Controller } from "../../controller/controller"
+import { ScoreEvent } from "../../events/scoreevent"
+import { Ball } from "../../model/ball"
+import { Outcome, OutcomeType } from "../../model/outcome"
+import { Rack } from "../../utils/rack"
+import { NineBall } from "./nineball"
+import { Rules } from "./rules"
+import { Table } from "../../model/table"
+import { Session } from "../../network/client/session"
+
+export class EightBall extends NineBall implements Rules {
+  openTable = true
+  p1Assignment = 0 // 0: None, 1: Solids, 2: Stripes
+  p2Assignment = 0
+
+  constructor(container: Container) {
+    super(container)
+    this.rulename = "eightball"
+  }
+
+  override rack(): Ball[] {
+    const balls = Rack.triangle()
+    // Rack.triangle() already puts cueball at index 0.
+    // Balls 1-15 are at indices 1-15.
+    // We want ball 8 (at triangle[8]) to be in the center (position tp[4]).
+    // tp[4] corresponds to the 5th object ball, which is at triangle[5].
+    Rack.swapBallPositions(balls[8], balls[5])
+    return balls
+  }
+
+  override startTurn(): void {
+    super.startTurn()
+    // Sync local state from Session on turn start
+    const session = Session.getInstance()
+    this.p1Assignment = session.p1a
+    this.p2Assignment = session.p2a
+    if (this.p1Assignment !== 0 || this.p2Assignment !== 0) {
+      this.openTable = false
+    }
+  }
+
+  override update(outcome: Outcome[]): Controller {
+    const reason = this.eightBallFoulReason(this.container.table, outcome)
+
+    if (reason) {
+      const ballsPotted = Outcome.pots(outcome)
+      if (ballsPotted.some((b) => (b.label || 0) === 8)) {
+        return this.handleGameEnd(false, "8-ball pocketed on foul")
+      }
+      return this.handleFoul(outcome, reason)
+    }
+
+    const pots = Outcome.pots(outcome)
+    if (pots.length > 0) {
+      const labels = pots.map((b) => b.label || 0)
+      const hasEight = labels.includes(8)
+
+      if (hasEight) {
+        const strikerAssignment = this.getStrikerAssignment()
+        if (
+          this.hasRemainingGroupBalls(this.container.table, strikerAssignment)
+        ) {
+          return this.handleGameEnd(false, "8-ball pocketed early")
+        }
+        return this.handleGameEnd(true)
+      }
+
+      if (this.openTable) {
+        const hasSolids = labels.some((l) => l >= 1 && l <= 7)
+        const hasStripes = labels.some((l) => l >= 9 && l <= 15)
+
+        if (hasSolids && !hasStripes) {
+          this.assignGroups(1)
+        } else if (hasStripes && !hasSolids) {
+          this.assignGroups(2)
+        }
+      }
+
+      return this.handlePot(outcome)
+    }
+
+    return this.handleMiss()
+  }
+
+  private assignGroups(assignment: number) {
+    this.openTable = false
+    const active = this.container.inferActivePlayer()
+    if (active === 1) {
+      this.p1Assignment = assignment
+      this.p2Assignment = assignment === 1 ? 2 : 1
+    } else {
+      this.p2Assignment = assignment
+      this.p1Assignment = assignment === 1 ? 2 : 1
+    }
+    const { p1: s1, p2: s2 } = Session.getInstance().orderedScoresForHud()
+    this.container.sendScoreUpdate(
+      s1,
+      s2,
+      this.currentBreak,
+      undefined,
+      this.p1Assignment,
+      this.p2Assignment
+    )
+  }
+
+  protected override isFoul(outcome: Outcome[]): boolean {
+    return this.eightBallFoulReason(this.container.table, outcome) !== null
+  }
+
+  private eightBallFoulReason(table: Table, outcome: Outcome[]): string | null {
+    const cueball = table.cueball
+
+    // 1. Cue ball potted
+    if (Outcome.isCueBallPotted(cueball, outcome)) {
+      return "Cue ball potted"
+    }
+
+    // 2. Wrong ball hit first
+    const firstCollision = Outcome.firstCollision(
+      Outcome.cueBallFirst(cueball, outcome)
+    )
+
+    if (!firstCollision) {
+      return "No ball hit"
+    }
+
+    const hitBall = firstCollision.ballB!
+    const hitBallLabel = hitBall.label || 0
+
+    if (this.openTable) {
+      if (hitBallLabel === 8) {
+        return "8-ball hit first on open table"
+      }
+    } else {
+      const strikerAssignment = this.getStrikerAssignment()
+      const isSolid = hitBallLabel >= 1 && hitBallLabel <= 7
+      const isStripe = hitBallLabel >= 9 && hitBallLabel <= 15
+
+      if (hitBallLabel === 8) {
+        if (this.hasRemainingGroupBalls(table, strikerAssignment)) {
+          return "8-ball hit first"
+        }
+      } else if (strikerAssignment === 1 && !isSolid) {
+        return "Wrong group hit first (Solids)"
+      } else if (strikerAssignment === 2 && !isStripe) {
+        return "Wrong group hit first (Stripes)"
+      }
+    }
+
+    // 3. No cushion after contact
+    if (Outcome.potCount(outcome) === 0) {
+      const firstCollisionIndex = outcome.indexOf(firstCollision)
+      const cushionsAfter = outcome
+        .slice(firstCollisionIndex + 1)
+        .some((o) => o.type === OutcomeType.Cushion)
+      if (!cushionsAfter) {
+        return "No cushion after contact"
+      }
+    }
+
+    return null
+  }
+
+  private getStrikerAssignment(): number {
+    const active = this.container.inferActivePlayer()
+    // if active is 1 (p1), return p1Assignment, if 2 (p2) return p2Assignment
+    return active === 1 ? this.p1Assignment : this.p2Assignment
+  }
+
+  override handleScore(event: ScoreEvent): Controller {
+    if (event.p1a !== undefined) this.p1Assignment = event.p1a
+    if (event.p2a !== undefined) this.p2Assignment = event.p2a
+    if (this.p1Assignment !== 0 || this.p2Assignment !== 0) {
+      this.openTable = false
+    }
+    return super.handleScore(event)
+  }
+
+  private hasRemainingGroupBalls(table: Table, assignment: number): boolean {
+    if (assignment === 0) return true
+    return table.balls.some((b) => {
+      if (!b.onTable() || b === table.cueball) return false
+      const label = b.label || 0
+      if (assignment === 1) return label >= 1 && label <= 7
+      if (assignment === 2) return label >= 9 && label <= 15
+      return false
+    })
+  }
+}

--- a/src/controller/rules/nineball.ts
+++ b/src/controller/rules/nineball.ts
@@ -1,169 +1,53 @@
-import { Vector3 } from "three"
-import { Container } from "../../container/container"
-import { Aim } from "../../controller/aim"
-import { Controller } from "../../controller/controller"
-import { PlaceBall } from "../../controller/placeball"
-import { WatchAim } from "../../controller/watchaim"
-import { PlaceBallEvent } from "../../events/placeballevent"
-import { RerackEvent } from "../../events/rerackevent"
-import { WatchEvent } from "../../events/watchevent"
-import { Ball } from "../../model/ball"
 import { Outcome, OutcomeType } from "../../model/outcome"
 import { Table } from "../../model/table"
 import { Rack } from "../../utils/rack"
-import { Rules } from "./rules"
-import { R } from "../../model/physics/constants"
+import { PoolRules } from "./poolrules"
+import { RerackEvent } from "../../events/rerackevent"
 import { Respot } from "../../utils/respot"
-import { TableGeometry } from "../../view/tablegeometry"
-import { StartAimEvent } from "../../events/startaimevent"
-import { MatchResultHelper } from "../../network/client/matchresult"
 import { Session } from "../../network/client/session"
-import { isFirstShot } from "../../utils/utils"
-import { roundVec } from "../../utils/three-utils"
+import { Ball } from "../../model/ball"
+import { Controller } from "../controller"
 
-export class NineBall implements Rules {
-  readonly container: Container
-
-  cueball: Ball
-  currentBreak = 0
-  previousBreak = 0
+export class NineBall extends PoolRules {
   rulename = "nineball"
 
-  constructor(container: Container) {
-    this.container = container
-  }
-
-  startTurn(): void {
-    this.previousBreak = this.currentBreak
-    this.currentBreak = 0
-  }
-
-  nextCandidateBall(): Ball | undefined {
+  override nextCandidateBall(): Ball | undefined {
     return this.container.table.balls
       .filter((b) => b !== this.cueball && b.onTable())
       .sort((a, b) => (a.label || 0) - (b.label || 0))[0]
   }
 
-  placeBall(target?: Vector3): Vector3 {
-    const baulkline = (-R * 11) / 0.5
-    if (target) {
-      const max = new Vector3(TableGeometry.tableX, TableGeometry.tableY)
-      const min = new Vector3(-TableGeometry.tableX, -TableGeometry.tableY)
-      if (isFirstShot(this.container.recorder)) {
-        max.setX(baulkline)
-        min.setX(baulkline)
-      }
-      return target.clone().clamp(min, max)
-    }
-    return new Vector3(baulkline, 0, 0)
-  }
-
-  asset(): string {
-    return "models/p8.min.gltf"
-  }
-
-  tableGeometry(): void {
-    TableGeometry.hasPockets = true
-  }
-
-  table(): Table {
-    const table = new Table(this.rack())
-    this.cueball = table.cueball
-    return table
-  }
-
-  rack(): Ball[] {
+  override rack(): Ball[] {
     return Rack.diamond()
   }
 
-  update(outcome: Outcome[]): Controller {
+  override update(outcome: Outcome[]): Controller {
     const reason = NineBall.foulReason(this.container.table, outcome)
 
     if (reason) {
+      this.startTurn()
+      const pots = Outcome.pots(outcome)
+      const nineBallPotted = pots.includes(this.container.table.balls[9])
+
+      if (nineBallPotted) {
+        this.respotAndBroadcastNineBall()
+      }
       return this.handleFoul(outcome, reason)
     }
 
     if (Outcome.potCount(outcome) > 0) {
+      if (Session.isPracticeMode()) {
+        if (Outcome.pots(outcome).includes(this.container.table.balls[9])) {
+          this.respotAndBroadcastNineBall()
+        }
+      }
       return this.handlePot(outcome)
     }
 
     return this.handleMiss()
   }
 
-  protected handleFoul(outcome: Outcome[], reason: string): Controller {
-    this.container.notify({
-      type: "Foul",
-      title: "FOUL",
-      subtext: reason,
-      extra: "Ball in hand",
-    })
-    this.startTurn()
-    const pots = Outcome.pots(outcome)
-    const nineBallPotted = pots.includes(this.container.table.balls[9])
-    const cueball = this.container.table.cueball
-
-    if (nineBallPotted) {
-      this.respotAndBroadcastNineBall()
-    }
-
-    const startPos = cueball.onTable() ? cueball.pos.clone() : this.placeBall()
-    roundVec(startPos)
-    const placeBallEvent = new PlaceBallEvent(startPos, undefined, true)
-    this.container.sendEvent(placeBallEvent)
-
-    if (this.container.isSinglePlayer) {
-      return new PlaceBall(this.container, startPos)
-    }
-    return new WatchAim(this.container)
-  }
-
-  protected handlePot(outcome: Outcome[]): Controller {
-    const table = this.container.table
-    const pots = Outcome.potCount(outcome)
-    this.currentBreak += pots
-    Session.getInstance().addMyScore(pots)
-
-    this.container.sound.playSuccess(table.inPockets())
-    if (this.isEndOfGame(outcome)) {
-      return this.handleGameEnd(true)
-    }
-
-    if (Session.isPracticeMode()) {
-      if (Outcome.pots(outcome).includes(table.balls[9])) {
-        this.respotAndBroadcastNineBall()
-      }
-    }
-
-    this.container.sendEvent(new WatchEvent(table.serialise()))
-    return new Aim(this.container)
-  }
-
-  handleGameEnd(isWinner: boolean, endSubtext?: string): Controller {
-    return MatchResultHelper.presentGameEnd(
-      this.container,
-      this.rulename,
-      isWinner,
-      endSubtext
-    )
-  }
-
-  protected handleMiss(): Controller {
-    const table = this.container.table
-    // if no pot and no foul switch to other player
-    this.container.sendEvent(new StartAimEvent())
-    if (this.container.isSinglePlayer) {
-      this.container.sendEvent(new WatchEvent(table.serialise()))
-      this.startTurn()
-      return new Aim(this.container)
-    }
-    return new WatchAim(this.container)
-  }
-
-  isPartOfBreak(outcome: Outcome[]): boolean {
-    return Outcome.isBallPottedNoFoul(this.container.table.cueball, outcome)
-  }
-
-  isEndOfGame(outcome: Outcome[]): boolean {
+  override isEndOfGame(outcome: Outcome[]): boolean {
     const nineBall = this.container.table.balls[9]
     const nineBallPotted = Outcome.pots(outcome).includes(nineBall)
     if (!nineBallPotted || this.isFoul(outcome)) {
@@ -174,19 +58,6 @@ export class NineBall implements Rules {
       return !NineBall.hasOtherObjectBalls(this.container.table)
     }
 
-    return true
-  }
-
-  otherPlayersCueBall(): Ball {
-    // only for three cushion
-    return this.cueball
-  }
-
-  secondToPlay(): void {
-    // only for three cushion
-  }
-
-  allowsPlaceBall(): boolean {
     return true
   }
 

--- a/src/controller/rules/nineball.ts
+++ b/src/controller/rules/nineball.ts
@@ -90,7 +90,7 @@ export class NineBall implements Rules {
     return this.handleMiss()
   }
 
-  private handleFoul(outcome: Outcome[], reason: string): Controller {
+  protected handleFoul(outcome: Outcome[], reason: string): Controller {
     this.container.notify({
       type: "Foul",
       title: "FOUL",
@@ -117,7 +117,7 @@ export class NineBall implements Rules {
     return new WatchAim(this.container)
   }
 
-  private handlePot(outcome: Outcome[]): Controller {
+  protected handlePot(outcome: Outcome[]): Controller {
     const table = this.container.table
     const pots = Outcome.potCount(outcome)
     this.currentBreak += pots
@@ -147,7 +147,7 @@ export class NineBall implements Rules {
     )
   }
 
-  private handleMiss(): Controller {
+  protected handleMiss(): Controller {
     const table = this.container.table
     // if no pot and no foul switch to other player
     this.container.sendEvent(new StartAimEvent())

--- a/src/controller/rules/poolrules.ts
+++ b/src/controller/rules/poolrules.ts
@@ -1,0 +1,153 @@
+import { Vector3 } from "three"
+import { Container } from "../../container/container"
+import { Aim } from "../../controller/aim"
+import { Controller } from "../../controller/controller"
+import { PlaceBall } from "../../controller/placeball"
+import { WatchAim } from "../../controller/watchaim"
+import { PlaceBallEvent } from "../../events/placeballevent"
+import { WatchEvent } from "../../events/watchevent"
+import { Ball } from "../../model/ball"
+import { Outcome } from "../../model/outcome"
+import { Table } from "../../model/table"
+import { Rules } from "./rules"
+import { R } from "../../model/physics/constants"
+import { TableGeometry } from "../../view/tablegeometry"
+import { StartAimEvent } from "../../events/startaimevent"
+import { MatchResultHelper } from "../../network/client/matchresult"
+import { Session } from "../../network/client/session"
+import { isFirstShot } from "../../utils/utils"
+import { roundVec } from "../../utils/three-utils"
+import { ScoreEvent } from "../../events/scoreevent"
+
+export abstract class PoolRules implements Rules {
+  readonly container: Container
+
+  cueball: Ball
+  currentBreak = 0
+  previousBreak = 0
+  abstract rulename: string
+
+  constructor(container: Container) {
+    this.container = container
+  }
+
+  startTurn(): void {
+    this.previousBreak = this.currentBreak
+    this.currentBreak = 0
+  }
+
+  abstract nextCandidateBall(): Ball | undefined
+
+  placeBall(target?: Vector3): Vector3 {
+    const baulkline = (-R * 11) / 0.5
+    if (target) {
+      const max = new Vector3(TableGeometry.tableX, TableGeometry.tableY)
+      const min = new Vector3(-TableGeometry.tableX, -TableGeometry.tableY)
+      if (isFirstShot(this.container.recorder)) {
+        max.setX(baulkline)
+        min.setX(baulkline)
+      }
+      return target.clone().clamp(min, max)
+    }
+    return new Vector3(baulkline, 0, 0)
+  }
+
+  asset(): string {
+    return "models/p8.min.gltf"
+  }
+
+  tableGeometry(): void {
+    TableGeometry.hasPockets = true
+  }
+
+  table(): Table {
+    const table = new Table(this.rack())
+    this.cueball = table.cueball
+    return table
+  }
+
+  abstract rack(): Ball[]
+  abstract update(outcome: Outcome[]): Controller
+
+  protected handleFoul(outcome: Outcome[], reason: string): Controller {
+    this.container.notify({
+      type: "Foul",
+      title: "FOUL",
+      subtext: reason,
+      extra: "Ball in hand",
+    })
+    this.startTurn()
+    const cueball = this.container.table.cueball
+
+    const startPos = cueball.onTable() ? cueball.pos.clone() : this.placeBall()
+    roundVec(startPos)
+    const placeBallEvent = new PlaceBallEvent(startPos, undefined, true)
+    this.container.sendEvent(placeBallEvent)
+
+    if (this.container.isSinglePlayer) {
+      return new PlaceBall(this.container, startPos)
+    }
+    return new WatchAim(this.container)
+  }
+
+  protected handlePot(outcome: Outcome[]): Controller {
+    const table = this.container.table
+    const pots = Outcome.potCount(outcome)
+    this.currentBreak += pots
+    Session.getInstance().addMyScore(pots)
+
+    this.container.sound.playSuccess(table.inPockets())
+    if (this.isEndOfGame(outcome)) {
+      return this.handleGameEnd(true)
+    }
+
+    this.container.sendEvent(new WatchEvent(table.serialise()))
+    return new Aim(this.container)
+  }
+
+  handleGameEnd(isWinner: boolean, endSubtext?: string): Controller {
+    return MatchResultHelper.presentGameEnd(
+      this.container,
+      this.rulename,
+      isWinner,
+      endSubtext
+    )
+  }
+
+  protected handleMiss(): Controller {
+    const table = this.container.table
+    this.container.sendEvent(new StartAimEvent())
+    if (this.container.isSinglePlayer) {
+      this.container.sendEvent(new WatchEvent(table.serialise()))
+      this.startTurn()
+      return new Aim(this.container)
+    }
+    return new WatchAim(this.container)
+  }
+
+  isPartOfBreak(outcome: Outcome[]): boolean {
+    return Outcome.isBallPottedNoFoul(this.container.table.cueball, outcome)
+  }
+
+  abstract isEndOfGame(outcome: Outcome[]): boolean
+
+  otherPlayersCueBall(): Ball {
+    return this.cueball
+  }
+
+  secondToPlay(): void {}
+
+  allowsPlaceBall(): boolean {
+    return true
+  }
+
+  handleScore(event: ScoreEvent): void {
+    this.container.updateScoreHud(
+      event.p1,
+      event.p2,
+      event.b,
+      event.active,
+      event.p1type
+    )
+  }
+}

--- a/src/controller/rules/rulefactory.ts
+++ b/src/controller/rules/rulefactory.ts
@@ -1,3 +1,4 @@
+import { EightBall } from "./eightball"
 import { FourteenOne } from "./fourteenone"
 import { NineBall } from "./nineball"
 import { Rules } from "./rules"
@@ -13,6 +14,8 @@ export class RuleFactory {
         return new FourteenOne(container)
       case "snooker":
         return new Snooker(container)
+      case "eightball":
+        return new EightBall(container)
       default:
         return new NineBall(container)
     }

--- a/src/controller/rules/rules.ts
+++ b/src/controller/rules/rules.ts
@@ -3,6 +3,7 @@ import { Controller } from "../../controller/controller"
 import { Ball } from "../../model/ball"
 import { Outcome } from "../../model/outcome"
 import { Table } from "../../model/table"
+import { ScoreEvent } from "../../events/scoreevent"
 
 export interface Rules {
   cueball: Ball
@@ -23,4 +24,5 @@ export interface Rules {
   nextCandidateBall(): Ball | undefined
   startTurn(): void
   handleGameEnd(isWinner: boolean, endSubtext?: string): Controller
+  handleScore(event: ScoreEvent): void
 }

--- a/src/events/scoreevent.ts
+++ b/src/events/scoreevent.ts
@@ -7,7 +7,9 @@ export class ScoreEvent extends GameEvent {
     readonly p1: number,
     readonly p2: number,
     readonly b: number,
-    readonly active: 0 | 1 | 2 = 0
+    readonly active: 0 | 1 | 2 = 0,
+    readonly p1a?: number,
+    readonly p2a?: number
   ) {
     super()
     this.type = EventType.SCORE
@@ -18,6 +20,13 @@ export class ScoreEvent extends GameEvent {
   }
 
   static fromJson(json: any): ScoreEvent {
-    return new ScoreEvent(json.p1, json.p2, json.b, json.active ?? 0)
+    return new ScoreEvent(
+      json.p1,
+      json.p2,
+      json.b,
+      json.active ?? 0,
+      json.p1a,
+      json.p2a
+    )
   }
 }

--- a/src/events/scoreevent.ts
+++ b/src/events/scoreevent.ts
@@ -8,8 +8,7 @@ export class ScoreEvent extends GameEvent {
     readonly p2: number,
     readonly b: number,
     readonly active: 0 | 1 | 2 = 0,
-    readonly p1a?: number,
-    readonly p2a?: number
+    readonly p1type?: number
   ) {
     super()
     this.type = EventType.SCORE
@@ -25,8 +24,7 @@ export class ScoreEvent extends GameEvent {
       json.p2,
       json.b,
       json.active ?? 0,
-      json.p1a,
-      json.p2a
+      json.p1type
     )
   }
 }

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -18,8 +18,7 @@ export class Session {
   playerIndex: number = 0
   private scoreByClientId: Record<string, number> = {}
   currentBreak: number = 0
-  p1a: number = 0
-  p2a: number = 0
+  p1type: number = 0
 
   private static instance: Session | undefined
   private static readonly fallbackOpponentClientId = "opponent"
@@ -137,22 +136,19 @@ export class Session {
   orderedScoresForHud(): {
     p1: number
     p2: number
-    p1a: number
-    p2a: number
+    p1type: number
   } {
     if (this.playerIndex === 0) {
       return {
         p1: this.myScore(),
         p2: this.opponentScore(),
-        p1a: this.p1a,
-        p2a: this.p2a,
+        p1type: this.p1type,
       }
     }
     return {
       p1: this.opponentScore(),
       p2: this.myScore(),
-      p1a: this.p1a,
-      p2a: this.p2a,
+      p1type: this.p1type,
     }
   }
 
@@ -197,8 +193,7 @@ export class Session {
     p1: number,
     p2: number,
     breakScore: number,
-    p1a?: number,
-    p2a?: number
+    p1type?: number
   ): void {
     if (this.playerIndex === 1) {
       this.setMyScore(p2)
@@ -208,7 +203,6 @@ export class Session {
       this.setOpponentScore(p2)
     }
     this.currentBreak = breakScore
-    if (p1a !== undefined) this.p1a = p1a
-    if (p2a !== undefined) this.p2a = p2a
+    if (p1type !== undefined) this.p1type = p1type
   }
 }

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -18,6 +18,8 @@ export class Session {
   playerIndex: number = 0
   private scoreByClientId: Record<string, number> = {}
   currentBreak: number = 0
+  p1a: number = 0
+  p2a: number = 0
 
   private static instance: Session | undefined
   private static readonly fallbackOpponentClientId = "opponent"
@@ -132,11 +134,26 @@ export class Session {
     this.scoreByClientId[clientId] = score
   }
 
-  orderedScoresForHud(): { p1: number; p2: number } {
+  orderedScoresForHud(): {
+    p1: number
+    p2: number
+    p1a: number
+    p2a: number
+  } {
     if (this.playerIndex === 0) {
-      return { p1: this.myScore(), p2: this.opponentScore() }
+      return {
+        p1: this.myScore(),
+        p2: this.opponentScore(),
+        p1a: this.p1a,
+        p2a: this.p2a,
+      }
     }
-    return { p1: this.opponentScore(), p2: this.myScore() }
+    return {
+      p1: this.opponentScore(),
+      p2: this.myScore(),
+      p1a: this.p1a,
+      p2a: this.p2a,
+    }
   }
 
   orderedNamesForHud(): { p1Name?: string; p2Name?: string } {
@@ -176,7 +193,13 @@ export class Session {
     return names
   }
 
-  updateScoresFromNetwork(p1: number, p2: number, breakScore: number): void {
+  updateScoresFromNetwork(
+    p1: number,
+    p2: number,
+    breakScore: number,
+    p1a?: number,
+    p2a?: number
+  ): void {
     if (this.playerIndex === 1) {
       this.setMyScore(p2)
       this.setOpponentScore(p1)
@@ -185,5 +208,7 @@ export class Session {
       this.setOpponentScore(p2)
     }
     this.currentBreak = breakScore
+    if (p1a !== undefined) this.p1a = p1a
+    if (p2a !== undefined) this.p2a = p2a
   }
 }

--- a/src/utils/rack.ts
+++ b/src/utils/rack.ts
@@ -89,6 +89,17 @@ export class Rack {
     return diamond
   }
 
+  static eightBall() {
+    const tp = Rack.trianglePositions()
+    const balls: Ball[] = []
+    balls.push(Rack.cueBall(Rack.spot))
+    const labels = [9, 1, 10, 11, 8, 2, 3, 12, 4, 13, 14, 5, 6, 15, 7]
+    labels.forEach((label, i) => {
+      balls.push(new Ball(Rack.jitter(tp[i]), Rack.BALL_COLORS[label], label))
+    })
+    return balls
+  }
+
   static triangle() {
     const tp = Rack.trianglePositions()
     const triangle: Ball[] = []

--- a/src/view/hud.ts
+++ b/src/view/hud.ts
@@ -40,19 +40,30 @@ export class Hud {
     p2: number,
     p1Name?: string,
     p2Name?: string,
-    b: number = 0
+    b: number = 0,
+    p1a: number = 0,
+    p2a: number = 0
   ) {
     this.setText(this.p1Element, "")
     this.setText(this.p2Element, "")
     this.setText(this.breakElement, "")
 
-    if (p1Name && p2Name) {
-      this.setText(this.p1Element, `${p1Name} ${p1}`)
-      this.setText(this.p2Element, `${p2} ${p2Name}`)
-    } else if (p1Name) {
-      this.setText(this.p1Element, `${p1Name} ${p1}`)
-    } else if (p2Name) {
-      this.setText(this.p2Element, `${p2} ${p2Name}`)
+    const group = (a: number) => {
+      if (a === 1) return " (Solids)"
+      if (a === 2) return " (Stripes)"
+      return ""
+    }
+
+    const n1 = p1Name ? `${p1Name}${group(p1a)}` : ""
+    const n2 = p2Name ? `${group(p2a)}${p2Name}` : ""
+
+    if (n1 && n2) {
+      this.setText(this.p1Element, `${n1} ${p1}`)
+      this.setText(this.p2Element, `${p2} ${n2}`)
+    } else if (n1) {
+      this.setText(this.p1Element, `${n1} ${p1}`)
+    } else if (n2) {
+      this.setText(this.p2Element, `${p2} ${n2}`)
     } else {
       this.setText(this.p1Element, `${p1}`)
     }

--- a/src/view/hud.ts
+++ b/src/view/hud.ts
@@ -41,8 +41,7 @@ export class Hud {
     p1Name?: string,
     p2Name?: string,
     b: number = 0,
-    p1a: number = 0,
-    p2a: number = 0
+    p1type: number = 0
   ) {
     this.setText(this.p1Element, "")
     this.setText(this.p2Element, "")
@@ -54,8 +53,9 @@ export class Hud {
       return ""
     }
 
-    const n1 = p1Name ? `${p1Name}${group(p1a)}` : ""
-    const n2 = p2Name ? `${group(p2a)}${p2Name}` : ""
+    const p2type = p1type === 0 ? 0 : p1type === 1 ? 2 : 1
+    const n1 = p1Name ? `${p1Name}${group(p1type)}` : ""
+    const n2 = p2Name ? `${group(p2type)}${p2Name}` : ""
 
     if (n1 && n2) {
       this.setText(this.p1Element, `${n1} ${p1}`)


### PR DESCRIPTION
This change introduces the 'eightball' rule type. Key features include:
- Correct triangle rack with the 8-ball in the center.
- Open table logic where any ball (except 8) can be hit first.
- Group assignment (Solids/Stripes) occurs on the first legal pot of a single group.
- Mixed pots on an open table keep the table open but continue the turn.
- Foul detection for hitting the wrong group, hitting the 8-ball early, and failing rail contact.
- UI feedback in the HUD showing assigned groups.
- Robust state synchronization for multiplayer games.

---
*PR created automatically by Jules for task [12158421970800443843](https://jules.google.com/task/12158421970800443843) started by @tailuge*