### PR TITLE
Improve ScoreReporter error logging

### DIFF
--- a/src/controller/rules/nineball.ts
+++ b/src/controller/rules/nineball.ts
@@ -161,11 +161,7 @@ export class NineBall implements Rules {
   isEndOfGame(outcome: Outcome[]): boolean {
     const nineBall = this.container.table.balls[9]
     const nineBallPotted = Outcome.pots(outcome).includes(nineBall)
-    if (!nineBallPotted || this.isFoul(outcome)) {
-      return false
-    }
-
-    return true
+    return nineBallPotted && !this.isFoul(outcome)
   }
 
   otherPlayersCueBall(): Ball {

--- a/src/network/client/scorereporter.ts
+++ b/src/network/client/scorereporter.ts
@@ -34,8 +34,8 @@ export class ScoreReporter {
         let errorBody = "Could not read response body"
         try {
           errorBody = await response.text()
-        } catch (e) {
-          // ignore
+        } catch {
+          errorBody = `Could not read response body (status: ${status})`
         }
         console.error(
           "Failed to submit match result:",

--- a/src/network/client/scorereporter.ts
+++ b/src/network/client/scorereporter.ts
@@ -30,12 +30,17 @@ export class ScoreReporter {
       if (response.ok) {
         console.log("Match result submitted successfully:", result)
       } else {
-        // Log the full response for better debugging
-        const errorBody = await response.text()
+        const { status, statusText } = response
+        let errorBody = "Could not read response body"
+        try {
+          errorBody = await response.text()
+        } catch (e) {
+          // ignore
+        }
         console.error(
           "Failed to submit match result:",
-          response.status,
-          response.statusText,
+          status,
+          statusText,
           errorBody
         )
       }

--- a/test/network/client/scorereporter.spec.ts
+++ b/test/network/client/scorereporter.spec.ts
@@ -102,7 +102,7 @@ describe("ScoreReporter", () => {
       "Failed to submit match result:",
       500,
       "Internal Server Error",
-      "Could not read response body"
+      "Could not read response body (status: 500)"
     )
   })
 

--- a/test/network/client/scorereporter.spec.ts
+++ b/test/network/client/scorereporter.spec.ts
@@ -88,6 +88,24 @@ describe("ScoreReporter", () => {
     )
   })
 
+  it("should log status code even if text() fails", async () => {
+    const reporter = new ScoreReporter()
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      text: () => Promise.reject(new Error("Body read error")),
+    })
+    await reporter.submitMatchResult(sampleMatchResult)
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to submit match result:",
+      500,
+      "Internal Server Error",
+      "Could not read response body"
+    )
+  })
+
   it("should log an error for a fetch network error", async () => {
     const reporter = new ScoreReporter()
     const networkError = new Error("Network is down")


### PR DESCRIPTION
The `ScoreReporter` was updated to capture `status` and `statusText` from the fetch response object immediately after the `ok` check. The call to `response.text()` is now wrapped in a `try-catch` block, preventing it from throwing and skipping the `console.error` log. This ensures that the actual HTTP status code is reported even if the response body cannot be read.

Additionally, a unit test was added to simulate a failed response with an unreadable body, confirming that the status code is still correctly logged.

---
*PR created automatically by Jules for task [14503976776009877022](https://jules.google.com/task/14503976776009877022) started by @tailuge*