### PR TITLE
Resolve click/double-click conflict on lobby indicator

### DIFF
--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -33,6 +33,7 @@ export class LobbyIndicator {
   private opponentOnline: boolean | null = null
   private users: PresenceMessage[] = []
   private readonly onChatMessage: ((msg: string) => void) | undefined
+  private clickTimer: any = null
 
   constructor(
     botMode: boolean,
@@ -75,16 +76,30 @@ export class LobbyIndicator {
       this.element.setAttribute("target", "_self")
       this.element.setAttribute("rel", "noopener")
     } else {
-      this.element.addEventListener("click", () => {
-        if (typeof globalThis.open === "function") {
-          globalThis.open(this.getLobbyUrl(), "_self")
-        }
-      })
       this.element.style.cursor = "pointer"
     }
 
+    this.element.addEventListener("click", (e) => {
+      const navigate = () => {
+        if (typeof globalThis.open === "function") {
+          globalThis.open(this.getLobbyUrl(), "_self")
+        }
+      }
+
+      if (e.detail === 0) {
+        navigate()
+      } else {
+        e.preventDefault()
+        if (e.detail === 1) {
+          globalThis.clearTimeout(this.clickTimer)
+          this.clickTimer = globalThis.setTimeout(navigate, 250)
+        }
+      }
+    })
+
     this.element.addEventListener("dblclick", (e) => {
       e.stopPropagation()
+      globalThis.clearTimeout(this.clickTimer)
       const game = encodeURIComponent(JSON.stringify(NetworkLogger.getGameLogs()))
       const lobby = encodeURIComponent(JSON.stringify(NetworkLogger.getLobbyLogs()))
       globalThis.open(`net.html?game=${game}&lobby=${lobby}`, "_blank")


### PR DESCRIPTION
This change fixes an issue where clicking the lobby indicator would immediately navigate to the lobby, making it difficult or impossible to trigger the double-click action for diagnostic logs.

The solution involves:
1. Adding a `clickTimer` to the `LobbyIndicator` class.
2. Intercepting `click` events and using `preventDefault()` to stop immediate navigation.
3. Using `setTimeout` to delay navigation by 250ms.
4. Clearing the timer in the `dblclick` handler.
5. Allowing `e.detail === 0` (keyboard/programmatic clicks) to navigate immediately to avoid breaking existing tests.

---
*PR created automatically by Jules for task [5170132450224941194](https://jules.google.com/task/5170132450224941194) started by @tailuge*