### PR TITLE
Integrate lobby chat messages into game UI

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -127,7 +127,8 @@ export class Container {
     this.lobbyIndicator = new LobbyIndicator(
       Session.getInstance().botMode,
       this.replayMode,
-      this.rules
+      this.rules,
+      (msg) => this.chat.showMessage(msg)
     )
     this.updateController(new Init(this))
     //  this.updateController(new End(this))

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -1,4 +1,9 @@
-import { MessagingClient, Lobby } from "@tailuge/messaging"
+import {
+  MessagingClient,
+  Lobby,
+  PresenceMessage,
+  ChatMessage,
+} from "@tailuge/messaging"
 import { Session } from "../network/client/session"
 import { Rules } from "../controller/rules/rules"
 import { id } from "../utils/dom"
@@ -24,9 +29,18 @@ export class LobbyIndicator {
   private readonly replayMode: boolean
   private readonly isSpectator: boolean
   private opponentOnline: boolean | null = null
-  constructor(botMode: boolean, replayMode: boolean, rules: Rules) {
+  private users: PresenceMessage[] = []
+  private readonly onChatMessage?: (msg: string) => void
+
+  constructor(
+    botMode: boolean,
+    replayMode: boolean,
+    rules: Rules,
+    onChatMessage?: (msg: string) => void
+  ) {
     this.rules = rules
     this.replayMode = replayMode
+    this.onChatMessage = onChatMessage
     this.isSpectator = Session.getInstance().spectator
     if (botMode) {
       this.ruleType = `${this.rules.rulename}-bot`
@@ -114,6 +128,7 @@ export class LobbyIndicator {
     this.lobby = await this.messagingClient.joinLobby(presence)
 
     this.lobby.onUsersChange((users) => {
+      this.users = users
       this.count = users.length
       const session = Session.getInstance()
       const opponentId = session.opponentClientId
@@ -127,6 +142,12 @@ export class LobbyIndicator {
         this.opponentOnline = null
       }
       this.updateDisplay()
+    })
+
+    this.lobby.onChat((chat: ChatMessage) => {
+      const sender = this.users.find((u) => u.userId === chat.senderId)
+      const senderName = sender ? sender.userName : "Unknown"
+      this.onChatMessage?.(`${senderName}: ${chat.text}`)
     })
 
     this.lobby.onChallenge((challenge) => {

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -11,6 +11,7 @@ jest.mock("@tailuge/messaging", () => ({
     start: jest.fn(),
     joinLobby: jest.fn().mockResolvedValue({
       onUsersChange: jest.fn(),
+      onChat: jest.fn(),
       onChallenge: jest.fn(),
       updatePresence: jest.fn(),
       leave: jest.fn(),


### PR DESCRIPTION
This change integrates incoming chat messages from the @tailuge/messaging lobby API into the existing on-screen chat UI. 

Key changes:
- `LobbyIndicator` now maintains a list of users to resolve sender IDs to names.
- A new `onChat` listener in `LobbyIndicator` formats messages as "senderName: message" and passes them to a callback.
- `Container` provides this callback to `LobbyIndicator` to display messages using `this.chat.showMessage`.
- Fixed test regressions caused by the updated `LobbyIndicator` initialization.

---
*PR created automatically by Jules for task [10981000372525353403](https://jules.google.com/task/10981000372525353403) started by @tailuge*