### PR TITLE
Fix and test 2-player Eight-Ball rules

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -185,17 +185,26 @@ export class Container {
     this.hud.setActivePlayer(active)
   }
 
-  updateScoreHud(p1: number, p2: number, b: number, active?: ActivePlayer) {
+  updateScoreHud(
+    p1: number,
+    p2: number,
+    b: number,
+    active?: ActivePlayer,
+    p1type?: number
+  ) {
     const session = Session.getInstance()
-    session.updateScoresFromNetwork(p1, p2, b)
+    session.updateScoresFromNetwork(p1, p2, b, p1type)
     const orderedScores = session.orderedScoresForHud()
     this.hudScores = orderedScores
     const orderedNames = session.orderedNamesForHud()
     if (this.rules.rulename === "eightball" && session.p1type !== 0) {
-      const typeLabel = session.p1type === 1 ? "solids" : "stripes"
-      const mySlot = session.playerIndex === 0 ? "p1Name" : "p2Name"
-      if (orderedNames[mySlot]) {
-        orderedNames[mySlot] = `${orderedNames[mySlot]}(${typeLabel})`
+      const p1Label = session.p1type === 1 ? "solids" : "stripes"
+      const p2Label = session.p1type === 1 ? "stripes" : "solids"
+      if (orderedNames.p1Name) {
+        orderedNames.p1Name = `${orderedNames.p1Name}(${p1Label})`
+      }
+      if (orderedNames.p2Name) {
+        orderedNames.p2Name = `${orderedNames.p2Name}(${p2Label})`
       }
     }
     this.hud.updateScores(

--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -36,7 +36,13 @@ export abstract class ControllerBase extends Controller {
   }
 
   override handleScore(event: ScoreEvent): Controller {
-    this.container.updateScoreHud(event.p1, event.p2, event.b, event.active)
+    this.container.updateScoreHud(
+      event.p1,
+      event.p2,
+      event.b,
+      event.active,
+      event.p1type
+    )
     return this
   }
 

--- a/src/controller/rules/eightball.ts
+++ b/src/controller/rules/eightball.ts
@@ -105,10 +105,16 @@ export class EightBall implements Rules {
 
   private isMyType(ball: Ball): boolean {
     const session = Session.getInstance()
-    if (session.p1type === 1) {
+    if (session.p1type === 0) {
+      return false
+    }
+    const activePlayer = this.container.inferActivePlayer()
+    const myType = activePlayer === 2 ? 3 - session.p1type : session.p1type
+
+    if (myType === 1) {
       return (ball.label || 0) >= 1 && (ball.label || 0) <= 7
     }
-    if (session.p1type === 2) {
+    if (myType === 2) {
       return (ball.label || 0) >= 9 && (ball.label || 0) <= 15
     }
     return false
@@ -215,7 +221,6 @@ export class EightBall implements Rules {
   }
 
   private handlePot(outcome: Outcome[]): Controller {
-    const session = Session.getInstance()
     const table = this.container.table
     const pots = Outcome.pots(outcome)
 
@@ -227,17 +232,9 @@ export class EightBall implements Rules {
       return this.respotEightBallFoul()
     }
 
-    if (session.p1type === 0) {
-      const solids = pots.filter((b) => b.label! >= 1 && b.label! <= 7)
-      const stripes = pots.filter((b) => b.label! >= 9 && b.label! <= 15)
+    this.assignGroupOnPot(pots)
 
-      if (solids.length > 0 && stripes.length === 0) {
-        session.p1type = 1
-      } else if (stripes.length > 0 && solids.length === 0) {
-        session.p1type = 2
-      }
-    }
-
+    const session = Session.getInstance()
     this.currentBreak += pots.length
     session.addMyScore(pots.length)
 
@@ -254,6 +251,21 @@ export class EightBall implements Rules {
 
     this.container.sendEvent(new WatchEvent(table.serialise()))
     return new Aim(this.container)
+  }
+
+  private assignGroupOnPot(pots: Ball[]): void {
+    const session = Session.getInstance()
+    if (session.p1type === 0) {
+      const solids = pots.filter((b) => b.label! >= 1 && b.label! <= 7)
+      const stripes = pots.filter((b) => b.label! >= 9 && b.label! <= 15)
+      const activePlayer = this.container.inferActivePlayer()
+
+      if (solids.length > 0 && stripes.length === 0) {
+        session.p1type = activePlayer === 2 ? 2 : 1
+      } else if (stripes.length > 0 && solids.length === 0) {
+        session.p1type = activePlayer === 2 ? 1 : 2
+      }
+    }
   }
 
   private respotEightBallFoul(): Controller {

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -177,7 +177,12 @@ export class Session {
     return names
   }
 
-  updateScoresFromNetwork(p1: number, p2: number, breakScore: number): void {
+  updateScoresFromNetwork(
+    p1: number,
+    p2: number,
+    breakScore: number,
+    p1type?: number
+  ): void {
     if (this.playerIndex === 1) {
       this.setMyScore(p2)
       this.setOpponentScore(p1)
@@ -186,5 +191,8 @@ export class Session {
       this.setOpponentScore(p2)
     }
     this.currentBreak = breakScore
+    if (p1type !== undefined) {
+      this.p1type = p1type
+    }
   }
 }

--- a/test/rules/eightball.spec.ts
+++ b/test/rules/eightball.spec.ts
@@ -63,30 +63,30 @@ describe("EightBall Rules", () => {
     )
   })
 
-  const testAssignment = (
+  const testShot = (
     ballLabel: number,
     activePlayer: number,
-    expectedP1Type: number
+    pot: boolean = true
   ) => {
     if (activePlayer === 2) {
       container.updateController(new WatchAim(container))
     }
     const ball = container.table.balls.find((b) => b.label === ballLabel)!
-    const outcome = [
-      Outcome.collision(container.table.cueball, ball, 1),
-      Outcome.pot(ball, 1),
-    ]
-    eightball.update(outcome)
-    expect(Session.getInstance().p1type).to.equal(expectedP1Type)
+    const outcome = [Outcome.collision(container.table.cueball, ball, 1)]
+    if (pot) {
+      outcome.push(Outcome.pot(ball, 1))
+    }
+    const nextController = eightball.update(outcome)
+    return { nextController, outcome }
   }
 
   it("should assign solids if only solids are potted", () => {
-    testAssignment(1, 1, 1) // P1 pots solid -> P1 type 1
+    testShot(1, 1) // P1 pots solid -> P1 type 1
     expect(Session.getInstance().p1type).to.equal(1)
   })
 
   it("should assign stripes if only stripes are potted", () => {
-    testAssignment(9, 1, 2) // P1 pots stripe -> P1 type 2
+    testShot(9, 1) // P1 pots stripe -> P1 type 2
     expect(Session.getInstance().p1type).to.equal(2)
   })
 
@@ -102,13 +102,20 @@ describe("EightBall Rules", () => {
     expect(Session.getInstance().p1type).to.equal(0)
   })
 
-  it("should foul if wrong group hit first after assignment", () => {
-    Session.getInstance().p1type = 1 // Solids
-    const ball9 = container.table.balls.find((b) => b.label === 9)!
-    const outcome = [Outcome.collision(container.table.cueball, ball9, 1)]
-    const nextController = eightball.update(outcome)
+  const testWrongGroupFoul = (activePlayer: number, wrongBallLabel: number) => {
+    Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
+    const { nextController, outcome } = testShot(
+      wrongBallLabel,
+      activePlayer,
+      false
+    )
     expect(nextController).to.be.an.instanceof(PlaceBall)
     expect(eightball.foulReason(outcome)).to.equal("Wrong group hit first")
+  }
+
+  it("should foul if wrong group hit first after assignment", () => {
+    testWrongGroupFoul(1, 9)
+    expect(Session.getInstance().p1type).to.equal(1)
   })
 
   it("should foul if no cushion hit and no pot", () => {
@@ -130,22 +137,21 @@ describe("EightBall Rules", () => {
     expect(eightBall.onTable()).to.be.true
   })
 
-  it("should win if 8-ball potted after clearing group", () => {
-    Session.getInstance().p1type = 1 // Solids
-    // Clear solids
+  const testWin = (activePlayer: number, groupRange: [number, number]) => {
+    Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
     container.table.balls.forEach((b) => {
-      if ((b.label || 0) >= 1 && (b.label || 0) <= 7) {
+      if ((b.label || 0) >= groupRange[0] && (b.label || 0) <= groupRange[1]) {
         b.state = State.InPocket
       }
     })
-    const eightBall = container.table.balls.find((b) => b.label === 8)!
-    const outcome = [
-      Outcome.collision(container.table.cueball, eightBall, 1),
-      Outcome.pot(eightBall, 1),
-    ]
+    const { nextController, outcome } = testShot(8, activePlayer)
     expect(eightball.isEndOfGame(outcome)).to.be.true
-    const nextController = eightball.update(outcome)
     expect(nextController).to.be.an.instanceof(End)
+  }
+
+  it("should win if 8-ball potted after clearing group", () => {
+    testWin(1, [1, 7])
+    expect(Session.getInstance().p1type).to.equal(1)
   })
 
   it("should lose if 8-ball potted on open table", () => {
@@ -222,57 +228,29 @@ describe("EightBall Rules", () => {
 
   describe("2-Player Rules", () => {
     it("should assign p1type=2 if Player 2 pots solids on open table", () => {
-      testAssignment(1, 2, 2) // P2 pots solid -> P1 type 2
+      testShot(1, 2) // P2 pots solid -> P1 type 2
       expect(Session.getInstance().p1type).to.equal(2)
     })
 
     it("should assign p1type=1 if Player 2 pots stripes on open table", () => {
-      testAssignment(9, 2, 1) // P2 pots stripe -> P1 type 1
+      testShot(9, 2) // P2 pots stripe -> P1 type 1
       expect(Session.getInstance().p1type).to.equal(1)
     })
 
     it("should foul if Player 2 hits wrong group", () => {
-      Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
-      container.updateController(new WatchAim(container))
-
-      const ball1 = container.table.balls.find((b) => b.label === 1)! // Solid
-      const outcome = [Outcome.collision(container.table.cueball, ball1, 1)]
-      const nextController = eightball.update(outcome)
-      expect(nextController).to.be.an.instanceof(PlaceBall)
-      expect(eightball.foulReason(outcome)).to.equal("Wrong group hit first")
+      testWrongGroupFoul(2, 1)
+      expect(Session.getInstance().p1type).to.equal(1)
     })
 
     it("should win if Player 2 pots 8-ball after clearing group", () => {
-      Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
-      // Clear Player 2's group (Stripes 9-15)
-      container.table.balls.forEach((b) => {
-        if ((b.label || 0) >= 9 && (b.label || 0) <= 15) {
-          b.state = State.InPocket
-        }
-      })
-      container.updateController(new WatchAim(container))
-
-      const eightBall = container.table.balls.find((b) => b.label === 8)!
-      const outcome = [
-        Outcome.collision(container.table.cueball, eightBall, 1),
-        Outcome.pot(eightBall, 1),
-      ]
-      expect(eightball.isEndOfGame(outcome)).to.be.true
-      const nextController = eightball.update(outcome)
-      expect(nextController).to.be.an.instanceof(End)
+      testWin(2, [9, 15])
+      expect(Session.getInstance().p1type).to.equal(1)
     })
 
     it("should lose if Player 2 pots 8-ball early", () => {
       Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
-      container.updateController(new WatchAim(container))
-
-      const eightBall = container.table.balls.find((b) => b.label === 8)!
-      const outcome = [
-        Outcome.collision(container.table.cueball, eightBall, 1),
-        Outcome.pot(eightBall, 1),
-      ]
+      const { nextController, outcome } = testShot(8, 2)
       expect(eightball.isEndOfGame(outcome)).to.be.false
-      const nextController = eightball.update(outcome)
       expect(nextController).to.be.an.instanceof(End)
     })
   })

--- a/test/rules/eightball.spec.ts
+++ b/test/rules/eightball.spec.ts
@@ -11,6 +11,7 @@ import { PlaceBall } from "../../src/controller/placeball"
 import { End } from "../../src/controller/end"
 import { Session } from "../../src/network/client/session"
 import { ScoreEvent } from "../../src/events/scoreevent"
+import { WatchAim } from "../../src/controller/watchaim"
 
 initDom()
 
@@ -210,5 +211,85 @@ describe("EightBall Rules", () => {
     })
     const candidate = eightball.nextCandidateBall()
     expect(candidate?.label).to.equal(8)
+  })
+
+  describe("2-Player Rules", () => {
+    it("should assign p1type=2 if Player 2 pots solids on open table", () => {
+      // Set Player 2 as active
+      container.updateController(new WatchAim(container))
+      expect(container.inferActivePlayer()).to.equal(2)
+
+      const ball1 = container.table.balls.find((b) => b.label === 1)!
+      const outcome = [
+        Outcome.collision(container.table.cueball, ball1, 1),
+        Outcome.pot(ball1, 1),
+      ]
+      eightball.update(outcome)
+      // If P2 pots solids, P1 is assigned stripes
+      expect(Session.getInstance().p1type).to.equal(2)
+    })
+
+    it("should assign p1type=1 if Player 2 pots stripes on open table", () => {
+      // Set Player 2 as active
+      container.updateController(new WatchAim(container))
+      expect(container.inferActivePlayer()).to.equal(2)
+
+      const ball9 = container.table.balls.find((b) => b.label === 9)!
+      const outcome = [
+        Outcome.collision(container.table.cueball, ball9, 1),
+        Outcome.pot(ball9, 1),
+      ]
+      eightball.update(outcome)
+      // If P2 pots stripes, P1 is assigned solids
+      expect(Session.getInstance().p1type).to.equal(1)
+    })
+
+    it("should foul if Player 2 hits wrong group", () => {
+      Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
+      // Set Player 2 as active
+      container.updateController(new WatchAim(container))
+
+      const ball1 = container.table.balls.find((b) => b.label === 1)! // Solid
+      const outcome = [Outcome.collision(container.table.cueball, ball1, 1)]
+      const nextController = eightball.update(outcome)
+      expect(nextController).to.be.an.instanceof(PlaceBall)
+      expect(eightball.foulReason(outcome)).to.equal("Wrong group hit first")
+    })
+
+    it("should win if Player 2 pots 8-ball after clearing group", () => {
+      Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
+      // Clear Player 2's group (Stripes 9-15)
+      container.table.balls.forEach((b) => {
+        if ((b.label || 0) >= 9 && (b.label || 0) <= 15) {
+          b.state = State.InPocket
+        }
+      })
+      // Set Player 2 as active
+      container.updateController(new WatchAim(container))
+
+      const eightBall = container.table.balls.find((b) => b.label === 8)!
+      const outcome = [
+        Outcome.collision(container.table.cueball, eightBall, 1),
+        Outcome.pot(eightBall, 1),
+      ]
+      expect(eightball.isEndOfGame(outcome)).to.be.true
+      const nextController = eightball.update(outcome)
+      expect(nextController).to.be.an.instanceof(End)
+    })
+
+    it("should lose if Player 2 pots 8-ball early", () => {
+      Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
+      // Set Player 2 as active
+      container.updateController(new WatchAim(container))
+
+      const eightBall = container.table.balls.find((b) => b.label === 8)!
+      const outcome = [
+        Outcome.collision(container.table.cueball, eightBall, 1),
+        Outcome.pot(eightBall, 1),
+      ]
+      expect(eightball.isEndOfGame(outcome)).to.be.false
+      const nextController = eightball.update(outcome)
+      expect(nextController).to.be.an.instanceof(End)
+    })
   })
 })

--- a/test/rules/eightball.spec.ts
+++ b/test/rules/eightball.spec.ts
@@ -63,24 +63,31 @@ describe("EightBall Rules", () => {
     )
   })
 
-  it("should assign solids if only solids are potted", () => {
-    const ball1 = container.table.balls.find((b) => b.label === 1)!
+  const testAssignment = (
+    ballLabel: number,
+    activePlayer: number,
+    expectedP1Type: number
+  ) => {
+    if (activePlayer === 2) {
+      container.updateController(new WatchAim(container))
+    }
+    const ball = container.table.balls.find((b) => b.label === ballLabel)!
     const outcome = [
-      Outcome.collision(container.table.cueball, ball1, 1),
-      Outcome.pot(ball1, 1),
+      Outcome.collision(container.table.cueball, ball, 1),
+      Outcome.pot(ball, 1),
     ]
     eightball.update(outcome)
-    expect(Session.getInstance().p1type).to.equal(1) // Solids
+    expect(Session.getInstance().p1type).to.equal(expectedP1Type)
+  }
+
+  it("should assign solids if only solids are potted", () => {
+    testAssignment(1, 1, 1) // P1 pots solid -> P1 type 1
+    expect(Session.getInstance().p1type).to.equal(1)
   })
 
   it("should assign stripes if only stripes are potted", () => {
-    const ball9 = container.table.balls.find((b) => b.label === 9)!
-    const outcome = [
-      Outcome.collision(container.table.cueball, ball9, 1),
-      Outcome.pot(ball9, 1),
-    ]
-    eightball.update(outcome)
-    expect(Session.getInstance().p1type).to.equal(2) // Stripes
+    testAssignment(9, 1, 2) // P1 pots stripe -> P1 type 2
+    expect(Session.getInstance().p1type).to.equal(2)
   })
 
   it("should remain open if both solid and stripe are potted", () => {
@@ -215,38 +222,17 @@ describe("EightBall Rules", () => {
 
   describe("2-Player Rules", () => {
     it("should assign p1type=2 if Player 2 pots solids on open table", () => {
-      // Set Player 2 as active
-      container.updateController(new WatchAim(container))
-      expect(container.inferActivePlayer()).to.equal(2)
-
-      const ball1 = container.table.balls.find((b) => b.label === 1)!
-      const outcome = [
-        Outcome.collision(container.table.cueball, ball1, 1),
-        Outcome.pot(ball1, 1),
-      ]
-      eightball.update(outcome)
-      // If P2 pots solids, P1 is assigned stripes
+      testAssignment(1, 2, 2) // P2 pots solid -> P1 type 2
       expect(Session.getInstance().p1type).to.equal(2)
     })
 
     it("should assign p1type=1 if Player 2 pots stripes on open table", () => {
-      // Set Player 2 as active
-      container.updateController(new WatchAim(container))
-      expect(container.inferActivePlayer()).to.equal(2)
-
-      const ball9 = container.table.balls.find((b) => b.label === 9)!
-      const outcome = [
-        Outcome.collision(container.table.cueball, ball9, 1),
-        Outcome.pot(ball9, 1),
-      ]
-      eightball.update(outcome)
-      // If P2 pots stripes, P1 is assigned solids
+      testAssignment(9, 2, 1) // P2 pots stripe -> P1 type 1
       expect(Session.getInstance().p1type).to.equal(1)
     })
 
     it("should foul if Player 2 hits wrong group", () => {
       Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
-      // Set Player 2 as active
       container.updateController(new WatchAim(container))
 
       const ball1 = container.table.balls.find((b) => b.label === 1)! // Solid
@@ -264,7 +250,6 @@ describe("EightBall Rules", () => {
           b.state = State.InPocket
         }
       })
-      // Set Player 2 as active
       container.updateController(new WatchAim(container))
 
       const eightBall = container.table.balls.find((b) => b.label === 8)!
@@ -279,7 +264,6 @@ describe("EightBall Rules", () => {
 
     it("should lose if Player 2 pots 8-ball early", () => {
       Session.getInstance().p1type = 1 // P1: Solids, P2: Stripes
-      // Set Player 2 as active
       container.updateController(new WatchAim(container))
 
       const eightBall = container.table.balls.find((b) => b.label === 8)!


### PR DESCRIPTION
This change fixes several issues with the Eight-Ball rules in multiplayer (2-player) mode. 

Previously, if the second player potted a ball on an open table, the group assignment logic incorrectly assigned the group to Player 1 instead of Player 2. Additionally, foul detection and win conditions were hardcoded to check against Player 1's group type, regardless of who was shooting.

Key improvements:
- **Correct Group Assignment:** `EightBall.handlePot` now uses `container.inferActivePlayer()` to determine which player made the pot and assigns `p1type` (the source of truth for Player 1's group) accordingly.
- **Dynamic Group Identification:** `EightBall.isMyType` now dynamically determines the active player's assigned group by comparing their slot against `p1type`.
- **State Synchronization:** `ScoreEvent` now carries `p1type`, and receiving clients update their local `Session` state, ensuring consistency in group assignments across the network.
- **Enhanced UI:** The HUD now labels both players with their assigned group (e.g., "Alice (solids) 0 - 0 Bob (stripes)") once the table is no longer open.
- **Comprehensive Testing:** Added new test cases in `test/rules/eightball.spec.ts` to verify Player 2's group assignment, foul logic, and win/loss conditions.

---
*PR created automatically by Jules for task [14516807050317247747](https://jules.google.com/task/14516807050317247747) started by @tailuge*