### PR TITLE
Fix legacy Safari layout in practice2.html

### DIFF
--- a/dist/blog1.html
+++ b/dist/blog1.html
@@ -270,7 +270,9 @@
       <a href="./index.html">Play</a>
       <a href="./practice.html">Practice</a>
       <a href="https://scoreboard-tailuge.vercel.app/game">Lobby</a>
-      <a href="https://scoreboard-tailuge.vercel.app/leaderboard">Leaderboard</a>
+      <a href="https://scoreboard-tailuge.vercel.app/leaderboard"
+        >Leaderboard</a
+      >
       <a href="https://github.com/tailuge/billiards">GitHub</a>
       <a href="./blog2.html">Blog: Line Up</a>
       <a href="./blog3.html">Blog: Cushion Physics</a>

--- a/dist/blog2.html
+++ b/dist/blog2.html
@@ -194,7 +194,9 @@
       <a href="./index.html">Play</a>
       <a href="./practice.html">Practice</a>
       <a href="https://scoreboard-tailuge.vercel.app/game">Lobby</a>
-      <a href="https://scoreboard-tailuge.vercel.app/leaderboard">Leaderboard</a>
+      <a href="https://scoreboard-tailuge.vercel.app/leaderboard"
+        >Leaderboard</a
+      >
       <a href="https://github.com/tailuge/billiards">GitHub</a>
       <a href="./blog1.html">Blog: Cushion Physics</a>
       <a href="./blog3.html">Blog: Mathavan</a>

--- a/dist/blog3.html
+++ b/dist/blog3.html
@@ -245,9 +245,19 @@
     <nav class="back" aria-label="Top navigation">
       <a href="./index.html">Play</a>
       <a href="./practice.html">Practice</a>
-      <a href="https://scoreboard-tailuge.vercel.app/game" rel="noopener noreferrer">Lobby</a>
-      <a href="https://scoreboard-tailuge.vercel.app/leaderboard" rel="noopener noreferrer">Leaderboard</a>
-      <a href="https://github.com/tailuge/billiards" rel="noopener noreferrer">GitHub</a>
+      <a
+        href="https://scoreboard-tailuge.vercel.app/game"
+        rel="noopener noreferrer"
+        >Lobby</a
+      >
+      <a
+        href="https://scoreboard-tailuge.vercel.app/leaderboard"
+        rel="noopener noreferrer"
+        >Leaderboard</a
+      >
+      <a href="https://github.com/tailuge/billiards" rel="noopener noreferrer"
+        >GitHub</a
+      >
       <a href="./blog1.html">Blog: Cushion Physics</a>
       <a href="./blog2.html">Blog: Line Up</a>
     </nav>
@@ -425,9 +435,19 @@
       <nav class="back back-bottom" aria-label="Bottom navigation">
         <a href="./index.html">Play</a>
         <a href="./practice.html">Practice</a>
-        <a href="https://scoreboard-tailuge.vercel.app/game" rel="noopener noreferrer">Lobby</a>
-        <a href="https://scoreboard-tailuge.vercel.app/leaderboard" rel="noopener noreferrer">Leaderboard</a>
-        <a href="https://github.com/tailuge/billiards" rel="noopener noreferrer">GitHub</a>
+        <a
+          href="https://scoreboard-tailuge.vercel.app/game"
+          rel="noopener noreferrer"
+          >Lobby</a
+        >
+        <a
+          href="https://scoreboard-tailuge.vercel.app/leaderboard"
+          rel="noopener noreferrer"
+          >Leaderboard</a
+        >
+        <a href="https://github.com/tailuge/billiards" rel="noopener noreferrer"
+          >GitHub</a
+        >
         <a href="./blog1.html">Blog: Cushion Physics</a>
         <a href="./blog2.html">Blog: Line Up</a>
       </nav>

--- a/dist/practice.html
+++ b/dist/practice.html
@@ -297,7 +297,7 @@
     </style>
   </head>
   <body>
-  <h1 hidden>Free Pool, Billiards and Snooker</h1>
+    <h1 hidden>Free Pool, Billiards and Snooker</h1>
     <div id="table-wrap">
       <div id="table-bg"></div>
       <div id="table-surface"></div>

--- a/dist/practice2.html
+++ b/dist/practice2.html
@@ -83,6 +83,7 @@
       }
 
       body {
+        min-height: 100vh;
         min-height: 100dvh;
         background: #0d0d0d;
         display: flex;
@@ -100,7 +101,6 @@
         position: relative;
         width: var(--table-width-landscape);
         max-width: 920px;
-        container-type: size;
         margin: auto;
       }
 
@@ -129,7 +129,10 @@
 
       #table-bg {
         position: absolute;
-        inset: 0;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
         background: url("images/practiceback.png") center / 100% 100% no-repeat;
         opacity: 0.75;
         z-index: 0;
@@ -142,8 +145,8 @@
 
       @media (orientation: portrait) {
         #table-bg {
-          width: 100cqh;
-          height: 100cqw;
+          width: 100%;
+          height: 100%;
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%) rotate(-90deg)
@@ -180,7 +183,10 @@
 
       .ball-body {
         position: absolute;
-        inset: 0;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
         border-radius: 50%;
         box-shadow: inset calc(var(--p) * -1) calc(var(--p) * -1) 0
           rgba(0, 0, 0, 0.3);
@@ -205,7 +211,10 @@
 
       .move-indicators {
         position: absolute;
-        inset: 0;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
         pointer-events: none;
       }
 
@@ -239,7 +248,11 @@
         max-width: 820px;
         flex-shrink: 0;
         justify-content: center;
-        margin-top: var(--controls-gap);
+        margin: calc(var(--controls-gap) - 4px) auto -4px;
+      }
+
+      .controls > button {
+        margin: 4px;
       }
 
       button {
@@ -297,6 +310,14 @@
         align-items: center;
         gap: 6px;
         margin-left: auto;
+      }
+      .btn-share svg {
+        margin-right: 6px;
+      }
+      @supports (gap: 6px) {
+        .btn-share svg {
+          margin-right: 0;
+        }
       }
       .btn-share:hover {
         background: #2a2a2a;
@@ -425,7 +446,7 @@
     </style>
   </head>
   <body>
-  <h1 hidden>Free Pool, Billiards and Snooker</h1>
+    <h1 hidden>Free Pool, Billiards and Snooker</h1>
     <div id="table-wrap">
       <div id="table-bg"></div>
       <div id="table-surface"></div>
@@ -491,11 +512,28 @@
       }
 
       function setAspectRatio() {
+        const bg = document.getElementById("table-bg")
         if (portrait()) {
           // height is constrained by CSS; width derives from aspect-ratio
+          const ratio = (HH * 2) / (HW * 2)
           wrap.style.aspectRatio = `${HH * 2} / ${HW * 2}`
+          const h = wrap.offsetHeight
+          wrap.style.width = h * ratio + "px"
+          wrap.style.height = h + "px"
+
+          // handle bg sizing in portrait (rotated)
+          const rect = surface.getBoundingClientRect()
+          bg.style.width = rect.height + "px"
+          bg.style.height = rect.width + "px"
         } else {
+          const ratio = (HW * 2) / (HH * 2)
           wrap.style.aspectRatio = `${HW * 2} / ${HH * 2}`
+          wrap.style.width = "" // let CSS width: 85% drive it
+          const w = wrap.offsetWidth
+          wrap.style.height = w / ratio + "px"
+
+          bg.style.width = ""
+          bg.style.height = ""
         }
       }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,8 @@ module.exports = {
             },
           },
         },
-        exclude: /node_modules\/(?!(three|@tailuge\/messaging|simple-peer-light|jsoncrush))/,
+        exclude:
+          /node_modules\/(?!(three|@tailuge\/messaging|simple-peer-light|jsoncrush))/,
       },
     ],
   },


### PR DESCRIPTION
This change addresses layout failures on older iOS Safari versions (specifically those prior to Safari 16) by providing fallbacks for modern CSS features like `dvh` units, container queries, `aspect-ratio`, `inset`, and Flexbox `gap`. A JavaScript-based fallback for aspect ratio and background sizing ensures the pool table remains correctly proportioned and rotated on older devices.

---
*PR created automatically by Jules for task [16240617949634834078](https://jules.google.com/task/16240617949634834078) started by @tailuge*