### PR TITLE
Update practice.html with mobile layout fixes

### DIFF
--- a/dist/practice.html
+++ b/dist/practice.html
@@ -102,13 +102,18 @@
         max-width: 920px;
         container-type: size;
         margin: auto;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
 
       /* portrait: constrain height so it fits viewport minus controls */
       @media (orientation: portrait) {
         #table-wrap {
           max-width: 90%;
-          height: var(--table-height-portrait);
+          height: 100%;
           width: auto;
           /* height drives layout; width is derived from aspect-ratio */
         }
@@ -119,7 +124,7 @@
         --bg-scale-y-landscape: 1.3;
         --bg-scale-x-portrait: 1.16;
         --bg-scale-y-portrait: 1.3;
-        --table-height-portrait: 80vh;
+        --table-height-portrait: 70dvh;
         --table-width-landscape: 85%;
         --controls-gap: 30px;
         --p: 2px;
@@ -142,6 +147,8 @@
         #table-bg {
           width: 100cqh;
           height: 100cqw;
+          max-width: 100cqh;
+          max-height: 100cqw;
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%) rotate(-90deg)


### PR DESCRIPTION
The `dist/practice.html` file has been updated with improvements from `dist/practice2.html`. These changes focus on mobile responsiveness by implementing a Flexbox-driven layout and using `dvh` (Dynamic Viewport Height) units for the table container. This ensures a consistent experience across different mobile browsers. Visual verification was performed using Playwright in both portrait and landscape orientations.

---
*PR created automatically by Jules for task [9160610677266664302](https://jules.google.com/task/9160610677266664302) started by @tailuge*