### PR TITLE
Fix practice.html layout for mobile viewports

### DIFF
--- a/dist/practice.html
+++ b/dist/practice.html
@@ -102,13 +102,18 @@
         max-width: 920px;
         container-type: size;
         margin: auto;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       /* portrait: constrain height so it fits viewport minus controls */
       @media (orientation: portrait) {
         #table-wrap {
           max-width: 90%;
-          height: var(--table-height-portrait);
+          height: 100%;
           width: auto;
           /* height drives layout; width is derived from aspect-ratio */
         }
@@ -119,7 +124,7 @@
         --bg-scale-y-landscape: 1.3;
         --bg-scale-x-portrait: 1.16;
         --bg-scale-y-portrait: 1.3;
-        --table-height-portrait: 80vh;
+        --table-height-portrait: 70dvh;
         --table-width-landscape: 85%;
         --controls-gap: 30px;
         --p: 2px;
@@ -142,6 +147,8 @@
         #table-bg {
           width: 100cqh;
           height: 100cqw;
+          max-width: 100cqh;
+          max-height: 100cqw;
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%) rotate(-90deg)

--- a/dist/practice2.html
+++ b/dist/practice2.html
@@ -102,13 +102,18 @@
         max-width: 920px;
         container-type: size;
         margin: auto;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       /* portrait: constrain height so it fits viewport minus controls */
       @media (orientation: portrait) {
         #table-wrap {
           max-width: 90%;
-          height: var(--table-height-portrait);
+          height: 100%;
           width: auto;
           /* height drives layout; width is derived from aspect-ratio */
         }
@@ -119,7 +124,7 @@
         --bg-scale-y-landscape: 1.3;
         --bg-scale-x-portrait: 1.16;
         --bg-scale-y-portrait: 1.3;
-        --table-height-portrait: 80vh;
+        --table-height-portrait: 70dvh;
         --table-width-landscape: 85%;
         --controls-gap: 30px;
         --p: 2px;
@@ -142,6 +147,8 @@
         #table-bg {
           width: 100cqh;
           height: 100cqw;
+          max-width: 100cqh;
+          max-height: 100cqw;
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%) rotate(-90deg)


### PR DESCRIPTION
This change applies recommended CSS fixes to `dist/practice.html` to resolve layout issues on mobile browsers, particularly the discrepancy between Chrome and Firefox regarding viewport height calculation.

Key changes:
1.  **Updated CSS Variables**: Changed `--table-height-portrait` from `80vh` to `70dvh` to account for dynamic browser UI elements.
2.  **Flexbox Layout**: Refactored `#table-wrap` to use `flex: 1` and `display: flex`. This allows the table to occupy the available space between the header/padding and the controls, ensuring that buttons aren't pushed off-screen.
3.  **Portrait Scaling**: Updated the portrait media query for `#table-wrap` to use `height: 100%` so it fills the flex container.
4.  **Background Containment**: Added `max-width: 100cqh` and `max-height: 100cqw` to `#table-bg` in portrait mode to ensure the rotated background stays within its parent's boundaries.

These changes ensure a consistent and centered layout across different mobile browser engines.

---
*PR created automatically by Jules for task [16192099487063137017](https://jules.google.com/task/16192099487063137017) started by @tailuge*