### PR TITLE
Implement cue elevation in spin physics

### DIFF
--- a/src/events/aimevent.ts
+++ b/src/events/aimevent.ts
@@ -8,6 +8,7 @@ export class AimEvent extends GameEvent {
   offset = new Vector3(0, 0, 0)
   angle = 0
   power = 0
+  elevation = 0
   pos = new Vector3(0, 0, 0)
   i = 0
 
@@ -26,6 +27,7 @@ export class AimEvent extends GameEvent {
     event.angle = json.angle
     event.offset = vec(json.offset)
     event.power = json.power
+    event.elevation = json.elevation || 0
     if (json.i) {
       event.i = json.i
     }

--- a/src/model/physics/physics.ts
+++ b/src/model/physics/physics.ts
@@ -208,14 +208,19 @@ export function mathavanAdapter(v: Vector3, w: Vector3) {
  *
  * @param offset (x,y,0) from center strike where x,y range from -0.5 to 0.5 the fraction of R from center.
  * @param v velocity of ball after strike
+ * @param elevation angle of cue in radians
  * @returns angular velocity
  */
-export function cueToSpin(offset: Vector3, v: Vector3) {
-  const spinAxis = Math.atan2(-offset.x, offset.y)
-  const spinRate = ((5 / 2) * v.length() * (offset.length() * R)) / (R * R)
+export function cueToSpin(offset: Vector3, v: Vector3, elevation: number = 0) {
+  const cosAlpha = Math.max(1e-3, Math.cos(elevation))
+  const sinAlpha = Math.sin(elevation)
+  const spinRate =
+    ((5 / 2) * v.length() * (offset.length() * R)) / (R * R * cosAlpha)
   const dir = v.clone().normalize()
+  const q = dir.clone().multiplyScalar(cosAlpha).addScaledVector(up, -sinAlpha)
+  const spinAxis = Math.atan2(-offset.x, offset.y)
   const rvel = upCross(dir)
-    .applyAxisAngle(dir, spinAxis)
+    .applyAxisAngle(q, spinAxis)
     .multiplyScalar(spinRate)
   return rvel
 }

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -79,7 +79,7 @@ export class Cue {
     ball.vel.copy(
       unitAtAngle(aim.angle, this.tempVec).multiplyScalar(aim.power)
     )
-    ball.rvel.copy(cueToSpin(aim.offset, ball.vel))
+    ball.rvel.copy(cueToSpin(aim.offset, ball.vel, aim.elevation))
   }
 
   aimAtNext(cueball, ball) {

--- a/test/model/physics.spec.ts
+++ b/test/model/physics.spec.ts
@@ -138,4 +138,35 @@ describe("Physics", () => {
     expect(restitutionCushion(v)).to.be.a("number")
     done()
   })
+
+  it("cueToSpin with elevation preserves behavior for elevation=0", (done) => {
+    const v = new Vector3(10, 0, 0)
+    const offset = new Vector3(0.1, 0.2, 0)
+    const w0 = cueToSpin(offset, v, 0)
+    const wDefault = cueToSpin(offset, v)
+    expect(w0.x).to.equal(wDefault.x)
+    expect(w0.y).to.equal(wDefault.y)
+    expect(w0.z).to.equal(wDefault.z)
+    done()
+  })
+
+  it("cueToSpin with elevation and side spin produces swerve (non-zero w.x/w.y components)", (done) => {
+    const v = new Vector3(10, 0, 0)
+    const offset = new Vector3(0.2, 0, 0) // Pure side spin
+    const elevation = Math.PI / 4 // 45 degrees
+    const w = cueToSpin(offset, v, elevation)
+
+    // With elevation and side spin, the spin axis is tilted.
+    // cueToSpin implementation:
+    // dir = (1, 0, 0)
+    // q = (cos(45), 0, -sin(45))
+    // upCross(dir) = (0, 1, 0)
+    // spinAxis = atan2(-0.2, 0) = -PI/2
+    // rotate (0, 1, 0) around (cos(45), 0, -sin(45)) by -PI/2
+    // This should result in a vector that has a Z component and a horizontal component.
+
+    expect(w.z).to.not.equal(0)
+    expect(w.x).to.not.equal(0)
+    done()
+  })
 })


### PR DESCRIPTION
This PR implements support for cue elevation in the billiards physics engine.

### Changes:
1.  **`src/events/aimevent.ts`**: Added an `elevation` property (default 0) to the `AimEvent` class and updated `fromJson` to handle it.
2.  **`src/model/physics/physics.ts`**: Updated the `cueToSpin` function to accept an optional `elevation` parameter. The physics formula now correctly models the tilted cue axis and its effect on the ball's angular velocity, including the division by `cos(elevation)` to adjust the spin rate.
3.  **`src/view/cue.ts`**: Updated the `hit` method to pass `this.aim.elevation` to the `cueToSpin` function.
4.  **`test/model/physics.spec.ts`**: Added new unit tests to:
    -   Ensure `elevation = 0` preserves existing horizontal strike behavior.
    -   Verify that elevated side-spin strikes produce horizontal components of angular velocity (necessary for modeling swerve/masse).

All existing and new tests pass.

---
*PR created automatically by Jules for task [12807250585623374818](https://jules.google.com/task/12807250585623374818) started by @tailuge*