### PR TITLE
Update placeball indicator and camera transition

### DIFF
--- a/src/controller/placeball.ts
+++ b/src/controller/placeball.ts
@@ -116,6 +116,7 @@ export class PlaceBall extends ControllerBase {
     this.container.sendEvent(
       new BreakEvent(this.container.table.shortSerialise())
     )
+    this.container.view.camera.forceMode(this.container.view.camera.aimView)
     return new Aim(this.container)
   }
 }

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -14,7 +14,7 @@ import { cueIntersectsAnything } from "../utils/cueintersect"
 export class Cue {
   mesh: Object3D
   helperMesh: Mesh
-  placerMesh: Mesh
+  placerMesh: Object3D
   shadowMesh: Mesh
   readonly offCenterLimit = 0.3
   readonly maxPower = 160 * R

--- a/src/view/cuemesh.ts
+++ b/src/view/cuemesh.ts
@@ -10,6 +10,7 @@ import {
   Group,
   PlaneGeometry,
   MeshBasicMaterial,
+  ConeGeometry,
 } from "three"
 
 export class CueMesh {
@@ -72,19 +73,26 @@ export class CueMesh {
   }
 
   static createPlacer() {
-    const geometry = new CylinderGeometry((R * 0.01) / 0.5, R, R, 4)
-    const mesh = new Mesh(geometry, CueMesh.placermaterial)
-    mesh.geometry
-      .applyMatrix4(
-        new Matrix4()
-          .identity()
-          .makeRotationAxis(new Vector3(1, 0, 0), -Math.PI / 2)
-      )
-      .applyMatrix4(
-        new Matrix4().identity().makeTranslation(0, 0, (R * 0.7) / 0.5)
-      )
-    mesh.visible = false
-    return mesh
+    const group = new Group()
+    const pyramidGeo = new ConeGeometry(0.96 * R, 1.6 * R, 3)
+    for (let i = 0; i < 4; i++) {
+      const pyramid = new Mesh(pyramidGeo, CueMesh.placermaterial)
+      const angle = (i * Math.PI) / 2
+
+      // Distribute around the ball
+      pyramid.position.x = Math.cos(angle) * 4 * R
+      pyramid.position.y = Math.sin(angle) * 4 * R
+      pyramid.position.z = 3.2 * R // Hover height
+
+      // Point toward the center
+      pyramid.lookAt(0, 0, R)
+      // Adjust rotation because ConeGeometry points up its Y axis
+      pyramid.rotateX(Math.PI / 2)
+
+      group.add(pyramid)
+    }
+    group.visible = false
+    return group
   }
 
   static createShadow(length: number) {


### PR DESCRIPTION
I have updated the "placeball" mode visual indicator to a new design featuring four tetrahedrons distributed at a $4R$ radius around the ball. I also implemented a camera transition that automatically switches to "aim mode" once the ball has been placed. 

Key changes:
- **Visuals**: Modified `src/view/cuemesh.ts` to create a `Group` of four tetrahedrons (triangular pyramids) using `ConeGeometry`. These are positioned at $4R$ from the ball center with a hover height of $3.2R$, scaled relative to the ball radius $R$.
- **Types**: Updated `src/view/cue.ts` to allow `placerMesh` to be an `Object3D`, supporting the new group structure while maintaining compatibility with position and rotation updates.
- **Camera**: Updated `src/controller/placeball.ts` to call `forceMode(aimView)` in the `placed()` method, providing a smoother transition into the shooting phase.
- **Verification**: Confirmed the new design and behavior via automated Playwright verification and ensured all 442 unit tests pass.

---
*PR created automatically by Jules for task [17832972107303606517](https://jules.google.com/task/17832972107303606517) started by @tailuge*