### PR TITLE
Force top view and orientation-aware drag in PlaceBall mode

### DIFF
--- a/src/controller/placeball.ts
+++ b/src/controller/placeball.ts
@@ -5,6 +5,7 @@ import { BreakEvent } from "../events/breakevent"
 import { R } from "../model/physics/constants"
 import { Vector3 } from "three"
 import { CueMesh } from "../view/cuemesh"
+import { CameraTop } from "../view/cameratop"
 
 /**
  * Place cue ball using input events.
@@ -22,7 +23,7 @@ export class PlaceBall extends ControllerBase {
     super(container)
     this.startPos = startPos
     this.container.table.cue.moveTo(this.container.table.cueball.pos)
-    this.container.view.camera.forceMode(this.container.view.camera.aimView)
+    this.container.view.camera.forceMode(this.container.view.camera.topView)
   }
 
   override onFirst() {
@@ -57,10 +58,10 @@ export class PlaceBall extends ControllerBase {
         break
       // use cursor movement for placing cueball
       case "movementXUp":
-        this.moveTo(0, -input.t * this.placescale * 2)
+        this.handleMovement(input.t * 2, 0)
         break
       case "movementYUp":
-        this.moveTo(-input.t * this.placescale * 2, 0)
+        this.handleMovement(0, input.t * 2)
         break
       // use IJKL for placing cueball
       case "KeyI":
@@ -86,6 +87,15 @@ export class PlaceBall extends ControllerBase {
     this.container.sendEvent(this.container.table.cue.aim)
 
     return this
+  }
+
+  handleMovement(dx: number, dy: number) {
+    const aspect = this.container.view.camera.camera.aspect
+    if (aspect > CameraTop.portrait) {
+      this.moveTo(dx * this.placescale, -dy * this.placescale)
+    } else {
+      this.moveTo(-dy * this.placescale, -dx * this.placescale)
+    }
   }
 
   moveTo(dx, dy) {


### PR DESCRIPTION
This PR updates the `PlaceBall` controller to force the camera into top-view mode and implements a mapping for mouse/touch drag events that accounts for the table's orientation.

Key changes:
- In `src/controller/placeball.ts`, the camera is now forced to `topView` upon initialization.
- A new `handleMovement` method is used for `movementXUp` and `movementYUp` inputs.
- `handleMovement` uses the `0.95` aspect ratio threshold (consistent with `CameraTop.portrait`) to determine if the table is in landscape or portrait.
- Drag coordinates are remapped in portrait mode to compensate for the 90-degree visual rotation, ensuring the ball always follows the user's cursor naturally.

Verified with unit tests (442/442 passed) and manual visual verification using Playwright screenshots in both landscape and portrait resolutions.

---
*PR created automatically by Jules for task [6261981219270281452](https://jules.google.com/task/6261981219270281452) started by @tailuge*