### PR TITLE
Network Event Logging and Diagnostic Viewer

### DIFF
--- a/dist/net.html
+++ b/dist/net.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Network Log</title>
+    <style>
+        body { font-family: monospace; background: #111; color: #ccc; padding: 20px; }
+        .log-entry { margin-bottom: 4px; }
+        .time { color: #888; margin-right: 15px; }
+        .label { color: #eee; }
+        .game { border-left: 3px solid #4a9; padding-left: 8px; }
+        .lobby { border-left: 3px solid #a49; padding-left: 8px; }
+    </style>
+</head>
+<body>
+    <div id="log"></div>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const game = JSON.parse(decodeURIComponent(params.get('game') || '[]'));
+        const lobby = JSON.parse(decodeURIComponent(params.get('lobby') || '[]'));
+
+        const combined = [
+            ...game.map(e => ({ ...e, type: 'game' })),
+            ...lobby.map(e => ({ ...e, type: 'lobby' }))
+        ].sort((a, b) => a.ts - b.ts);
+
+        const container = document.getElementById('log');
+        combined.forEach(e => {
+            const div = document.createElement('div');
+            div.className = `log-entry ${e.type}`;
+            const timeStr = new Date(e.ts).toISOString().split('T')[1].slice(0, -1);
+
+            const timeSpan = document.createElement('span');
+            timeSpan.className = 'time';
+            timeSpan.textContent = timeStr;
+
+            const labelSpan = document.createElement('span');
+            labelSpan.className = 'label';
+            labelSpan.textContent = `[${e.type}] ${e.label}`;
+
+            div.appendChild(timeSpan);
+            div.appendChild(labelSpan);
+            container.appendChild(div);
+        });
+    </script>
+</body>
+</html>

--- a/src/network/client/nchanmessagerelay.ts
+++ b/src/network/client/nchanmessagerelay.ts
@@ -1,4 +1,5 @@
 import { MessageRelay } from "./messagerelay"
+import { NetworkLogger } from "../../utils/network-logger"
 
 export class NchanMessageRelay implements MessageRelay {
   private readonly websockets = new Map<string, WebSocket>()
@@ -49,6 +50,7 @@ export class NchanMessageRelay implements MessageRelay {
 
         try {
           const parsed = JSON.parse(decoded)
+          NetworkLogger.logGame(`recv: ${parsed.type || "unknown"}`)
           const timestamp = parsed.meta?.ts
 
           if (typeof timestamp === "number") {
@@ -74,6 +76,7 @@ export class NchanMessageRelay implements MessageRelay {
     }
 
     ws.onerror = (error: Event) => {
+      NetworkLogger.logGame("error")
       console.warn(
         "WebSocket error:",
         this.stringifyLog(this.normalizeEvent(error))
@@ -82,14 +85,17 @@ export class NchanMessageRelay implements MessageRelay {
 
     ws.onopen = () => {
       this.clearTimer(key)
+      NetworkLogger.logGame("connected")
       console.log(`Connected to ${url}`)
     }
 
     ws.onclose = (event: CloseEvent) => {
+      NetworkLogger.logGame("disconnected")
       console.log("Disconnected event", event)
       // Only trigger reconnect if this specific instance is still the active one
       if (this.websockets.get(key) === ws) {
         this.websockets.delete(key)
+        NetworkLogger.logGame("reconnecting")
         console.warn(`Disconnected from ${url}. Reconnecting...`)
 
         const nextDelay = Math.min(backoffDelay * 2, 30000)
@@ -102,12 +108,19 @@ export class NchanMessageRelay implements MessageRelay {
   }
 
   publish(channel: string, message: string, prefix = "table"): void {
+    try {
+      const parsed = JSON.parse(message)
+      NetworkLogger.logGame(`sent: ${parsed.type || "unknown"}`)
+    } catch {
+      NetworkLogger.logGame("sent: raw")
+    }
     const url = `${this.httpProtocol}://${this.baseURL}/publish/${prefix}/${channel}`
     fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: message,
     }).catch((error) => {
+      NetworkLogger.logGame("publish error")
       console.error("Publication error for", url, error)
     })
   }

--- a/src/utils/network-logger.ts
+++ b/src/utils/network-logger.ts
@@ -1,0 +1,28 @@
+export interface NetworkEvent {
+  ts: number;
+  label: string;
+}
+
+export class NetworkLogger {
+  private static gameLogs: NetworkEvent[] = [];
+  private static lobbyLogs: NetworkEvent[] = [];
+  private static readonly MAX_LOGS = 50;
+
+  static logGame(label: string) {
+    this.gameLogs.push({ ts: Date.now(), label });
+    if (this.gameLogs.length > this.MAX_LOGS) this.gameLogs.shift();
+  }
+
+  static logLobby(label: string) {
+    this.lobbyLogs.push({ ts: Date.now(), label });
+    if (this.lobbyLogs.length > this.MAX_LOGS) this.lobbyLogs.shift();
+  }
+
+  static getGameLogs(): NetworkEvent[] {
+    return [...this.gameLogs];
+  }
+
+  static getLobbyLogs(): NetworkEvent[] {
+    return [...this.lobbyLogs];
+  }
+}

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -9,6 +9,7 @@ import { Rules } from "../controller/rules/rules"
 import { id } from "../utils/dom"
 import { LOBBY_URL } from "../utils/gameover"
 import { VERSION } from "../utils/version"
+import { NetworkLogger } from "../utils/network-logger"
 
 export class LobbyIndicator {
   private readonly element: HTMLElement | null
@@ -82,6 +83,13 @@ export class LobbyIndicator {
       this.element.style.cursor = "pointer"
     }
 
+    this.element.addEventListener("dblclick", (e) => {
+      e.stopPropagation()
+      const game = encodeURIComponent(JSON.stringify(NetworkLogger.getGameLogs()))
+      const lobby = encodeURIComponent(JSON.stringify(NetworkLogger.getLobbyLogs()))
+      globalThis.open(`net.html?game=${game}&lobby=${lobby}`, "_blank")
+    })
+
     id("challengeDecline")?.addEventListener("click", (e) => {
       e.stopPropagation()
       if (this.lobby && this.challenger) {
@@ -100,6 +108,7 @@ export class LobbyIndicator {
 
   async init(): Promise<void> {
     if (!this.element) return
+    NetworkLogger.logLobby("init")
 
     const userId = Session.getInstance().clientId
     const userName = Session.getInstance().playername
@@ -134,8 +143,10 @@ export class LobbyIndicator {
     }
 
     this.lobby = await this.messagingClient.joinLobby(presence)
+    NetworkLogger.logLobby("joined")
 
     this.lobby.onUsersChange((users) => {
+      NetworkLogger.logLobby(`users: ${users.length}`)
       this.users = users
       this.count = users.length
       const session = Session.getInstance()
@@ -153,12 +164,14 @@ export class LobbyIndicator {
     })
 
     this.lobby.onChat((chat: ChatMessage) => {
+      NetworkLogger.logLobby("chat")
       const sender = this.users.find((u) => u.userId === chat.senderId)
       const senderName = sender ? sender.userName : "Unknown"
       this.onChatMessage?.(`${senderName}: ${chat.text}`)
     })
 
     this.lobby.onChallenge((challenge) => {
+      NetworkLogger.logLobby(`challenge: ${challenge.type}`)
       if (challenge.type === "offer") {
         this.challenger = {
           userId: challenge.challengerId,


### PR DESCRIPTION
This change introduces a diagnostic tool to record and view significant network events. 

- **NetworkLogger**: A new utility in `src/utils/network-logger.ts` that maintains two separate lists (game and lobby) of the last 50 events each.
- **NchanMessageRelay**: Instrumentated to log WebSocket connection states (connected, disconnected, error, reconnecting) and the types of messages sent and received.
- **LobbyIndicator**: Instrumentated to log lobby lifecycle events and user interactions (init, joined, users count, chat, challenges).
- **Log Viewer**: A new `dist/net.html` file that parses the logs from query parameters, combines them into a single chronologically sorted list, and displays them with a clean, color-coded UI. It uses `textContent` for secure rendering.
- **Trigger**: The log viewer is opened in a new tab by double-clicking the lobby indicator icon.

All changes were verified with Playwright screenshots and existing unit tests pass.

---
*PR created automatically by Jules for task [1994665776448174729](https://jules.google.com/task/1994665776448174729) started by @tailuge*