### PR TITLE
Wire up μs, μw, and ee physical constant sliders

### DIFF
--- a/dist/diagrams/three.html
+++ b/dist/diagrams/three.html
@@ -65,6 +65,7 @@
       #muC,
       #μs,
       #μw,
+      #ee,
       #rho {
         width: 75%;
       }
@@ -411,6 +412,8 @@
           <label for="μs">μs</label>
           <input id="μw" type="range" />
           <label for="μw">μw</label>
+          <input id="ee" type="range" />
+          <label for="ee">ee</label>
         </div>
 
         <div id="spin-power-wrap">

--- a/dist/index.html
+++ b/dist/index.html
@@ -260,6 +260,12 @@
         <input id="rho" type="range" /><label for="rho">rho</label>
       </div>
       <div class="nw">
+        <input id="μs" type="range" /><label for="μs">μs</label>
+      </div>
+      <div class="nw">
+        <input id="μw" type="range" /><label for="μw">μw</label>
+      </div>
+      <div class="nw">
         <button id="network" aria-label="Toggle network settings">
           network🗲
         </button>

--- a/src/model/table.ts
+++ b/src/model/table.ts
@@ -53,7 +53,10 @@ export class Table {
     let depth = 0
     while (!this.prepareAdvanceAll(t)) {
       if (depth++ > 100) {
-        console.log("Depth exceeded resolving collisions", JSON.stringify(this.shortSerialise()))
+        console.log(
+          "Depth exceeded resolving collisions",
+          JSON.stringify(this.shortSerialise())
+        )
         throw new Error("Depth exceeded resolving collisions")
       }
     }


### PR DESCRIPTION
This change adds the missing μs (static friction) and μw (rolling friction) sliders to the main game page (dist/index.html) and adds the ee (restitution) slider to the 3D diagram page (dist/diagrams/three.html). 

The `Sliders` class in `src/view/sliders.ts` automatically wires up elements with IDs matching physical constant names. By adding these elements to the HTML, they are now functional and update the simulation's physics constants in real-time. 

Verification included:
- Visual confirmation of slider placement and styling via Playwright screenshots.
- Functional confirmation that sliders initialize with correct values and update labels.
- Running all unit tests (436/436 passed).
- Linting and formatting checks.

---
*PR created automatically by Jules for task [3366950986513041695](https://jules.google.com/task/3366950986513041695) started by @tailuge*