### PR TITLE
Enable early 9-ball wins in practice mode

### DIFF
--- a/src/controller/rules/nineball.ts
+++ b/src/controller/rules/nineball.ts
@@ -128,11 +128,6 @@ export class NineBall implements Rules {
       return this.handleGameEnd(true)
     }
 
-    if (Session.isPracticeMode()) {
-      if (Outcome.pots(outcome).includes(table.balls[9])) {
-        this.respotAndBroadcastNineBall()
-      }
-    }
 
     this.container.sendEvent(new WatchEvent(table.serialise()))
     return new Aim(this.container)
@@ -168,10 +163,6 @@ export class NineBall implements Rules {
     const nineBallPotted = Outcome.pots(outcome).includes(nineBall)
     if (!nineBallPotted || this.isFoul(outcome)) {
       return false
-    }
-
-    if (Session.isPracticeMode()) {
-      return !NineBall.hasOtherObjectBalls(this.container.table)
     }
 
     return true

--- a/test/rules/nineball.spec.ts
+++ b/test/rules/nineball.spec.ts
@@ -302,7 +302,7 @@ describe("NineBall Rules", () => {
       )
     })
 
-    it("should respot 9-ball if potted early on a legal shot", () => {
+    it("should end game if 9-ball is potted early on a legal shot", () => {
       const ball1 = container.table.balls.find((b) => b.label === 1)!
       const nineBall = container.table.balls.find((b) => b.label === 9)!
       const outcome = [
@@ -310,12 +310,8 @@ describe("NineBall Rules", () => {
         Outcome.pot(nineBall, 1),
       ]
 
-      const sentEvents: any[] = []
-      container.broadcast = (event) => sentEvents.push(event)
-
-      expect(nineball.update(outcome)).to.be.an.instanceof(Aim)
-      expect(nineBall.state).to.equal(State.Stationary)
-      verifyRerackEvent(sentEvents, nineBall.id)
+      const nextController = nineball.update(outcome)
+      expect(nextController).to.be.an.instanceof(End)
     })
 
     it("should end game if 9-ball is potted last", () => {


### PR DESCRIPTION
This change updates the Nine-Ball rules to allow immediate wins in practice mode when the 9-ball is pocketed legally, matching the behavior of competitive play. Previously, practice mode had a special condition that required all other object balls to be cleared first, which led to the 9-ball being respotted if pocketed early.

Technical details:
- `NineBall.isEndOfGame` now returns `true` for any legal 9-ball pot regardless of the session mode.
- `NineBall.handlePot` no longer contains a special branch for respotting the 9-ball in practice mode.
- Test cases in `test/rules/nineball.spec.ts` were updated to assert that an `End` state is reached upon an early 9-ball pot in practice mode.

---
*PR created automatically by Jules for task [18230938090134155583](https://jules.google.com/task/18230938090134155583) started by @tailuge*