### PR TITLE
Improve cue tilt input with custom AngleInput component

### DIFF
--- a/dist/css/aiminputs.css
+++ b/dist/css/aiminputs.css
@@ -13,8 +13,8 @@
 }
 
 .tiltSliderContainer {
-  width: 60px;
-  height: 240px;
+  width: 140px;
+  height: 160px;
   padding: 10px;
   border: 1px solid #2d1e16;
   border-radius: 10px;
@@ -59,22 +59,11 @@
   width: 100%;
 }
 
-input[type="range"].tiltSlider {
-  appearance: slider-vertical;
-  -webkit-appearance: slider-vertical;
-  writing-mode: vertical-lr;
-  direction: rtl;
+angle-input {
   flex: 1 1 auto;
-  width: 20px;
-  min-height: 180px;
+  width: 120px;
+  height: 120px;
   margin: 0 auto;
-  accent-color: #d1a05c;
-  cursor: pointer;
-}
-
-input[type="range"].tiltSlider.is-disabled,
-input[type="range"].tiltSlider:disabled {
-  cursor: not-allowed;
 }
 
 .ballContainerWrapper {

--- a/dist/css/aiminputs.css
+++ b/dist/css/aiminputs.css
@@ -13,17 +13,16 @@
 }
 
 .tiltSliderContainer {
-  width: 140px;
-  height: 160px;
-  padding: 10px;
+  width: var(--ball-size-base);
+  height: var(--ball-size-base);
+  padding: 0;
   border: 1px solid #2d1e16;
   border-radius: 10px;
   background-color: rgb(37 24 10 / 92%);
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
+  justify-content: center;
   opacity: 0;
   transform: translateY(160px);
   pointer-events: none;
@@ -31,7 +30,6 @@
     opacity 0.5s ease,
     transform 0.5s ease;
   margin-bottom: 0;
-  margin-left: 36px;
   z-index: 30;
 }
 
@@ -49,21 +47,90 @@
   filter: grayscale(0.7) brightness(0.6);
 }
 
-.tiltSliderLabel {
-  flex: 0 0 auto;
-  color: #f3e4c1;
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-align: center;
+angle-input {
+  display: block;
+  position: relative;
+  aspect-ratio: 1;
+  touch-action: none;
   width: 100%;
+  height: 100%;
 }
 
-angle-input {
-  flex: 1 1 auto;
-  width: 120px;
-  height: 120px;
-  margin: 0 auto;
+angle-input .area {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #111827;
+  border: 2px solid #374151;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: grab;
+  box-sizing: border-box;
+}
+
+angle-input .area:active {
+  cursor: grabbing;
+}
+
+angle-input .ball {
+  position: absolute;
+  bottom: 12%;
+  left: 12%;
+  width: 8%;
+  height: 8%;
+  background: radial-gradient(
+    circle at 35% 35%,
+    #fff 0%,
+    #ddd 70%,
+    #999 100%
+  );
+  border-radius: 50%;
+  transform: translate(-50%, 50%);
+  pointer-events: none;
+  z-index: 2;
+}
+
+angle-input .rotator {
+  position: absolute;
+  bottom: 12%;
+  left: 12%;
+  width: 80%;
+  height: 6%;
+  transform-origin: 0% 50%;
+  transform: translate(0, 50%) rotate(calc(-1deg * var(--angle, 0)));
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  z-index: 1;
+}
+
+angle-input .stick {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  margin-left: 12%;
+  clip-path: polygon(0% 40%, 100% 20%, 100% 80%, 0% 60%);
+}
+
+angle-input .tip {
+  width: 3%;
+  background: #256bb4;
+  border-radius: 4px 0 0 4px;
+}
+
+angle-input .ferrule {
+  width: 6%;
+  background: #e4e4e4;
+}
+
+angle-input .shaft {
+  flex: 1;
+  background: #f6c386;
+}
+
+angle-input .butt {
+  width: 25%;
+  background: #000;
 }
 
 .ballContainerWrapper {

--- a/dist/index.html
+++ b/dist/index.html
@@ -160,16 +160,7 @@
         </div>
         <div id="tiltSliderContainer" class="tiltSliderContainer" hidden>
           <label for="cueTilt" class="tiltSliderLabel">tilt</label>
-          <input
-            class="tiltSlider"
-            type="range"
-            min="0"
-            max="1.31"
-            step="0.01"
-            value="0"
-            id="cueTilt"
-            aria-label="tilt slider"
-          />
+          <angle-input id="cueTilt" aria-label="tilt angle"></angle-input>
         </div>
         <div id="ballContainerWrapper" class="ballContainerWrapper">
           <div id="ballContainer" class="ballContainer">

--- a/dist/index.html
+++ b/dist/index.html
@@ -159,9 +159,21 @@
           </button>
         </div>
         <div id="tiltSliderContainer" class="tiltSliderContainer" hidden>
-          <label for="cueTilt" class="tiltSliderLabel">tilt</label>
           <angle-input id="cueTilt" aria-label="tilt angle"></angle-input>
         </div>
+        <template id="angle-input-template">
+          <div class="area" id="area">
+            <div class="ball"></div>
+            <div class="rotator" id="rot">
+              <div class="stick">
+                <div class="tip"></div>
+                <div class="ferrule"></div>
+                <div class="shaft"></div>
+                <div class="butt"></div>
+              </div>
+            </div>
+          </div>
+        </template>
         <div id="ballContainerWrapper" class="ballContainerWrapper">
           <div id="ballContainer" class="ballContainer">
             <div id="objectBall" class="objectBall"></div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { BrowserContainer } from "./container/browsercontainer"
 import { logusage } from "./utils/usage"
+import { AngleInput } from "./view/dom/elevation"
 import { getCanvas } from "./utils/dom"
 import { VERSION } from "./utils/version"
 import { ClientErrorReporter } from "./network/client/clienterrorreporter"
+
+customElements.define("angle-input", AngleInput)
 
 initialise()
 

--- a/src/view/dom/aiminputs.ts
+++ b/src/view/dom/aiminputs.ts
@@ -6,6 +6,7 @@ import { Overlap } from "../../utils/overlap"
 import { unitAtAngle } from "../../utils/three-utils"
 import { id } from "../../utils/dom"
 import { TimeoutButton } from "../timeoutbutton"
+import { AngleInput } from "./elevation"
 
 export class AimInputs {
   readonly ballContainerWrapperElement
@@ -15,7 +16,7 @@ export class AimInputs {
   readonly powerSliderContainerElement
   readonly cuePowerElement
   readonly tiltSliderContainerElement
-  readonly cueTiltElement
+  readonly cueTiltElement: AngleInput
   /** Shared button for both "Hit" and "Place Ball" actions. */
   readonly cueHitElement
   readonly objectBallStyle: CSSStyleDeclaration | undefined
@@ -38,7 +39,7 @@ export class AimInputs {
     this.powerSliderContainerElement = id("powerSliderContainer")
     this.cuePowerElement = id("cuePower")
     this.tiltSliderContainerElement = id("tiltSliderContainer")
-    this.cueTiltElement = id("cueTilt") as HTMLInputElement
+    this.cueTiltElement = id("cueTilt") as AngleInput
     this.cueHitElement = id("cueHit") as HTMLButtonElement
     if (this.cueHitElement) {
       const params = new URLSearchParams(location.search)
@@ -161,7 +162,6 @@ export class AimInputs {
     }
     if (this.cueTiltElement) {
       this.cueTiltElement.disabled = this.controlsDisabled
-      this.cueTiltElement.classList.toggle("is-disabled", this.controlsDisabled)
     }
   }
 
@@ -254,7 +254,7 @@ export class AimInputs {
     if (this.controlsDisabled || !this.cueTiltElement) {
       return
     }
-    this.container.table.cue.aim.elevation = Number(this.cueTiltElement.value)
+    this.container.table.cue.aim.elevation = this.cueTiltElement.radians
     this.container.lastEventTime = performance.now()
   }
 
@@ -267,7 +267,7 @@ export class AimInputs {
 
   updateTiltSlider(elevation) {
     if (this.cueTiltElement) {
-      this.cueTiltElement.value = elevation.toString()
+      this.cueTiltElement.radians = elevation
       if (this.controlsDisabled) {
         if (elevation > 0) {
           this.showTiltControl()

--- a/src/view/dom/elevation.ts
+++ b/src/view/dom/elevation.ts
@@ -5,83 +5,6 @@ export class AngleInput extends HTMLElement {
 
   constructor() {
     super()
-    this.attachShadow({ mode: "open" })
-    if (this.shadowRoot) {
-      this.shadowRoot.innerHTML = `
-            <style>
-                :host {
-                    display: block;
-                    position: relative;
-                    aspect-ratio: 1;
-                    touch-action: none; /* Prevents scrolling while dragging */
-                    width: 100%;
-                    height: 100%;
-                }
-                .area {
-                    position: relative;
-                    width: 100%;
-                    height: 100%;
-                    background: #111827;
-                    border: 2px solid #374151;
-                    border-radius: 8px;
-                    overflow: hidden;
-                    cursor: grab;
-                    box-sizing: border-box;
-                }
-                .area:active { cursor: grabbing; }
-
-                /* Origin is pinned at 12% bottom-left */
-                .ball {
-                    position: absolute;
-                    bottom: 12%;
-                    left: 12%;
-                    width: 8%;
-                    height: 8%;
-                    background: radial-gradient(circle at 35% 35%, #fff 0%, #ddd 70%, #999 100%);
-                    border-radius: 50%;
-                    transform: translate(-50%, 50%);
-                    pointer-events: none;
-                    z-index: 2;
-                }
-                .rotator {
-                    position: absolute;
-                    bottom: 12%;
-                    left: 12%;
-                    width: 80%;
-                    height: 6%;
-                    transform-origin: 0% 50%;
-                    transform: translate(0, 50%) rotate(calc(-1deg * var(--angle, 0)));
-                    pointer-events: none;
-                    display: flex;
-                    align-items: center;
-                    z-index: 1;
-                }
-                .stick {
-                    display: flex;
-                    width: 100%;
-                    height: 100%;
-                    margin-left: 12%; /* Space between ball and tip */
-                    clip-path: polygon(0% 40%, 100% 20%, 100% 80%, 0% 60%);
-                }
-                .tip     { width: 3%; background: #256bb4; border-radius: 4px 0 0 4px; }
-                .ferrule { width: 6%; background: #e4e4e4; }
-                .shaft   { flex: 1;  background: #f6c386; }
-                .butt    { width: 25%; background: #000; }
-            </style>
-            <div class="area" id="area">
-                <div class="ball"></div>
-                <div class="rotator" id="rot">
-                    <div class="stick">
-                        <div class="tip"></div>
-                        <div class="ferrule"></div>
-                        <div class="shaft"></div>
-                        <div class="butt"></div>
-                    </div>
-                </div>
-            </div>
-        `
-    }
-
     this.onPointerDown = this.onPointerDown.bind(this)
     this.onPointerMove = this.onPointerMove.bind(this)
     this.onPointerUp = this.onPointerUp.bind(this)
@@ -119,7 +42,15 @@ export class AngleInput extends HTMLElement {
   }
 
   connectedCallback() {
-    this.area = this.shadowRoot?.getElementById("area") as HTMLElement
+    if (this.innerHTML.trim() === "") {
+      const template = document.getElementById(
+        "angle-input-template"
+      ) as HTMLTemplateElement
+      if (template) {
+        this.appendChild(template.content.cloneNode(true))
+      }
+    }
+    this.area = this.querySelector("#area") as HTMLElement
     this.updateRadians(Number.parseFloat(this.getAttribute("value") || "0"))
     this.area?.addEventListener(
       "pointerdown",

--- a/src/view/dom/elevation.ts
+++ b/src/view/dom/elevation.ts
@@ -1,0 +1,192 @@
+export class AngleInput extends HTMLElement {
+  private _radians = 0
+  private _disabled = false
+  private area: HTMLElement | null = null
+
+  constructor() {
+    super()
+    this.attachShadow({ mode: "open" })
+    if (this.shadowRoot) {
+      this.shadowRoot.innerHTML = `
+            <style>
+                :host {
+                    display: block;
+                    position: relative;
+                    aspect-ratio: 1;
+                    touch-action: none; /* Prevents scrolling while dragging */
+                    width: 100%;
+                    height: 100%;
+                }
+                .area {
+                    position: relative;
+                    width: 100%;
+                    height: 100%;
+                    background: #111827;
+                    border: 2px solid #374151;
+                    border-radius: 8px;
+                    overflow: hidden;
+                    cursor: grab;
+                    box-sizing: border-box;
+                }
+                .area:active { cursor: grabbing; }
+
+                /* Origin is pinned at 12% bottom-left */
+                .ball {
+                    position: absolute;
+                    bottom: 12%;
+                    left: 12%;
+                    width: 8%;
+                    height: 8%;
+                    background: radial-gradient(circle at 35% 35%, #fff 0%, #ddd 70%, #999 100%);
+                    border-radius: 50%;
+                    transform: translate(-50%, 50%);
+                    pointer-events: none;
+                    z-index: 2;
+                }
+                .rotator {
+                    position: absolute;
+                    bottom: 12%;
+                    left: 12%;
+                    width: 80%;
+                    height: 6%;
+                    transform-origin: 0% 50%;
+                    transform: translate(0, 50%) rotate(calc(-1deg * var(--angle, 0)));
+                    pointer-events: none;
+                    display: flex;
+                    align-items: center;
+                    z-index: 1;
+                }
+                .stick {
+                    display: flex;
+                    width: 100%;
+                    height: 100%;
+                    margin-left: 12%; /* Space between ball and tip */
+                    clip-path: polygon(0% 40%, 100% 20%, 100% 80%, 0% 60%);
+                }
+                .tip     { width: 3%; background: #256bb4; border-radius: 4px 0 0 4px; }
+                .ferrule { width: 6%; background: #e4e4e4; }
+                .shaft   { flex: 1;  background: #f6c386; }
+                .butt    { width: 25%; background: #000; }
+            </style>
+            <div class="area" id="area">
+                <div class="ball"></div>
+                <div class="rotator" id="rot">
+                    <div class="stick">
+                        <div class="tip"></div>
+                        <div class="ferrule"></div>
+                        <div class="shaft"></div>
+                        <div class="butt"></div>
+                    </div>
+                </div>
+            </div>
+        `
+    }
+
+    this.onPointerDown = this.onPointerDown.bind(this)
+    this.onPointerMove = this.onPointerMove.bind(this)
+    this.onPointerUp = this.onPointerUp.bind(this)
+  }
+
+  get value(): string {
+    return this._radians.toString()
+  }
+
+  set value(val: string) {
+    const parsed = Number.parseFloat(val)
+    if (!Number.isNaN(parsed)) {
+      this.updateRadians(parsed)
+    }
+  }
+
+  get radians(): number {
+    return this._radians
+  }
+
+  set radians(val: number) {
+    this.updateRadians(val)
+  }
+
+  get disabled(): boolean {
+    return this._disabled
+  }
+
+  set disabled(val: boolean) {
+    this._disabled = val
+    if (this.area) {
+      this.area.style.pointerEvents = val ? "none" : "auto"
+      this.area.style.opacity = val ? "0.5" : "1"
+    }
+  }
+
+  connectedCallback() {
+    this.area = this.shadowRoot?.getElementById("area") as HTMLElement
+    this.updateRadians(Number.parseFloat(this.getAttribute("value") || "0"))
+    this.area?.addEventListener(
+      "pointerdown",
+      this.onPointerDown as EventListener
+    )
+  }
+
+  disconnectedCallback() {
+    this.area?.removeEventListener(
+      "pointerdown",
+      this.onPointerDown as EventListener
+    )
+    this.cleanup()
+  }
+
+  private onPointerDown(e: PointerEvent) {
+    if (this._disabled) return
+    this.area?.setPointerCapture(e.pointerId)
+    this.area?.addEventListener(
+      "pointermove",
+      this.onPointerMove as EventListener
+    )
+    this.area?.addEventListener("pointerup", this.onPointerUp as EventListener)
+    this.area?.addEventListener(
+      "pointercancel",
+      this.onPointerUp as EventListener
+    )
+    this.onPointerMove(e)
+  }
+
+  private onPointerMove(e: PointerEvent) {
+    if (!this.area) return
+    const rect = this.area.getBoundingClientRect()
+    const offset = rect.width * 0.12
+    const x = e.clientX - rect.left - offset
+    const y = rect.bottom - e.clientY - offset
+
+    const angleDeg = Math.atan2(y, x) * (180 / Math.PI)
+    this.updateRadians(Math.max(0, Math.min(90, angleDeg)) * (Math.PI / 180))
+  }
+
+  private onPointerUp(e: PointerEvent) {
+    this.area?.releasePointerCapture(e.pointerId)
+    this.cleanup()
+    this.dispatchEvent(new Event("change", { bubbles: true }))
+  }
+
+  private cleanup() {
+    this.area?.removeEventListener(
+      "pointermove",
+      this.onPointerMove as EventListener
+    )
+    this.area?.removeEventListener("pointerup", this.onPointerUp as EventListener)
+    this.area?.removeEventListener(
+      "pointercancel",
+      this.onPointerUp as EventListener
+    )
+  }
+
+  private updateRadians(rad: number) {
+    const clamped = Math.max(0, Math.min(Math.PI / 2, rad))
+    if (this._radians === clamped) return
+
+    this._radians = clamped
+    const angleDeg = Math.round(clamped * (180 / Math.PI))
+    this.style.setProperty("--angle", angleDeg.toString())
+
+    this.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+}

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -55,8 +55,8 @@ describe("AimInput", () => {
   it("tilt slider updates aim elevation", (done) => {
     aiminputs.setDisabled(false)
     aiminputs.tiltSliderContainerElement.hidden = false
-    aiminputs.cueTiltElement.value = "0.75"
-    fireEvent.input(aiminputs.cueTiltElement, { target: { value: "0.75" } })
+    aiminputs.cueTiltElement.radians = 0.75
+    fireEvent.input(aiminputs.cueTiltElement)
     expect(container.table.cue.aim.elevation).to.equal(0.75)
     done()
   })


### PR DESCRIPTION
I have improved the cue tilt input by replacing the standard range slider with a custom `AngleInput` web component, implemented in TypeScript. This new component allows users to set the cue elevation by dragging, providing a better user experience. I have also updated the relevant logic in `AimInputs`, adjusted the CSS for the new layout, and updated the unit tests to ensure everything works correctly.

---
*PR created automatically by Jules for task [11424607199989759700](https://jules.google.com/task/11424607199989759700) started by @tailuge*