### PR TITLE
Initialize Lobby Indicator with Custom Messaging URL

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -121,6 +121,7 @@ export class BrowserContainer {
       keyboard: new Keyboard(this.canvas3d),
       id: this.playername,
       relay: this.messageRelay,
+      messagingUrl: this.wss ?? undefined,
       scoreReporter: scoreReporter,
       replayMode: !!this.replay,
       botMode: this.botMode,
@@ -153,7 +154,7 @@ export class BrowserContainer {
   }
 
   private initMultiplayer(scoreReporter: ScoreReporter) {
-    this.messageRelay = new NchanMessageRelay()
+    this.messageRelay = new NchanMessageRelay(this.wss ?? undefined)
     this.container = this.createContainer(scoreReporter)
     this.container.init()
 

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -129,7 +129,8 @@ export class Container {
       Session.getInstance().botMode,
       this.replayMode,
       this.rules,
-      (msg) => this.chat.showMessage(msg)
+      (msg) => this.chat.showMessage(msg),
+      config.messagingUrl
     )
     this.updateController(new Init(this))
     //  this.updateController(new End(this))

--- a/src/container/containerconfig.ts
+++ b/src/container/containerconfig.ts
@@ -10,6 +10,7 @@ export interface ContainerConfig {
   keyboard?: Keyboard
   id?: string
   relay?: MessageRelay | null
+  messagingUrl?: string
   scoreReporter?: ScoreReporter | null
   replayMode?: boolean
   botMode?: boolean

--- a/src/network/client/nchanmessagerelay.ts
+++ b/src/network/client/nchanmessagerelay.ts
@@ -8,9 +8,11 @@ export class NchanMessageRelay implements MessageRelay {
     ReturnType<typeof setTimeout>
   >()
 
-  constructor(
-    private readonly baseURL: string = "billiards-network.onrender.com"
-  ) {}
+  private readonly baseURL: string
+
+  constructor(baseURL: string = "billiards-network.onrender.com") {
+    this.baseURL = baseURL.replace(/^(https?|wss?):\/\//, "")
+  }
 
   subscribe(
     channel: string,

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -25,6 +25,7 @@ export class LobbyIndicator {
   private readonly rules: Rules
   private readonly ruleType: string
   private static readonly NCHAN_URL = "https://billiards-network.onrender.com"
+  private readonly messagingUrl: string
   private currentTableId: string | null = null
   private readonly replayMode: boolean
   private readonly isSpectator: boolean
@@ -36,11 +37,15 @@ export class LobbyIndicator {
     botMode: boolean,
     replayMode: boolean,
     rules: Rules,
-    onChatMessage?: (msg: string) => void
+    onChatMessage?: (msg: string) => void,
+    messagingUrl?: string
   ) {
     this.rules = rules
     this.replayMode = replayMode
     this.onChatMessage = onChatMessage
+    this.messagingUrl = messagingUrl
+      ? `https://${messagingUrl.replace(/^(https?|wss?):\/\//, "")}`
+      : LobbyIndicator.NCHAN_URL
     this.isSpectator = Session.getInstance().spectator
     if (botMode) {
       this.ruleType = `${this.rules.rulename}-bot`
@@ -97,7 +102,7 @@ export class LobbyIndicator {
     const userName = Session.getInstance().playername
 
     this.messagingClient = new MessagingClient({
-      baseUrl: LobbyIndicator.NCHAN_URL,
+      baseUrl: this.messagingUrl,
     })
     this.messagingClient.setVersion(VERSION + `-${Session.getInstance().lod}`)
     this.messagingClient.start()

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -1,4 +1,5 @@
-import { expect } from "chai"
+import { expect as chaiExpect } from "chai"
+import { MessagingClient } from "@tailuge/messaging"
 import { LobbyIndicator } from "../../src/view/lobbyindicator"
 import { initDom } from "./dom"
 import { Session } from "../../src/network/client/session"
@@ -39,8 +40,8 @@ describe("LobbyIndicator", () => {
 
     const element = document.getElementById("lobbyOverlay")
     const countElement = element?.querySelector(".lobby-count")
-    expect(countElement?.textContent).to.equal("TestPlayer 👥0")
-    expect(countElement?.classList.contains("is-hidden")).to.be.false
+    chaiExpect(countElement?.textContent).to.equal("TestPlayer 👥0")
+    chaiExpect(countElement?.classList.contains("is-hidden")).to.be.false
   })
 
   it("updates display when challenged", async () => {
@@ -63,17 +64,17 @@ describe("LobbyIndicator", () => {
     })
 
     const countElement = element?.querySelector(".lobby-count")
-    expect(countElement?.classList.contains("is-hidden")).to.be.false
-    expect(document.getElementById("challengePill")?.textContent).to.contain(
+    chaiExpect(countElement?.classList.contains("is-hidden")).to.be.false
+    chaiExpect(document.getElementById("challengePill")?.textContent).to.contain(
       "Challenge of nineball from Bob"
     )
-    expect(element?.getAttribute("aria-label")).to.contain("CHALLENGE FROM Bob")
+    chaiExpect(element?.getAttribute("aria-label")).to.contain("CHALLENGE FROM Bob")
 
     const href = element?.getAttribute("href") ?? ""
-    expect(href).to.contain("action=join")
-    expect(href).to.contain("ruletype=nineball")
-    expect(href).to.contain("opponentId=u2")
-    expect(href).to.contain("opponentName=Bob")
+    chaiExpect(href).to.contain("action=join")
+    chaiExpect(href).to.contain("ruletype=nineball")
+    chaiExpect(href).to.contain("opponentId=u2")
+    chaiExpect(href).to.contain("opponentName=Bob")
 
     // Simulate challenge decline/cancel
     onChallengeCallback({
@@ -83,10 +84,10 @@ describe("LobbyIndicator", () => {
       challengeeId: "default",
       ruleType: "nineball",
     })
-    expect(document.getElementById("challengePill")?.hidden).to.be.true
-    expect(document.getElementById("challengeDecline")).to.not.be.null
-    expect(countElement?.classList.contains("is-hidden")).to.be.false
-    expect(element?.getAttribute("href")).to.equal(LOBBY_URL)
+    chaiExpect(document.getElementById("challengePill")?.hidden).to.be.true
+    chaiExpect(document.getElementById("challengeDecline")).to.not.be.null
+    chaiExpect(countElement?.classList.contains("is-hidden")).to.be.false
+    chaiExpect(element?.getAttribute("href")).to.equal(LOBBY_URL)
   })
 
   it("handles non-anchor elements and click events", async () => {
@@ -112,7 +113,7 @@ describe("LobbyIndicator", () => {
     }) as any
 
     div.click()
-    expect(openedUrl).to.equal(LOBBY_URL)
+    chaiExpect(openedUrl).to.equal(LOBBY_URL)
 
     await indicator.stop()
     div.remove()
@@ -129,14 +130,14 @@ describe("LobbyIndicator", () => {
     const updatePresenceFn = mockLobby.updatePresence
 
     indicator.setTableId("table-123")
-    expect(updatePresenceFn.mock.calls.length).to.be.greaterThan(0)
+    chaiExpect(updatePresenceFn.mock.calls.length).to.be.greaterThan(0)
 
     const firstCall = updatePresenceFn.mock.calls[0]
-    expect(firstCall[0]).to.deep.equal({ tableId: "table-123" })
+    chaiExpect(firstCall[0]).to.deep.equal({ tableId: "table-123" })
 
     indicator.setTableId(null)
     const secondCall = updatePresenceFn.mock.calls[1]
-    expect(secondCall[0]).to.deep.equal({ tableId: undefined })
+    chaiExpect(secondCall[0]).to.deep.equal({ tableId: undefined })
 
     await indicator.stop()
   })
@@ -152,7 +153,7 @@ describe("LobbyIndicator", () => {
     const countElement = element?.querySelector(".lobby-count") as HTMLElement
 
     await indicator.init()
-    expect(countElement.textContent).to.equal("Player 1 👥0")
+    chaiExpect(countElement.textContent).to.equal("Player 1 👥0")
 
     // Access the mock lobby to trigger onUsersChange callback
     const mockLobby = (indicator as any).lobby
@@ -163,18 +164,18 @@ describe("LobbyIndicator", () => {
       { userId: "p1", tableId: "table-1" },
       { userId: "p2", tableId: "table-1" },
     ])
-    expect(countElement.textContent).to.equal("Player 1 👥2 🟢")
+    chaiExpect(countElement.textContent).to.equal("Player 1 👥2 🟢")
 
     // Simulate opponent disconnected (not in list)
     onUsersChangeCallback([{ userId: "p1", tableId: "table-1" }])
-    expect(countElement.textContent).to.equal("Player 1 👥1 🔴")
+    chaiExpect(countElement.textContent).to.equal("Player 1 👥1 🔴")
 
     // Simulate opponent at a different table
     onUsersChangeCallback([
       { userId: "p1", tableId: "table-1" },
       { userId: "p2", tableId: "other-table" },
     ])
-    expect(countElement.textContent).to.equal("Player 1 👥2 🔴")
+    chaiExpect(countElement.textContent).to.equal("Player 1 👥2 🔴")
 
     await indicator.stop()
   })
@@ -189,7 +190,7 @@ describe("LobbyIndicator", () => {
 
     const element = document.getElementById("lobbyOverlay")
     const countElement = element?.querySelector(".lobby-count") as HTMLElement
-    expect(countElement.textContent).to.equal("Player 1 👥0")
+    chaiExpect(countElement.textContent).to.equal("Player 1 👥0")
     await indicator.stop()
 
     // Replay mode
@@ -198,7 +199,45 @@ describe("LobbyIndicator", () => {
     const indicator2 = new LobbyIndicator(false, true, mockRules)
     await indicator2.init()
     const countElement2 = element?.querySelector(".lobby-count") as HTMLElement
-    expect(countElement2.textContent).to.equal("Anon 👥0")
+    chaiExpect(countElement2.textContent).to.equal("Anon 👥0")
     await indicator2.stop()
+  })
+
+  it("uses custom messaging URL when provided", async () => {
+    const mockRules = { rulename: "nineball" } as any
+    const customUrl = "custom.server.com"
+    const indicator = new LobbyIndicator(
+      false,
+      false,
+      mockRules,
+      undefined,
+      customUrl
+    )
+    await indicator.init()
+
+    expect(MessagingClient).toHaveBeenCalledWith({
+      baseUrl: "https://custom.server.com",
+    })
+
+    await indicator.stop()
+  })
+
+  it("handles protocol-prefixed custom messaging URL", async () => {
+    const mockRules = { rulename: "nineball" } as any
+    const customUrl = "wss://custom.server.com"
+    const indicator = new LobbyIndicator(
+      false,
+      false,
+      mockRules,
+      undefined,
+      customUrl
+    )
+    await indicator.init()
+
+    expect(MessagingClient).toHaveBeenCalledWith({
+      baseUrl: "https://custom.server.com",
+    })
+
+    await indicator.stop()
   })
 })

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -1,4 +1,3 @@
-import { expect as chaiExpect } from "chai"
 import { MessagingClient } from "@tailuge/messaging"
 import { LobbyIndicator } from "../../src/view/lobbyindicator"
 import { initDom } from "./dom"
@@ -40,8 +39,8 @@ describe("LobbyIndicator", () => {
 
     const element = document.getElementById("lobbyOverlay")
     const countElement = element?.querySelector(".lobby-count")
-    chaiExpect(countElement?.textContent).to.equal("TestPlayer 👥0")
-    chaiExpect(countElement?.classList.contains("is-hidden")).to.be.false
+    expect(countElement?.textContent).toBe("TestPlayer 👥0")
+    expect(countElement?.classList.contains("is-hidden")).toBe(false)
   })
 
   it("updates display when challenged", async () => {
@@ -64,17 +63,17 @@ describe("LobbyIndicator", () => {
     })
 
     const countElement = element?.querySelector(".lobby-count")
-    chaiExpect(countElement?.classList.contains("is-hidden")).to.be.false
-    chaiExpect(document.getElementById("challengePill")?.textContent).to.contain(
+    expect(countElement?.classList.contains("is-hidden")).toBe(false)
+    expect(document.getElementById("challengePill")?.textContent).toContain(
       "Challenge of nineball from Bob"
     )
-    chaiExpect(element?.getAttribute("aria-label")).to.contain("CHALLENGE FROM Bob")
+    expect(element?.getAttribute("aria-label")).toContain("CHALLENGE FROM Bob")
 
     const href = element?.getAttribute("href") ?? ""
-    chaiExpect(href).to.contain("action=join")
-    chaiExpect(href).to.contain("ruletype=nineball")
-    chaiExpect(href).to.contain("opponentId=u2")
-    chaiExpect(href).to.contain("opponentName=Bob")
+    expect(href).toContain("action=join")
+    expect(href).toContain("ruletype=nineball")
+    expect(href).toContain("opponentId=u2")
+    expect(href).toContain("opponentName=Bob")
 
     // Simulate challenge decline/cancel
     onChallengeCallback({
@@ -84,10 +83,10 @@ describe("LobbyIndicator", () => {
       challengeeId: "default",
       ruleType: "nineball",
     })
-    chaiExpect(document.getElementById("challengePill")?.hidden).to.be.true
-    chaiExpect(document.getElementById("challengeDecline")).to.not.be.null
-    chaiExpect(countElement?.classList.contains("is-hidden")).to.be.false
-    chaiExpect(element?.getAttribute("href")).to.equal(LOBBY_URL)
+    expect(document.getElementById("challengePill")?.hidden).toBe(true)
+    expect(document.getElementById("challengeDecline")).not.toBeNull()
+    expect(countElement?.classList.contains("is-hidden")).toBe(false)
+    expect(element?.getAttribute("href")).toBe(LOBBY_URL)
   })
 
   it("handles non-anchor elements and click events", async () => {
@@ -113,7 +112,7 @@ describe("LobbyIndicator", () => {
     }) as any
 
     div.click()
-    chaiExpect(openedUrl).to.equal(LOBBY_URL)
+    expect(openedUrl).toBe(LOBBY_URL)
 
     await indicator.stop()
     div.remove()
@@ -130,14 +129,14 @@ describe("LobbyIndicator", () => {
     const updatePresenceFn = mockLobby.updatePresence
 
     indicator.setTableId("table-123")
-    chaiExpect(updatePresenceFn.mock.calls.length).to.be.greaterThan(0)
+    expect(updatePresenceFn.mock.calls.length).toBeGreaterThan(0)
 
     const firstCall = updatePresenceFn.mock.calls[0]
-    chaiExpect(firstCall[0]).to.deep.equal({ tableId: "table-123" })
+    expect(firstCall[0]).toEqual({ tableId: "table-123" })
 
     indicator.setTableId(null)
     const secondCall = updatePresenceFn.mock.calls[1]
-    chaiExpect(secondCall[0]).to.deep.equal({ tableId: undefined })
+    expect(secondCall[0]).toEqual({ tableId: undefined })
 
     await indicator.stop()
   })
@@ -153,7 +152,7 @@ describe("LobbyIndicator", () => {
     const countElement = element?.querySelector(".lobby-count") as HTMLElement
 
     await indicator.init()
-    chaiExpect(countElement.textContent).to.equal("Player 1 👥0")
+    expect(countElement.textContent).toBe("Player 1 👥0")
 
     // Access the mock lobby to trigger onUsersChange callback
     const mockLobby = (indicator as any).lobby
@@ -164,18 +163,18 @@ describe("LobbyIndicator", () => {
       { userId: "p1", tableId: "table-1" },
       { userId: "p2", tableId: "table-1" },
     ])
-    chaiExpect(countElement.textContent).to.equal("Player 1 👥2 🟢")
+    expect(countElement.textContent).toBe("Player 1 👥2 🟢")
 
     // Simulate opponent disconnected (not in list)
     onUsersChangeCallback([{ userId: "p1", tableId: "table-1" }])
-    chaiExpect(countElement.textContent).to.equal("Player 1 👥1 🔴")
+    expect(countElement.textContent).toBe("Player 1 👥1 🔴")
 
     // Simulate opponent at a different table
     onUsersChangeCallback([
       { userId: "p1", tableId: "table-1" },
       { userId: "p2", tableId: "other-table" },
     ])
-    chaiExpect(countElement.textContent).to.equal("Player 1 👥2 🔴")
+    expect(countElement.textContent).toBe("Player 1 👥2 🔴")
 
     await indicator.stop()
   })
@@ -190,7 +189,7 @@ describe("LobbyIndicator", () => {
 
     const element = document.getElementById("lobbyOverlay")
     const countElement = element?.querySelector(".lobby-count") as HTMLElement
-    chaiExpect(countElement.textContent).to.equal("Player 1 👥0")
+    expect(countElement.textContent).toBe("Player 1 👥0")
     await indicator.stop()
 
     // Replay mode
@@ -199,7 +198,7 @@ describe("LobbyIndicator", () => {
     const indicator2 = new LobbyIndicator(false, true, mockRules)
     await indicator2.init()
     const countElement2 = element?.querySelector(".lobby-count") as HTMLElement
-    chaiExpect(countElement2.textContent).to.equal("Anon 👥0")
+    expect(countElement2.textContent).toBe("Anon 👥0")
     await indicator2.stop()
   })
 


### PR DESCRIPTION
This change ensures that the `websocketserver` URL parameter, which is already used for 2-player game synchronization, is also used to initialize the messaging URL for the `LobbyIndicator`. This allows for full customization of the networking backend via URL parameters.

Key changes:
- `src/container/containerconfig.ts`: Added `messagingUrl` property.
- `src/container/browsercontainer.ts`: Passed the `wss` address to `NchanMessageRelay` and `ContainerConfig`.
- `src/container/container.ts`: Passed `messagingUrl` from config to `LobbyIndicator`.
- `src/view/lobbyindicator.ts`: Updated constructor and `init` to use the optional `messagingUrl`, including logic to strip any existing protocol before prepending `https://`.
- `src/network/client/nchanmessagerelay.ts`: Updated constructor to accept a `baseURL` and strip existing protocols for consistency.
- `test/view/lobbyindicator.spec.ts`: Added tests for custom messaging URL initialization and fixed `expect` naming conflicts between Chai and Jest.

---
*PR created automatically by Jules for task [11177612567891324361](https://jules.google.com/task/11177612567891324361) started by @tailuge*