### PR TITLE
Fix unclickable buttons in three.html diagram

### DIFF
--- a/dist/diagrams/three.html
+++ b/dist/diagrams/three.html
@@ -168,7 +168,7 @@
         transform: translateX(-50%);
         display: flex;
         gap: 8px;
-        z-index: 10;
+        z-index: 200;
       }
 
       .topview {


### PR DESCRIPTION
Increased the z-index of the #overlay-buttons container in three.html to 200. This ensures that the replay and preset buttons are not obscured by the .controls-row element, which overlaps them due to its negative top margin. Verified the fix using Playwright across multiple viewport sizes.

---
*PR created automatically by Jules for task [10669892248712112777](https://jules.google.com/task/10669892248712112777) started by @tailuge*