### PR TITLE
Add force diagram and improve equation display in blog3

### DIFF
--- a/dist/blog2.html
+++ b/dist/blog2.html
@@ -243,7 +243,10 @@
       </p>
 
       <figure style="margin: 32px 0">
-        <a href="https://scoreboard-tailuge.vercel.app/api/replay/482" style="display: block">
+        <a
+          href="https://scoreboard-tailuge.vercel.app/api/replay/482"
+          style="display: block"
+        >
           <img
             src="./images/celebrate.jpg"
             alt="Cleared the line up"
@@ -258,8 +261,6 @@
           />
         </a>
       </figure>
-
-      
 
       <nav
         class="back"

--- a/dist/blog3.html
+++ b/dist/blog3.html
@@ -167,6 +167,12 @@
       .equation-block {
         margin: 24px 0;
         overflow-x: auto;
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+      }
+
+      .equation-block::-webkit-scrollbar {
+        display: none;
       }
 
       .cta {
@@ -280,6 +286,22 @@
         the collision into compression and restitution phases, accounting for
         slip velocities at both the cushion and table contact points.
       </p>
+
+      <figure>
+        <img
+          src="./images/mh.jpg"
+          alt="Forces on ball at cushion"
+          loading="lazy"
+        />
+        <figcaption>
+          Forces on ball at cushion. (Source:
+          <a
+            href="https://billiards.colostate.edu/physics_articles/Mathavan_IMechE_2010.pdf"
+            rel="noopener noreferrer"
+            >Mathavan et al. (2010)</a
+          >)
+        </figcaption>
+      </figure>
 
       <h2>The Mathavan Model</h2>
 


### PR DESCRIPTION
This PR adds a diagram showing the forces on a ball at a cushion to the "Implementing Mathavan Cushion Physics" blog post (`blog3.html`). The image is placed early in the article for context and includes a caption with a direct link to the referenced scientific paper. Additionally, the CSS for equation blocks has been updated to hide horizontal scrollbars (while remaining scrollable on touch/wheel), providing a cleaner reading experience. Project linters and tests were run to ensure consistency and quality.

---
*PR created automatically by Jules for task [18181100002036493672](https://jules.google.com/task/18181100002036493672) started by @tailuge*