### PR TITLE
Update sitemap.xml

### DIFF
--- a/dist/sitemap.xml
+++ b/dist/sitemap.xml
@@ -2,25 +2,43 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://tailuge.github.io/billiards/dist/</loc>
-    <lastmod>2026-02-03</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://tailuge.github.io/billiards/dist/practice.html</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://tailuge.github.io/billiards/dist/2p.html</loc>
-    <lastmod>2026-02-03</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://tailuge.github.io/billiards/dist/multi.html</loc>
-    <lastmod>2026-02-03</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://tailuge.github.io/billiards/dist/blog1.html</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://tailuge.github.io/billiards/dist/blog2.html</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://tailuge.github.io/billiards/dist/embed.html</loc>
-    <lastmod>2026-02-03</lastmod>
+    <lastmod>2026-04-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
Updated `dist/sitemap.xml` to include the new `practice.html`, `blog1.html`, and `blog2.html` pages. Also updated the `lastmod` date for all sitemap entries to `2026-04-23`. Verified the XML structure and ensured no regressions were introduced by running `yarn lint` and `yarn test`.

---
*PR created automatically by Jules for task [18268028124786454915](https://jules.google.com/task/18268028124786454915) started by @tailuge*