### PR TITLE
Fix cue animation translation axis

### DIFF
--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -151,12 +151,11 @@ export class Cue {
     const curveVal = this.hitAnimationCurve(this.t)
     const hitOffset = this.hitAnimationWeight * curveVal * 2 * R
     const strokeX = (1 - this.hitAnimationWeight) * swing - hitOffset
-    const strokeZ = (0.15 + Math.min(this.t / 5, 0.25)) * hitOffset
 
     this.cueBody.position.set(
       -this.length / 2 - R + strokeX,
       this.aim.offset.x * 2 * R,
-      R * 0.12 + strokeZ + this.aim.offset.y * 2 * R
+      R * 0.12 + this.aim.offset.y * 2 * R
     )
 
     return strokeX
@@ -169,15 +168,18 @@ export class Cue {
     const unitToBall = unitAtAngle(this.aim.angle, this.tempVec)
     const sideVec = upCross(unitToBall).normalize()
     const elevation = this.tiltMesh.rotation.y as number
-    const projectedStroke =
-      strokeX * Math.cos(elevation) +
-      (this.cueBody.position.z - R * 0.12) * Math.sin(elevation)
+
+    const localX = strokeX - R
+    const localZ = this.cueBody.position.z
+    const projectedX =
+      localX * Math.cos(elevation) + localZ * Math.sin(elevation)
 
     this.shadowMesh.position
       .copy(pos)
       .addScaledVector(sideVec, this.cueBody.position.y)
-      .addScaledVector(unitToBall, projectedStroke)
+      .addScaledVector(unitToBall, projectedX + R * Math.cos(elevation))
     this.shadowMesh.position.z = -R * 0.99
+    this.shadowMesh.scale.x = Math.cos(elevation)
 
     this.helperMesh.position.copy(pos)
     this.placerMesh.position.copy(pos)
@@ -187,7 +189,6 @@ export class Cue {
   moveTo(pos) {
     this.aim.pos.copy(pos)
     this.updateCueRotation()
-    const offset = this.spinOffset()
     const swing =
       (sin(this.t * 1.5 + Math.PI / 2) - 1) *
       2 *

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -155,25 +155,27 @@ export class Cue {
 
     this.cueBody.position.set(
       -this.length / 2 - R + strokeX,
-      0,
-      R * 0.12 + strokeZ
+      this.aim.offset.x * 2 * R,
+      R * 0.12 + strokeZ + this.aim.offset.y * 2 * R
     )
 
     return strokeX
   }
 
-  private updateCuePosition(pos: Vector3, offset: Vector3, strokeX: number) {
-    this.mesh.position.copy(pos).add(offset)
+  private updateCuePosition(pos: Vector3, strokeX: number) {
+    this.mesh.position.copy(pos)
 
     // Project local strokeX through tilt onto the horizontal plane for shadow
     const unitToBall = unitAtAngle(this.aim.angle, this.tempVec)
+    const sideVec = upCross(unitToBall).normalize()
+    const elevation = this.tiltMesh.rotation.y as number
     const projectedStroke =
-      strokeX * Math.cos(this.tiltMesh.rotation.y as number)
+      strokeX * Math.cos(elevation) +
+      (this.cueBody.position.z - R * 0.12) * Math.sin(elevation)
 
-    const horizontalOffset = this.tempVec2.set(offset.x, offset.y, 0)
     this.shadowMesh.position
       .copy(pos)
-      .add(horizontalOffset)
+      .addScaledVector(sideVec, this.cueBody.position.y)
       .addScaledVector(unitToBall, projectedStroke)
     this.shadowMesh.position.z = -R * 0.99
 
@@ -192,7 +194,7 @@ export class Cue {
       R *
       (this.aim.power / this.maxPower)
     const strokeX = this.applyHitAnimation(swing)
-    this.updateCuePosition(pos, offset, strokeX)
+    this.updateCuePosition(pos, strokeX)
   }
 
   hitAnimationCurve(t: number) {

--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -151,11 +151,12 @@ export class Cue {
     const curveVal = this.hitAnimationCurve(this.t)
     const hitOffset = this.hitAnimationWeight * curveVal * 2 * R
     const strokeX = (1 - this.hitAnimationWeight) * swing - hitOffset
+    const strokeZ = (0.15 + Math.min(this.t / 5, 0.25)) * hitOffset
 
     this.cueBody.position.set(
       -this.length / 2 - R + strokeX,
       this.aim.offset.x * 2 * R,
-      R * 0.12 + this.aim.offset.y * 2 * R
+      R * 0.12 + strokeZ + this.aim.offset.y * 2 * R
     )
 
     return strokeX

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Corrected the cue animation and spin offset application to move locally along the cue's axis rather than translating the entire mesh in world space. This ensures that the cue remains correctly aligned and tilted throughout the swing and hit animations. Updated the shadow projection logic to account for these local movements.

---
*PR created automatically by Jules for task [5247782152516403278](https://jules.google.com/task/5247782152516403278) started by @tailuge*