### PR TITLE
Show Player vs Player notification at game start

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -227,7 +227,25 @@ export class BrowserContainer {
       Session.getInstance().setOpponentClientId(event.clientId)
     }
     if (event.playername) {
-      Session.getInstance().opponentName = event.playername
+      const session = Session.getInstance()
+      session.opponentName = event.playername
+      if (
+        !session.vsNotificationShown &&
+        !this.botMode &&
+        !session.rematchInfo &&
+        !this.spectator &&
+        session.playername &&
+        session.opponentName
+      ) {
+        const names = session.orderedNamesForHud()
+        if (names.p1Name && names.p2Name) {
+          this.container.notifyLocal({
+            type: "Info",
+            title: `${names.p1Name} vs ${names.p2Name}`,
+          })
+          session.vsNotificationShown = true
+        }
+      }
     }
     this.container.eventQueue.push(event)
   }

--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -68,8 +68,22 @@ export class Spectate extends ControllerBase {
     }
 
     if (changed) {
+      const names = session.orderedNamesForHud()
       const scores = session.orderedScoresForHud()
       this.container.updateScoreHud(scores.p1, scores.p2, session.currentBreak)
+
+      if (
+        !session.vsNotificationShown &&
+        !session.rematchInfo &&
+        names.p1Name &&
+        names.p2Name
+      ) {
+        this.container.notifyLocal({
+          type: "Info",
+          title: `${names.p1Name} vs ${names.p2Name}`,
+        })
+        session.vsNotificationShown = true
+      }
     }
   }
 

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -15,6 +15,7 @@ export class Session {
   opponentClientId?: string
   spectatedP1Name?: string
   spectatedP2Name?: string
+  vsNotificationShown: boolean = false
   playerIndex: number = 0
   private scoreByClientId: Record<string, number> = {}
   currentBreak: number = 0


### PR DESCRIPTION
This change introduces a "Player1 vs Player2" notification that appears at the start of a human-vs-human multiplayer game when the participants' names are identified. 

Key changes:
- `src/network/client/session.ts`: Added a `vsNotificationShown` boolean to track whether the notification has been displayed during the current session.
- `src/container/browsercontainer.ts`: Implemented logic in `netEvent` to show the notification for players when the opponent's name is received, provided it's a human multiplayer match and not a rematch.
- `src/controller/spectate.ts`: Updated `sniffNames` to show the notification to spectators once both player names have been discovered.

The notification uses the existing `notifyLocal` system to ensure it's only shown to the local user and not broadcasted over the network. Bot games and rematches are explicitly excluded to maintain existing behavior and avoid redundancy.

---
*PR created automatically by Jules for task [16612531312985220811](https://jules.google.com/task/16612531312985220811) started by @tailuge*