### PR TITLE
Add Blog button to practice.html

### DIFF
--- a/dist/practice.html
+++ b/dist/practice.html
@@ -271,7 +271,7 @@
         box-shadow: 0 6px 18px rgba(16, 185, 129, 0.5);
       }
 
-      .btn-share {
+      .btn-secondary {
         background: #1e1e1e;
         color: #aaa;
         border: 1px solid #333;
@@ -282,17 +282,19 @@
         display: flex;
         align-items: center;
         gap: 6px;
-        margin-left: auto;
       }
-      .btn-share:hover {
+      .btn-secondary:hover {
         background: #2a2a2a;
         color: #eee;
         border-color: #555;
       }
-      .btn-share svg {
+      .btn-secondary svg {
         width: 14px;
         height: 14px;
         stroke-width: 2.5;
+      }
+      #blogBtn {
+        margin-left: auto;
       }
     </style>
   </head>
@@ -308,7 +310,27 @@
       <button class="btn-preset" data-preset="line">line up</button>
       <button class="btn-preset" data-preset="corners">corners</button>
       <button class="btn-preset" data-preset="cluster">cluster</button>
-      <button class="btn-share" id="shareBtn">
+      <button class="btn-secondary" id="blogBtn">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"></path>
+          <path d="M14 2v4a2 2 0 0 0 2 2h4"></path>
+          <path d="M10 9H8"></path>
+          <path d="M16 13H8"></path>
+          <path d="M16 17H8"></path>
+        </svg>
+        Blog
+      </button>
+      <button class="btn-secondary" id="shareBtn">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="24"
@@ -591,6 +613,10 @@
 
       document.querySelectorAll(".btn-preset").forEach((btn) => {
         btn.addEventListener("click", () => applyPreset(btn.dataset.preset))
+      })
+
+      document.getElementById("blogBtn").addEventListener("click", () => {
+        window.location.href = "./blog3.html"
       })
 
       document.getElementById("shareBtn").addEventListener("click", () => {


### PR DESCRIPTION
The changes add a "Blog" button to the practice page (`dist/practice.html`) as requested. The button is styled consistently with the existing "Share" button and includes a document icon. It is positioned to the left of the "Share" button in the right-aligned section of the controls bar. Clicking the button redirects the user to the Mathavan blog post (`blog3.html`).

Key modifications:
1.  **CSS Refactoring**: Renamed `.btn-share` to `.btn-secondary` to share styles between the Blog and Share buttons.
2.  **Layout Adjustment**: Applied `margin-left: auto` to `#blogBtn` to ensure it and subsequent buttons are pushed to the right side of the flex container.
3.  **HTML Structure**: Inserted the Blog button before the Share button with a "file-text" SVG icon.
4.  **JavaScript Logic**: Added a click listener to `#blogBtn` for navigation.

Verification:
- Visual verification performed using a Playwright script.
- Screenshot captured confirming correct layout and styling.
- All project tests and linters passed.

---
*PR created automatically by Jules for task [18183623152325249172](https://jules.google.com/task/18183623152325249172) started by @tailuge*