### PR TITLE
Pixel Ball Styling for Practice Mode

### DIFF
--- a/dist/practice.html
+++ b/dist/practice.html
@@ -5,7 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>9-Ball Layout Visualizer</title>
     <style>
-      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
       body {
         min-height: 100dvh;
@@ -40,10 +46,11 @@
       }
 
       :root {
+        --p: 1px;
         --bg-scale-x-landscape: 1.16;
-        --bg-scale-y-landscape: 1.30;
+        --bg-scale-y-landscape: 1.3;
         --bg-scale-x-portrait: 1.16;
-        --bg-scale-y-portrait: 1.30;
+        --bg-scale-y-portrait: 1.3;
         --table-height-portrait: 80vh;
         --table-width-landscape: 85%;
         --controls-gap: 30px;
@@ -56,7 +63,10 @@
         opacity: 0.75;
         z-index: 0;
         pointer-events: none;
-        transform: scale(var(--bg-scale-x-landscape), var(--bg-scale-y-landscape));
+        transform: scale(
+          var(--bg-scale-x-landscape),
+          var(--bg-scale-y-landscape)
+        );
       }
 
       @media (orientation: portrait) {
@@ -65,7 +75,8 @@
           height: 100cqw;
           top: 50%;
           left: 50%;
-          transform: translate(-50%, -50%) rotate(-90deg) scale(var(--bg-scale-x-portrait), var(--bg-scale-y-portrait));
+          transform: translate(-50%, -50%) rotate(-90deg)
+            scale(var(--bg-scale-x-portrait), var(--bg-scale-y-portrait));
         }
       }
 
@@ -80,31 +91,55 @@
 
       .ball {
         position: absolute;
-        border-radius: 50%;
-        cursor: grab;
         transform: translate(-50%, -50%);
-        filter: drop-shadow(2px 3px 1.5px rgba(0,0,0,1));
+        cursor: grab;
         user-select: none;
         touch-action: none;
         z-index: 10;
-        image-rendering: pixelated;
-        image-rendering: crisp-edges;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        filter: drop-shadow(
+          calc(var(--p) * 2) calc(var(--p) * 2) 0 rgba(0, 0, 0, 0.5)
+        );
+        will-change: left, top;
       }
+      .ball:active,
       .ball.dragging {
         cursor: grabbing;
-        filter: drop-shadow(4px 6px 12px rgba(0,0,0,0.95));
+      }
+      .ball.dragging {
         z-index: 100;
       }
-
-      .ball-label {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: 100;
-        pointer-events: none;
+      .ball-body {
+        width: 100%;
+        height: 100%;
         border-radius: 50%;
+        position: relative;
+        overflow: hidden;
+        box-shadow: inset calc(var(--p) * -1) calc(var(--p) * -1) 0
+          rgba(0, 0, 0, 0.3);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border: var(--p) solid #000;
+      }
+      /* Shine effect */
+      .ball-body::after {
+        content: "";
+        position: absolute;
+        top: 15%;
+        left: 15%;
+        width: 25%;
+        height: 25%;
+        background: rgba(255, 255, 255, 0.8);
+        border-radius: 50%;
+      }
+      .ball-label {
+        position: relative;
+        z-index: 1;
+        font-weight: bold;
+        pointer-events: none;
       }
 
       .controls {
@@ -123,11 +158,17 @@
         border-radius: 6px;
         cursor: pointer;
         font-weight: 600;
-        transition: transform 0.15s, box-shadow 0.15s;
+        transition:
+          transform 0.15s,
+          box-shadow 0.15s;
         flex-shrink: 0;
       }
-      button:hover  { transform: translateY(-2px); }
-      button:active { transform: translateY(0); }
+      button:hover {
+        transform: translateY(-2px);
+      }
+      button:active {
+        transform: translateY(0);
+      }
 
       .btn-preset {
         background: #1e1e1e;
@@ -136,19 +177,25 @@
         padding: 7px 13px;
         font-size: 11px;
         letter-spacing: 0.03em;
-        box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
       }
-      .btn-preset:hover { background: #2a2a2a; color: #eee; border-color: #555; }
+      .btn-preset:hover {
+        background: #2a2a2a;
+        color: #eee;
+        border-color: #555;
+      }
 
       .btn-play {
         background: linear-gradient(135deg, #10b981, #059669);
         color: #fff;
         padding: 8px 22px;
         font-size: 14px;
-        box-shadow: 0 4px 12px rgba(16,185,129,0.35);
+        box-shadow: 0 4px 12px rgba(16, 185, 129, 0.35);
         margin-left: auto;
       }
-      .btn-play:hover { box-shadow: 0 6px 18px rgba(16,185,129,0.5); }
+      .btn-play:hover {
+        box-shadow: 0 6px 18px rgba(16, 185, 129, 0.5);
+      }
     </style>
   </head>
   <body>
@@ -167,24 +214,34 @@
 
     <script>
       // ── Physics constants ──────────────────────────────────────
-      const R  = 0.03275
-      const HW = R * 43 + R   // half-width  (X)
-      const HH = R * 21 + R   // half-height (Y)
+      const R = 0.03275
+      const HW = R * 43 + R // half-width  (X)
+      const HH = R * 21 + R // half-height (Y)
 
       const BALL_COLORS = [
-        "#ffffff","#ffd700","#2563eb","#ef4444",
-        "#9333ea","#f97316","#16a34a","#991b1b","#111111","#fbbf24",
+        "#ffffff",
+        "#ffd700",
+        "#2563eb",
+        "#ef4444",
+        "#9333ea",
+        "#f97316",
+        "#16a34a",
+        "#991b1b",
+        "#111111",
+        "#fbbf24",
       ]
 
       // ── State ──────────────────────────────────────────────────
       let balls = []
-      let dragging = null   // { ball, startTableX, startTableY }
+      let dragging = null // { ball, startTableX, startTableY }
 
-      const wrap    = document.getElementById("table-wrap")
+      const wrap = document.getElementById("table-wrap")
       const surface = document.getElementById("table-surface")
 
       // ── Orientation ────────────────────────────────────────────
-      function portrait() { return window.innerHeight > window.innerWidth }
+      function portrait() {
+        return window.innerHeight > window.innerWidth
+      }
 
       function setAspectRatio() {
         if (portrait()) {
@@ -202,12 +259,12 @@
           // rotate 90°: table-x → screen-down, table-y → screen-left
           return {
             left: ((HH - ty) / (HH * 2)) * 100,
-            top:  ((tx + HW) / (HW * 2)) * 100,
+            top: ((tx + HW) / (HW * 2)) * 100,
           }
         }
         return {
           left: ((tx + HW) / (HW * 2)) * 100,
-          top:  ((ty + HH) / (HH * 2)) * 100,
+          top: ((ty + HH) / (HH * 2)) * 100,
         }
       }
 
@@ -217,12 +274,12 @@
         const px = clientX - r.left
         const py = clientY - r.top
         if (portrait()) {
-          const tx =  (py / r.height) * (HW * 2) - HW
-          const ty = -(px / r.width)  * (HH * 2) + HH
+          const tx = (py / r.height) * (HW * 2) - HW
+          const ty = -(px / r.width) * (HH * 2) + HH
           return { x: tx, y: ty }
         }
         return {
-          x: (px / r.width)  * (HW * 2) - HW,
+          x: (px / r.width) * (HW * 2) - HW,
           y: (py / r.height) * (HH * 2) - HH,
         }
       }
@@ -238,8 +295,9 @@
       function collides(ball, nx, ny) {
         for (const o of balls) {
           if (o === ball) continue
-          const dx = nx - o.x, dy = ny - o.y
-          if (dx*dx + dy*dy < (2*R)**2) return true
+          const dx = nx - o.x,
+            dy = ny - o.y
+          if (dx * dx + dy * dy < (2 * R) ** 2) return true
         }
         return false
       }
@@ -248,29 +306,28 @@
       function positionBall(ball) {
         const sz = ballPx()
         const { left, top } = tableToCSS(ball.x, ball.y)
-        ball.el.style.width    = sz + "px"
-        ball.el.style.height   = sz + "px"
-        ball.el.style.fontSize = (sz * 0.78) + "px"
-        ball.el.style.left     = left + "%"
-        ball.el.style.top      = top  + "%"
+        ball.el.style.width = sz + "px"
+        ball.el.style.height = sz + "px"
+        ball.el.style.fontSize = sz * 0.78 + "px"
+        ball.el.style.left = left + "%"
+        ball.el.style.top = top + "%"
       }
 
       function buildBall(ball) {
         const el = document.createElement("div")
         el.className = "ball"
-        const c = ball.color
-        el.style.background = [
-          `radial-gradient(circle at 62% 65%, rgba(52,211,153,0.22) 0%, transparent 55%)`,
-          `radial-gradient(circle at 35% 30%, rgba(255,255,255,0.85) 0%, rgba(255,255,255,0) 38%)`,
-          `radial-gradient(circle at 38% 35%, ${c} 0%, #000 100%)`,
-        ].join(", ")
+
+        const body = document.createElement("div")
+        body.className = "ball-body"
+        body.style.backgroundColor = ball.color
+        el.appendChild(body)
 
         if (ball.id !== 0) {
           const lbl = document.createElement("span")
           lbl.className = "ball-label"
           lbl.textContent = ball.id
           lbl.style.color = ball.id === 8 ? "#fff" : "#000"
-          el.appendChild(lbl)
+          body.appendChild(lbl)
         }
 
         surface.appendChild(el)
@@ -285,8 +342,9 @@
         // find closest ball within 2R
         for (let i = balls.length - 1; i >= 0; i--) {
           const b = balls[i]
-          const dx = pos.x - b.x, dy = pos.y - b.y
-          if (dx*dx + dy*dy < (2*R)**2) {
+          const dx = pos.x - b.x,
+            dy = pos.y - b.y
+          if (dx * dx + dy * dy < (2 * R) ** 2) {
             dragging = b
             b.el.classList.add("dragging")
             e.preventDefault()
@@ -300,11 +358,12 @@
         e.preventDefault()
         const touch = e.touches ? e.touches[0] : e
         const pos = clientToTable(touch.clientX, touch.clientY)
-        const nx = Math.max(-(HW-R), Math.min(HW-R, pos.x))
-        const ny = Math.max(-(HH-R), Math.min(HH-R, pos.y))
+        const nx = Math.max(-(HW - R), Math.min(HW - R, pos.x))
+        const ny = Math.max(-(HH - R), Math.min(HH - R, pos.y))
 
         if (!collides(dragging, nx, ny)) {
-          dragging.x = nx; dragging.y = ny
+          dragging.x = nx
+          dragging.y = ny
         } else {
           if (!collides(dragging, nx, dragging.y)) dragging.x = nx
           if (!collides(dragging, dragging.x, ny)) dragging.y = ny
@@ -314,16 +373,37 @@
       }
 
       function pointerUp() {
-        if (dragging) { dragging.el.classList.remove("dragging"); dragging = null }
+        if (dragging) {
+          dragging.el.classList.remove("dragging")
+          dragging = null
+        }
       }
 
       // ── Presets ────────────────────────────────────────────────
       const PRESETS = {
-        scattered: () => [-0.6004, -0.1078, -1, -0.3, -0.5, 0.4, 0.2, -0.5, 0.7, 0.2, -0.8, 0.5, 0.4, -0.2, -0.3, 0, 1, 0.4, -0.6, -0.5],
-        grid: () => [0.0056, -0.0037, 1.0837, 0.3792, 1.0726, -0.3829, 0.7231, -0.3829, 0.7268, 0.3755, 0.3699, 0.3755, 1.08, -0.0037, 0.3699, -0.3829, 0.7231, -0.0037, 0.3551, -0.0037],
-        line: () => [-0.7175, 0, -0.3297, 0, -0.1594, 0, 0.0109, 0, 0.1812, 0, 0.3515, 0, 0.5218, 0, 0.6921, 0, 0.8624, 0, 1.0327, 0],
-        corners: () => [-0.725, 0, -0.0056, -0.6764, 1.3661, -0.6615, 1.2841, 0.5718, 0.0019, 0.6652, -1.3549, 0.6503, -1.2804, -0.5792, -1.34, -0.6316, 1.3437, 0.6278, 0.0019, 0],
-        cluster: () => [-0.1617, 0.171, 0.3922, 0.2417, 0.4815, 0.0632, 0.6227, 0.0558, 0.6488, -0.0112, 0.619, -0.0855, 0.5521, 0.0892, 0.5447, -0.1041, 0.4629, -0.0706, 0.4406, 0],
+        scattered: () => [
+          -0.6004, -0.1078, -1, -0.3, -0.5, 0.4, 0.2, -0.5, 0.7, 0.2, -0.8, 0.5,
+          0.4, -0.2, -0.3, 0, 1, 0.4, -0.6, -0.5,
+        ],
+        grid: () => [
+          0.0056, -0.0037, 1.0837, 0.3792, 1.0726, -0.3829, 0.7231, -0.3829,
+          0.7268, 0.3755, 0.3699, 0.3755, 1.08, -0.0037, 0.3699, -0.3829,
+          0.7231, -0.0037, 0.3551, -0.0037,
+        ],
+        line: () => [
+          -0.7175, 0, -0.3297, 0, -0.1594, 0, 0.0109, 0, 0.1812, 0, 0.3515, 0,
+          0.5218, 0, 0.6921, 0, 0.8624, 0, 1.0327, 0,
+        ],
+        corners: () => [
+          -0.725, 0, -0.0056, -0.6764, 1.3661, -0.6615, 1.2841, 0.5718, 0.0019,
+          0.6652, -1.3549, 0.6503, -1.2804, -0.5792, -1.34, -0.6316, 1.3437,
+          0.6278, 0.0019, 0,
+        ],
+        cluster: () => [
+          -0.1617, 0.171, 0.3922, 0.2417, 0.4815, 0.0632, 0.6227, 0.0558,
+          0.6488, -0.0112, 0.619, -0.0855, 0.5521, 0.0892, 0.5447, -0.1041,
+          0.4629, -0.0706, 0.4406, 0,
+        ],
       }
 
       function applyPreset(name) {
@@ -340,7 +420,9 @@
 
       // ── Coords ─────────────────────────────────────────────────
       function logCoords() {
-        console.log(`[${balls.flatMap(b => [+b.x.toFixed(4), +b.y.toFixed(4)]).join(", ")}]`)
+        console.log(
+          `[${balls.flatMap((b) => [+b.x.toFixed(4), +b.y.toFixed(4)]).join(", ")}]`
+        )
       }
 
       // ── Init ───────────────────────────────────────────────────
@@ -354,12 +436,12 @@
       }
 
       // ── Events ─────────────────────────────────────────────────
-      surface.addEventListener("mousedown",  pointerDown)
+      surface.addEventListener("mousedown", pointerDown)
       surface.addEventListener("touchstart", pointerDown, { passive: false })
-      window.addEventListener("mousemove",   pointerMove)
-      window.addEventListener("touchmove",   pointerMove, { passive: false })
-      window.addEventListener("mouseup",     pointerUp)
-      window.addEventListener("touchend",    pointerUp)
+      window.addEventListener("mousemove", pointerMove)
+      window.addEventListener("touchmove", pointerMove, { passive: false })
+      window.addEventListener("mouseup", pointerUp)
+      window.addEventListener("touchend", pointerUp)
 
       window.addEventListener("resize", () => {
         setAspectRatio()
@@ -367,11 +449,14 @@
       })
 
       document.getElementById("playBtn").addEventListener("click", () => {
-        const coords = balls.flatMap(b => [+b.x.toFixed(4), +(-b.y).toFixed(4)])
+        const coords = balls.flatMap((b) => [
+          +b.x.toFixed(4),
+          +(-b.y).toFixed(4),
+        ])
         window.location.href = `./index.html?practice=true&init=${encodeURIComponent(JSON.stringify(coords))}`
       })
 
-      document.querySelectorAll(".btn-preset").forEach(btn => {
+      document.querySelectorAll(".btn-preset").forEach((btn) => {
         btn.addEventListener("click", () => applyPreset(btn.dataset.preset))
       })
 


### PR DESCRIPTION
Applied the requested "Pixel Ball Styling" to the 9-ball layout visualizer in `practice.html`. This involved a CSS overhaul to use a 1px base unit for borders and shadows, and a JavaScript update to create a nested DOM structure (`.ball > .ball-body > .ball-label`) that supports the new aesthetic. Verified the visual changes with a screenshot.

---
*PR created automatically by Jules for task [17168863127893007452](https://jules.google.com/task/17168863127893007452) started by @tailuge*