### PR TITLE
Fix legacy Safari and iPhone compatibility

### DIFF
--- a/dist/css/.stylelintrc.json
+++ b/dist/css/.stylelintrc.json
@@ -3,6 +3,11 @@
   "rules": {
     "selector-id-pattern": null,
     "selector-class-pattern": null,
-    "keyframes-name-pattern": null
+    "keyframes-name-pattern": null,
+    "color-function-notation": null,
+    "alpha-value-notation": null,
+    "color-function-alias-notation": null,
+    "declaration-block-no-duplicate-custom-properties": null,
+    "declaration-block-no-duplicate-properties": null
   }
 }

--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -100,6 +100,7 @@ canvas {
   align-items: flex-end;
   gap: 0;
   padding: 0;
+  background: linear-gradient(rgb(0, 64, 94), #000214);
   background: linear-gradient(rgb(0 64 94), #000214);
   border-radius: 0;
   border-top: 1px solid #2d1e16;
@@ -108,6 +109,7 @@ canvas {
 
 .toggleButton {
   height: 100%;
+  width: 28px;
   width: 20%;
   margin-right: 4px;
   aspect-ratio: 0.4;
@@ -124,9 +126,11 @@ canvas {
 
 a.pill {
   outline: none;
+  background: rgba(0, 0, 0, 0.4);
   background: rgb(0 0 0 / 40%);
   border-radius: 8px;
   text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border: 1px solid rgb(255 255 255 / 15%);
   margin: 0;
   padding: 0 8px;
@@ -171,7 +175,9 @@ label {
   width: 320px;
   min-height: 30px;
   max-height: 400px;
+  background: rgba(0, 0, 0, 0.4);
   background: rgb(0 0 0 / 40%);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border: 1px solid rgb(255 255 255 / 15%);
   border-radius: 8px;
   padding: 0 8px;

--- a/dist/css/notification.css
+++ b/dist/css/notification.css
@@ -21,20 +21,35 @@
   /* Neutrals & Opacity Layers */
   --notification-white: #fff;
   --notification-black: #000;
+  --notification-white-10: rgba(255, 255, 255, 0.1);
   --notification-white-10: rgb(255 255 255 / 10%);
+  --notification-white-15: rgba(255, 255, 255, 0.15);
   --notification-white-15: rgb(255 255 255 / 15%);
+  --notification-white-20: rgba(255, 255, 255, 0.2);
   --notification-white-20: rgb(255 255 255 / 20%);
+  --notification-white-25: rgba(255, 255, 255, 0.25);
   --notification-white-25: rgb(255 255 255 / 25%);
+  --notification-white-30: rgba(255, 255, 255, 0.3);
   --notification-white-30: rgb(255 255 255 / 30%);
+  --notification-white-40: rgba(255, 255, 255, 0.4);
   --notification-white-40: rgb(255 255 255 / 40%);
+  --notification-white-50: rgba(255, 255, 255, 0.5);
   --notification-white-50: rgb(255 255 255 / 50%);
+  --notification-white-60: rgba(255, 255, 255, 0.6);
   --notification-white-60: rgb(255 255 255 / 60%);
+  --notification-white-90: rgba(255, 255, 255, 0.9);
   --notification-white-90: rgb(255 255 255 / 90%);
+  --notification-black-05: rgba(0, 0, 0, 0.05);
   --notification-black-05: rgb(0 0 0 / 5%);
+  --notification-black-10: rgba(0, 0, 0, 0.1);
   --notification-black-10: rgb(0 0 0 / 10%);
+  --notification-black-15: rgba(0, 0, 0, 0.15);
   --notification-black-15: rgb(0 0 0 / 15%);
+  --notification-black-20: rgba(0, 0, 0, 0.2);
   --notification-black-20: rgb(0 0 0 / 20%);
+  --notification-black-30: rgba(0, 0, 0, 0.3);
   --notification-black-30: rgb(0 0 0 / 30%);
+  --notification-black-40: rgba(0, 0, 0, 0.4);
   --notification-black-40: rgb(0 0 0 / 40%);
 
   /* --- Spacing (4px based) --- */
@@ -237,6 +252,7 @@
   padding: var(--notification-space-2) var(--notification-space-4)
     var(--notification-space-3);
   border-top: 1px solid var(--notification-score-border);
+  background: rgba(0, 0, 0, 0.09);
   background: rgb(0 0 0 / 9%);
 }
 
@@ -278,6 +294,7 @@
   --notification-text-clr-sub: var(--notification-text-clr-inv);
   --notification-score-bg: var(--notification-black-05);
   --notification-score-border: var(--notification-black-10);
+  --notification-score-label-clr: rgba(0, 0, 0, 0.5);
   --notification-score-label-clr: rgb(0 0 0 / 50%);
   --notification-score-value-clr: var(--notification-text-clr-inv);
 }
@@ -295,6 +312,7 @@
   --notification-text-clr-sub: var(--notification-text-clr-inv);
   --notification-score-bg: var(--notification-black-05);
   --notification-score-border: var(--notification-black-10);
+  --notification-score-label-clr: rgba(0, 0, 0, 0.5);
   --notification-score-label-clr: rgb(0 0 0 / 50%);
   --notification-score-value-clr: var(--notification-text-clr-inv);
 }

--- a/dist/css/tray.css
+++ b/dist/css/tray.css
@@ -8,8 +8,10 @@
   height: 30px;
   display: flex;
   align-items: center;
+  background: rgba(0, 0, 0, 0.4);
   background: rgb(0 0 0 / 40%);
   border-radius: 0 0 8px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
   border: 1px solid rgb(255 255 255 / 15%);
   border-top: none;
   z-index: 1500;
@@ -30,6 +32,7 @@
   letter-spacing: 0.5px;
   line-height: 1.2;
   color: white;
+  text-shadow: 1px 1px 0 rgb(0, 0, 0, 1);
   text-shadow: 1px 1px 0 rgb(0 0 0 / 100%);
   padding-top: 2px;
   pointer-events: none;
@@ -75,6 +78,7 @@
 .break-group {
   display: flex;
   align-items: center;
+  background: rgba(255, 255, 255, 0.1);
   background: rgb(255 255 255 / 10%);
   padding: 0 3px;
   border-radius: 12px;
@@ -89,6 +93,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+  color: rgba(255, 255, 255, 0.5);
   color: rgb(255 255 255 / 50%);
   font-size: 12px;
   transition:
@@ -97,10 +102,12 @@
   user-select: none;
   z-index: 10;
   opacity: 0;
+  background: rgba(255, 255, 255, 0.05);
   background: rgb(255 255 255 / 5%);
 }
 
 .nav-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
   background: rgb(255 255 255 / 20%);
   color: white;
 }

--- a/dist/practice.html
+++ b/dist/practice.html
@@ -80,6 +80,7 @@
       }
 
       body {
+        min-height: 100vh;
         min-height: 100dvh;
         background: #0d0d0d;
         display: flex;
@@ -121,6 +122,7 @@
         --bg-scale-y-landscape: 1.3;
         --bg-scale-x-portrait: 1.16;
         --bg-scale-y-portrait: 1.3;
+        --table-height-portrait: 70vh;
         --table-height-portrait: 70dvh;
         --table-width-landscape: 85%;
         --controls-gap: 30px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
             },
           },
         },
-        exclude: /node_modules\/(?!(@tailuge\/messaging))/,
+        exclude: /node_modules\/(?!(three|@tailuge\/messaging))/,
       },
     ],
   },


### PR DESCRIPTION
Restored functionality for older iPhones (targeting iOS 12+ Safari) by addressing both JavaScript and CSS compatibility issues.

Key changes:
1. Updated `webpack.config.js` to include `three` in the transpilation process via `swc-loader`. This removes modern syntax features like optional chaining and nullish coalescing that cause syntax errors in Safari < 13.1.
2. Added CSS fallbacks across `index.css`, `tray.css`, `notification.css`, and `practice.html`:
   - Provided `rgba(r, g, b, a)` fallbacks for modern `rgb(r g b / a)` syntax.
   - Provided `vh` fallbacks for `dvh` units.
   - Added explicit `width` fallbacks for `aspect-ratio`.
3. Adjusted Stylelint configuration in `dist/css/.stylelintrc.json` to allow the intentional use of legacy syntax and duplicate properties required for these fallbacks.
4. Verified that `dist/index.js` no longer contains untranspiled modern JS features.
5. Confirmed visual layout remains correct on modern browsers via Playwright screenshots.

---
*PR created automatically by Jules for task [5536563357272959526](https://jules.google.com/task/5536563357272959526) started by @tailuge*