### PR TITLE
Add 3-cushion drill mode (?ruletype=threecushion&practice&drill)

### DIFF
--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -345,3 +345,54 @@ label {
 #botDebugLog::-webkit-scrollbar-thumb:hover {
   background: #777;
 }
+
+.drill-panel {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+  pointer-events: auto;
+}
+
+.drill-panel-top {
+  top: 10px;
+  transform: none;
+}
+
+.drill-gap {
+  height: 44px;
+}
+
+.drill-btn {
+  width: 90px;
+  height: 44px;
+  border-radius: 8px;
+  border: 2px solid rgb(255 255 255 / 25%);
+  background: rgb(0 30 60 / 75%);
+  color: antiquewhite;
+  font-size: 13px;
+  font-family: var(--font-family-primary, sans-serif);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
+}
+
+.drill-btn:not(:disabled):hover {
+  background: rgb(0 60 110 / 85%);
+  border-color: rgb(255 255 255 / 50%);
+}
+
+.drill-btn:not(:disabled):active {
+  transform: scale(0.96);
+}
+
+.drill-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}

--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -25,6 +25,7 @@ import { BeginEvent } from "../events/beginevent"
 import { Logger } from "../network/bot/logger"
 import { getUID } from "../utils/uid"
 import { setmu, setmuS } from "../model/physics/constants"
+import { DrillPanel } from "../view/drillpanel"
 
 /**
  * Integrate game container into HTML page
@@ -59,6 +60,7 @@ export class BrowserContainer {
   botMode: boolean = false
   botName: string = ""
   practiceMode: boolean = false
+  drillMode: boolean = false
   readonly botDelay: number = 500
   constructor(canvas3d, params) {
     this.now = Date.now()
@@ -80,6 +82,7 @@ export class BrowserContainer {
     this.botMode = params.has("bot")
     this.botName = params.get("bot") ?? ""
     this.practiceMode = params.has("practice")
+    this.drillMode = params.has("drill")
     SnookerConfig.reds = Number.parseInt(params.get("reds") ?? "15") || 15
     ThreeCushionConfig.raceTo =
       Number.parseInt(params.get("raceTo") ?? "5") || 5
@@ -117,11 +120,15 @@ export class BrowserContainer {
   }
 
   private createContainer(scoreReporter: ScoreReporter) {
+    const effectiveRuletype =
+      this.drillMode && this.ruletype === "threecushion"
+        ? "threecushion-drill"
+        : this.ruletype
     const config: ContainerConfig = {
       element: this.canvas3d,
       log: console.log,
       assets: this.assets,
-      ruletype: this.ruletype,
+      ruletype: effectiveRuletype,
       keyboard: new Keyboard(this.canvas3d),
       id: this.playername,
       relay: this.messageRelay,
@@ -197,6 +204,9 @@ export class BrowserContainer {
       this.broadcast(e)
     }
     this.container.table.cushionModel = this.cushionModel
+    if (this.drillMode) {
+      new DrillPanel(this.container)
+    }
     this.setReplayLink()
 
     if (this.spectator) {

--- a/src/controller/aim.ts
+++ b/src/controller/aim.ts
@@ -27,7 +27,9 @@ export class Aim extends ControllerBase {
   }
 
   override onFirst() {
+    this.container.table.showTraces(false)
     this.container.table.cue.aimInputs.setDisabled(false)
+    this.container.table.cue.aimInputs.setButtonText("Hit")
   }
 
   override handleInput(input: Input): Controller {

--- a/src/controller/drilloptions.ts
+++ b/src/controller/drilloptions.ts
@@ -1,0 +1,60 @@
+import { ControllerBase } from "./controllerbase"
+import { Controller, Input } from "./controller"
+import { Aim } from "./aim"
+import { DrillReplay } from "./drillreplay"
+
+export class DrillOptions extends ControllerBase {
+  override get name() {
+    return "DrillOptions"
+  }
+  private readonly preShotState: number[]
+
+  constructor(container, preShotState: number[]) {
+    super(container)
+    this.preShotState = preShotState
+  }
+
+  override onFirst() {
+    this.container.table.cue.aimInputs.setDisabled(false)
+    this.container.table.cue.aimInputs.setButtonText("Continue")
+  }
+
+  override handleInput(input: Input): Controller {
+    switch (input.key) {
+      case "SpaceUp":
+        this.container.notification.clear()
+        return new Aim(this.container)
+      case "KeyRUp":
+        this.container.notification.clear()
+        this.container.table.updateFromShortSerialised(this.preShotState)
+        return new Aim(this.container)
+      case "KeyVUp": {
+        this.container.notification.clear()
+        const recorder = this.container.recorder
+        const last = recorder.last()
+        if (last >= 0) {
+          return new DrillReplay(
+            this.container,
+            this.preShotState,
+            [recorder.entries[last].event]
+          )
+        }
+        return this
+      }
+      case "KeySUp": {
+        const balls = this.container.table.balls
+        this.container.rules.cueball =
+          this.container.rules.cueball === balls[0] ? balls[1] : balls[0]
+        this.container.table.cueball = this.container.rules.cueball
+        this.container.table.cue.aim.i = balls.indexOf(
+          this.container.table.cueball
+        )
+        this.container.table.cue.moveTo(this.container.table.cueball.pos)
+        break
+      }
+      default:
+        this.commonKeyHandler(input)
+    }
+    return this
+  }
+}

--- a/src/controller/drillreplay.ts
+++ b/src/controller/drillreplay.ts
@@ -1,0 +1,21 @@
+import { Controller } from "./controller"
+import { Replay } from "./replay"
+import { Aim } from "./aim"
+import { GameEvent } from "../events/gameevent"
+
+export class DrillReplay extends Replay {
+  constructor(container, preShotState: number[], shots: GameEvent[]) {
+    super(container, preShotState, shots, false, 1500)
+    container.view.camera.forceMode(container.view.camera.topView)
+  }
+
+  override handleStationary(_): Controller {
+    if (this.shots.length > 0 && this.timer === undefined) {
+      this.playNextShot(this.delay)
+    }
+    if (this.shots.length === 0 && this.timer === undefined) {
+      return new Aim(this.container)
+    }
+    return this
+  }
+}

--- a/src/controller/init.ts
+++ b/src/controller/init.ts
@@ -50,7 +50,7 @@ export class Init extends ControllerBase {
       )
       return new Aim(this.container)
     }
-    return new PlaceBall(this.container)
+    return this.container.rules.initialController?.() ?? new PlaceBall(this.container)
   }
 
   override handleWatch(event: WatchEvent): Controller {
@@ -87,6 +87,6 @@ export class Init extends ControllerBase {
       )
       return new Aim(this.container)
     }
-    return new PlaceBall(this.container)
+    return this.container.rules.initialController?.() ?? new PlaceBall(this.container)
   }
 }

--- a/src/controller/placeallballs.ts
+++ b/src/controller/placeallballs.ts
@@ -1,0 +1,180 @@
+import { Vector3, Raycaster, Plane, Vector2 } from "three"
+import { ControllerBase } from "./controllerbase"
+import { Controller, Input } from "./controller"
+import { Aim } from "./aim"
+import { BreakEvent } from "../events/breakevent"
+import { CueMesh } from "../view/cuemesh"
+import { R } from "../model/physics/constants"
+import type { Ball } from "../model/ball"
+import type { Container } from "../container/container"
+
+const BALL_LABELS = ["Place White", "Place Yellow", "Place Red"]
+
+export class PlaceAllBalls extends ControllerBase {
+  override get name() {
+    return "PlaceAllBalls"
+  }
+  readonly placescale = 0.02 * R
+  private readonly balls: Ball[]
+  private currentIndex = 0
+  private readonly raycaster = new Raycaster()
+  private readonly tablePlane = new Plane(new Vector3(0, 0, 1), 0)
+  private readonly dragOffset = new Vector3()
+  private isDragging = false
+  private removeListeners: (() => void) | null = null
+
+  constructor(container: Container) {
+    super(container)
+    this.balls = [...container.table.balls]
+  }
+
+  override onFirst() {
+    this.setupForCurrentBall()
+    this.container.table.cue.aimInputs.setDisabled(false)
+    ;(this.container.view.element as HTMLElement).focus()
+    this.addDragListeners()
+  }
+
+  private setupForCurrentBall() {
+    const ball = this.balls[this.currentIndex]
+    ball.setStationary()
+    ball.updateMesh(0)
+    this.container.table.cue.placeBallMode()
+    this.container.table.cue.showHelper(false)
+    this.container.table.cue.moveTo(ball.pos)
+    this.container.view.camera.forceMode(this.container.view.camera.topView)
+    this.container.table.cue.aimInputs.setButtonText(
+      BALL_LABELS[this.currentIndex] ?? "Place Ball"
+    )
+  }
+
+  private addDragListeners() {
+    const canvas = this.container.view.element as HTMLElement
+    const camera = this.container.view.camera.camera
+
+    const toTable = (clientX: number, clientY: number): Vector3 | null => {
+      const rect = canvas.getBoundingClientRect()
+      const ndc = new Vector2(
+        ((clientX - rect.left) / rect.width) * 2 - 1,
+        -((clientY - rect.top) / rect.height) * 2 + 1
+      )
+      this.raycaster.setFromCamera(ndc, camera)
+      const hit = new Vector3()
+      return this.raycaster.ray.intersectPlane(this.tablePlane, hit) ? hit : null
+    }
+
+    const onPointerDown = (e: PointerEvent) => {
+      const tablePos = toTable(e.clientX, e.clientY)
+      if (!tablePos) return
+      const ball = this.balls[this.currentIndex]
+      this.dragOffset.copy(ball.pos).sub(tablePos)
+      this.isDragging = true
+      canvas.setPointerCapture(e.pointerId)
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!this.isDragging) return
+      try {
+        const tablePos = toTable(e.clientX, e.clientY)
+        if (!tablePos) return
+        const ball = this.balls[this.currentIndex]
+        const newPos = tablePos.add(this.dragOffset)
+        newPos.copy(this.container.rules.placeBall(newPos))
+        newPos.x = Math.fround(newPos.x)
+        newPos.y = Math.fround(newPos.y)
+        newPos.copy(this.container.rules.placeBall(newPos))
+        ball.pos.copy(newPos)
+        CueMesh.indicateValid(!this.container.table.overlapsAny(ball.pos, ball))
+        this.container.table.cue.moveTo(ball.pos)
+      } catch (e) {
+        this.isDragging = false
+        console.error("PlaceAllBalls drag error:", e)
+      }
+    }
+
+    const stopDrag = (e: PointerEvent) => {
+      this.isDragging = false
+      try { canvas.releasePointerCapture(e.pointerId) } catch (_) {}
+    }
+
+    canvas.addEventListener("pointerdown", onPointerDown)
+    canvas.addEventListener("pointermove", onPointerMove)
+    canvas.addEventListener("pointerup", stopDrag)
+    canvas.addEventListener("pointercancel", stopDrag)
+
+    this.removeListeners = () => {
+      canvas.removeEventListener("pointerdown", onPointerDown)
+      canvas.removeEventListener("pointermove", onPointerMove)
+      canvas.removeEventListener("pointerup", stopDrag)
+      canvas.removeEventListener("pointercancel", stopDrag)
+    }
+  }
+
+  override handleInput(input: Input): Controller {
+    try {
+      const ball = this.balls[this.currentIndex]
+      switch (input.key) {
+        case "ArrowLeft":
+          this.moveTo(-input.t * this.placescale, 0)
+          break
+        case "ArrowRight":
+          this.moveTo(input.t * this.placescale, 0)
+          break
+        case "ArrowUp":
+          this.moveTo(0, input.t * this.placescale)
+          break
+        case "ArrowDown":
+          this.moveTo(0, -input.t * this.placescale)
+          break
+        case "movementXUp":
+        case "movementYUp":
+          break
+        case "SpaceUp":
+        case "EnterUp":
+          return this.placed()
+        default:
+          this.commonKeyHandler(input)
+      }
+
+      this.container.table.cue.moveTo(ball.pos)
+      this.container.view.camera.forceMove(this.container.table.cue.aim)
+      this.container.sendEvent(this.container.table.cue.aim)
+    } catch (e) {
+      console.error("PlaceAllBalls.handleInput error:", e)
+    }
+
+    return this
+  }
+
+  private moveTo(dx: number, dy: number) {
+    const ball = this.balls[this.currentIndex]
+    const ballPos = ball.pos.add(new Vector3(dx, dy))
+    ballPos.copy(this.container.rules.placeBall(ballPos))
+    ball.fround()
+    ballPos.copy(this.container.rules.placeBall(ballPos))
+    CueMesh.indicateValid(!this.container.table.overlapsAny(ballPos, ball))
+  }
+
+  private placed(): Controller {
+    const ball = this.balls[this.currentIndex]
+    if (this.container.table.overlapsAny(ball.pos, ball)) {
+      return this
+    }
+    ball.fround()
+    this.currentIndex++
+    if (this.currentIndex < this.balls.length) {
+      this.setupForCurrentBall()
+      return this
+    }
+    this.removeListeners?.()
+    this.removeListeners = null
+    this.isDragging = false
+    this.container.table.cue.aimInputs.setButtonText("Hit")
+    this.container.sound.playNotify()
+    this.container.sendEvent(
+      new BreakEvent(this.container.table.shortSerialise())
+    )
+    this.container.view.camera.forceMode(this.container.view.camera.aimView)
+    return new Aim(this.container)
+  }
+}

--- a/src/controller/rules/drill.ts
+++ b/src/controller/rules/drill.ts
@@ -1,0 +1,56 @@
+import { MathUtils, Vector3 } from "three"
+import { Controller } from "../controller"
+import { Outcome } from "../../model/outcome"
+import { TableGeometry } from "../../view/tablegeometry"
+import { ThreeCushion } from "./threecushion"
+import { Aim } from "../aim"
+
+export class Drill extends ThreeCushion {
+  preShotState: number[] = []
+
+  override allowsPlaceBall(): boolean {
+    return true
+  }
+
+  override placeBall(target?: Vector3): Vector3 {
+    if (!target) return new Vector3(0, 0, 0)
+    target.x = MathUtils.clamp(
+      target.x,
+      -TableGeometry.tableX,
+      TableGeometry.tableX
+    )
+    target.y = MathUtils.clamp(
+      target.y,
+      -TableGeometry.tableY,
+      TableGeometry.tableY
+    )
+    return target
+  }
+
+  override update(outcomes: Outcome[]): Controller {
+    const last = this.container.recorder.last()
+    this.preShotState = this.container.recorder.entries[last]?.state ?? []
+
+    if (Outcome.isThreeCushionPoint(this.cueball, outcomes)) {
+      this.container.sound.playSuccess(outcomes.length / 3)
+      this.currentBreak++
+    } else {
+      this.previousBreak = this.currentBreak
+      this.currentBreak = 0
+      this.cueball = this.otherPlayersCueBall()
+      this.container.table.cueball = this.cueball
+      this.container.table.cue.aim.i = this.container.table.balls.indexOf(
+        this.cueball
+      )
+    }
+    return new Aim(this.container)
+  }
+
+  override isEndOfGame(_outcome: Outcome[]): boolean {
+    return false
+  }
+
+  initialController(): Controller {
+    return new Aim(this.container)
+  }
+}

--- a/src/controller/rules/rulefactory.ts
+++ b/src/controller/rules/rulefactory.ts
@@ -3,12 +3,15 @@ import { EightBall } from "./eightball"
 import { Rules } from "./rules"
 import { Snooker } from "./snooker"
 import { ThreeCushion } from "./threecushion"
+import { Drill } from "./drill"
 
 export class RuleFactory {
   static create(ruletype, container): Rules {
     switch (ruletype) {
       case "threecushion":
         return new ThreeCushion(container)
+      case "threecushion-drill":
+        return new Drill(container)
       case "eightball":
         return new EightBall(container)
       case "snooker":

--- a/src/controller/rules/rules.ts
+++ b/src/controller/rules/rules.ts
@@ -27,4 +27,5 @@ export interface Rules {
   getAmountScored(outcome: Outcome[]): number
   respot(outcome: Outcome[]): Ball[]
   advanceState?(outcome: Outcome[]): void
+  initialController?(): Controller
 }

--- a/src/model/physics/cushion.ts
+++ b/src/model/physics/cushion.ts
@@ -19,6 +19,18 @@ export class Cushion {
   ): number | undefined {
     const futurePosition = ball.futurePosition(t)
 
+    if (!hasPockets) {
+      const overX = Math.abs(futurePosition.x) - TableGeometry.tableX
+      const overY = Math.abs(futurePosition.y) - TableGeometry.tableY
+      if (overX > 0 && overY > 0) {
+        const dir =
+          overX >= overY
+            ? futurePosition.x > 0 ? 0 : Math.PI
+            : futurePosition.y > 0 ? -Math.PI / 2 : Math.PI / 2
+        return Cushion.bounceIn(dir, ball, cushionModel)
+      }
+    }
+
     if (Cushion.willBounceLong(futurePosition, hasPockets)) {
       const dir =
         futurePosition.y > TableGeometry.tableY ? -Math.PI / 2 : Math.PI / 2

--- a/src/model/previewshot.ts
+++ b/src/model/previewshot.ts
@@ -1,0 +1,57 @@
+import { Table } from "./table"
+import { State } from "./ball"
+import { cueStrike } from "./physics/physics"
+
+export function previewShot(table: Table): boolean {
+  const saved = table.balls.map((b) => ({
+    pos: b.pos.clone(),
+    vel: b.vel.clone(),
+    rvel: b.rvel.clone(),
+    state: b.state,
+    pocket: b.pocket,
+  }))
+  const savedOutcome = table.outcome
+
+  let success = false
+  try {
+    table.outcome = []
+    table.balls.forEach((b) => {
+      b.ballmesh.trace.reset()
+      b.ballmesh.trace.line.visible = true
+    })
+
+    const cueball = table.cueball
+    const { angle, power, offset, elevation } = table.cue.aim
+    cueball.state = State.Sliding
+    const strike = cueStrike(angle, power, offset, elevation)
+    cueball.vel.copy(strike.vel)
+    cueball.rvel.copy(strike.rvel)
+
+    const dt = 1 / 240
+    for (let i = 0; i < 10000 && !table.allStationary(); i++) {
+      table.advance(dt)
+      table.updateBallMesh(dt)
+    }
+    success = true
+  } catch (_) {
+    // physics error (e.g. depth exceeded for close-together balls) — restore below
+  } finally {
+    table.balls.forEach((b, i) => {
+      b.pos.copy(saved[i].pos)
+      b.vel.copy(saved[i].vel)
+      b.rvel.copy(saved[i].rvel)
+      b.state = saved[i].state
+      b.pocket = saved[i].pocket
+      b.ballmesh.updatePosition(b.pos)
+    })
+    table.outcome = savedOutcome
+    table.proximityIndicator.hide()
+    if (!success) {
+      table.balls.forEach((b) => {
+        b.ballmesh.trace.line.visible = false
+        b.ballmesh.trace.reset()
+      })
+    }
+  }
+  return success
+}

--- a/src/model/table.ts
+++ b/src/model/table.ts
@@ -134,17 +134,19 @@ export class Table {
       return false
     }
 
-    const k = Knuckle.findBouncing(a, t)
-    if (k) {
-      const knuckleIncidentSpeed = k.bounce(a)
-      this.outcome.push(Outcome.cushion(a, knuckleIncidentSpeed, this.time))
-      return false
-    }
-    const p = Pocket.findPocket(PocketGeometry.pocketCenters, a, t)
-    if (p) {
-      const pocketIncidentSpeed = p.fall(a, t)
-      this.outcome.push(Outcome.pot(a, pocketIncidentSpeed, this.time))
-      return false
+    if (TableGeometry.hasPockets) {
+      const k = Knuckle.findBouncing(a, t)
+      if (k) {
+        const knuckleIncidentSpeed = k.bounce(a)
+        this.outcome.push(Outcome.cushion(a, knuckleIncidentSpeed, this.time))
+        return false
+      }
+      const p = Pocket.findPocket(PocketGeometry.pocketCenters, a, t)
+      if (p) {
+        const pocketIncidentSpeed = p.fall(a, t)
+        this.outcome.push(Outcome.pot(a, pocketIncidentSpeed, this.time))
+        return false
+      }
     }
 
     return true

--- a/src/view/drillpanel.ts
+++ b/src/view/drillpanel.ts
@@ -1,0 +1,224 @@
+import { Container } from "../container/container"
+import { Aim } from "../controller/aim"
+import { PlaceAllBalls } from "../controller/placeallballs"
+import { DrillReplay } from "../controller/drillreplay"
+import { Drill } from "../controller/rules/drill"
+import { previewShot } from "../model/previewshot"
+
+const PREVIEW_DEBOUNCE = 0.15
+
+export class DrillPanel {
+  private readonly container: Container
+  private readonly placeBallsBtn: HTMLButtonElement
+  private readonly retryBtn: HTMLButtonElement
+  private readonly replayBtn: HTMLButtonElement
+  private readonly switchBallBtn: HTMLButtonElement
+  private readonly previewBtn: HTMLButtonElement
+  private previewActive = false
+  private pendingPreview = false
+  private ballsWerePlaced = false
+  private wasPlacing = false
+  private aimStableTime = 0
+  private previewAimSnapshot: {
+    angle: number
+    power: number
+    ox: number
+    oy: number
+    elevation: number
+  } | null = null
+
+  constructor(container: Container) {
+    this.container = container
+
+    this.placeBallsBtn = this.createBtn("Place Balls")
+    this.placeBallsBtn.addEventListener("click", () => {
+      if (this.container.table.allStationary()) {
+        this.container.updateController(new PlaceAllBalls(this.container))
+      }
+    })
+
+    this.retryBtn = this.createBtn("Retry")
+    this.retryBtn.addEventListener("click", () => {
+      const drill = this.container.rules as Drill
+      const recorder = this.container.recorder
+      const last = recorder.last()
+      if (!drill.preShotState.length) return
+      const prevAim = last >= 0 ? (recorder.entries[last].event as any) : null
+      this.container.notification.clear()
+      this.container.table.updateFromShortSerialised(drill.preShotState)
+      if (prevAim?.i !== undefined) {
+        drill.cueball = this.container.table.balls[prevAim.i]
+      }
+      this.container.updateController(new Aim(this.container))
+      if (prevAim) {
+        const aim = this.container.table.cue.aim
+        if (prevAim.angle !== undefined) aim.angle = prevAim.angle
+        if (prevAim.power !== undefined) aim.power = prevAim.power
+        if (prevAim.offset) aim.offset.set(prevAim.offset.x ?? 0, prevAim.offset.y ?? 0, 0)
+        if (prevAim.elevation !== undefined) aim.elevation = prevAim.elevation
+        this.container.table.cue.updateAimInput()
+      }
+    })
+
+    this.replayBtn = this.createBtn("Replay")
+    this.replayBtn.addEventListener("click", () => {
+      const drill = this.container.rules as Drill
+      const recorder = this.container.recorder
+      const last = recorder.last()
+      if (!drill.preShotState.length || last < 0) return
+      this.container.notification.clear()
+      this.container.updateController(
+        new DrillReplay(this.container, drill.preShotState, [
+          recorder.entries[last].event,
+        ])
+      )
+    })
+
+    this.switchBallBtn = this.createBtn("Switch Ball")
+    this.switchBallBtn.addEventListener("click", () => {
+      const drill = this.container.rules as Drill
+      const balls = this.container.table.balls
+      drill.cueball = drill.cueball === balls[0] ? balls[1] : balls[0]
+      const table = this.container.table
+      table.cueball = drill.cueball
+      table.cue.aim.i = balls.indexOf(drill.cueball)
+      table.cue.moveTo(drill.cueball.pos)
+      table.cue.aimAtNext(drill.cueball, drill.nextCandidateBall())
+      table.cue.updateAimInput()
+    })
+
+    this.previewBtn = this.createBtn("Preview")
+    this.previewBtn.addEventListener("click", () => {
+      if (this.previewActive) {
+        this.hidePreview()
+      } else if (previewShot(this.container.table)) {
+        const aim = this.container.table.cue.aim
+        this.previewAimSnapshot = {
+          angle: aim.angle,
+          power: aim.power,
+          ox: aim.offset.x,
+          oy: aim.offset.y,
+          elevation: aim.elevation,
+        }
+        this.previewActive = true
+        this.pendingPreview = false
+        this.aimStableTime = 0
+        this.previewBtn.textContent = "Hide Preview"
+      }
+    })
+
+    const topPanel = document.createElement("div")
+    topPanel.className = "drill-panel drill-panel-top"
+    topPanel.appendChild(this.replayBtn)
+
+    const centerPanel = document.createElement("div")
+    centerPanel.className = "drill-panel"
+    centerPanel.appendChild(this.placeBallsBtn)
+    centerPanel.appendChild(this.retryBtn)
+    centerPanel.appendChild(this.switchBallBtn)
+    const gap = document.createElement("div")
+    gap.className = "drill-gap"
+    centerPanel.appendChild(gap)
+    centerPanel.appendChild(this.previewBtn)
+
+    const root = document.getElementById("viewP1")
+    root?.appendChild(topPanel)
+    root?.appendChild(centerPanel)
+
+    const prevFrame = container.frame
+    container.frame = (t: number) => {
+      prevFrame?.(t)
+      this.update(t)
+    }
+  }
+
+  private createBtn(label: string): HTMLButtonElement {
+    const btn = document.createElement("button") as HTMLButtonElement
+    btn.className = "drill-btn"
+    btn.textContent = label
+    return btn
+  }
+
+  private hidePreview() {
+    this.container.table.showTraces(false)
+    this.container.table.proximityIndicator.hide()
+    this.previewActive = false
+    this.pendingPreview = false
+    this.aimStableTime = 0
+    this.previewAimSnapshot = null
+    this.previewBtn.textContent = "Preview"
+  }
+
+  private runPendingPreview() {
+    this.pendingPreview = false
+    this.aimStableTime = 0
+    if (previewShot(this.container.table)) {
+      const aim = this.container.table.cue.aim
+      this.previewAimSnapshot = {
+        angle: aim.angle,
+        power: aim.power,
+        ox: aim.offset.x,
+        oy: aim.offset.y,
+        elevation: aim.elevation,
+      }
+    }
+  }
+
+  private update(t: number) {
+    const stationary = this.container.table.allStationary()
+    const ctrl = this.container.controller
+    const isAiming = ctrl instanceof Aim
+    const isPlacing = ctrl instanceof PlaceAllBalls
+    const isReplaying = ctrl instanceof DrillReplay
+    const drill = this.container.rules as Drill
+    const hasPreShot = drill.preShotState.length > 0
+    const hasLastShot = this.container.recorder.last() >= 0
+
+    if (this.wasPlacing && !isPlacing) {
+      this.ballsWerePlaced = true
+    }
+    this.wasPlacing = isPlacing
+
+    this.placeBallsBtn.disabled =
+      !stationary || isPlacing || isReplaying || this.previewActive
+    this.retryBtn.disabled = !isAiming || !hasPreShot
+    this.replayBtn.disabled = !isAiming || !hasLastShot
+    this.switchBallBtn.disabled = !isAiming || (!hasPreShot && !this.ballsWerePlaced)
+    this.previewBtn.disabled = !isAiming
+
+    if (this.previewActive) {
+      if (!isAiming) {
+        this.hidePreview()
+        return
+      }
+
+      const a = this.container.table.cue.aim
+      const s = this.previewAimSnapshot!
+      const aimChanged =
+        a.angle !== s.angle ||
+        a.power !== s.power ||
+        a.offset.x !== s.ox ||
+        a.offset.y !== s.oy ||
+        a.elevation !== s.elevation
+
+      if (aimChanged) {
+        this.container.table.showTraces(false)
+        this.container.table.proximityIndicator.hide()
+        this.previewAimSnapshot = {
+          angle: a.angle,
+          power: a.power,
+          ox: a.offset.x,
+          oy: a.offset.y,
+          elevation: a.elevation,
+        }
+        this.pendingPreview = true
+        this.aimStableTime = 0
+      } else if (this.pendingPreview) {
+        this.aimStableTime += t
+        if (this.aimStableTime >= PREVIEW_DEBOUNCE) {
+          this.runPendingPreview()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
New solo practice mode for 3-cushion billiards activated via the &drill URL flag. The mode builds on top of the existing &practice flag and uses ThreeCushion rules as its base.

New files:
- src/controller/rules/drill.ts: Drill extends ThreeCushion - free ball placement anywhere on table, no scoring, auto-switches cueball on miss, stores pre-shot state for retry
- src/controller/placeallballs.ts: places all three balls sequentially using arrow keys (left/right = X axis, up/down = Y axis), Space or Enter confirms each ball
- src/controller/drillreplay.ts: top-view replay of last shot, returns to Aim when finished
- src/model/previewshot.ts: runs physics silently to show ball traces without moving the actual balls
- src/view/drillpanel.ts: left-side UI panel with Place Balls, Retry, Replay, Switch Ball and Preview buttons; Retry restores pre-shot ball positions and exact aim parameters (angle, power, spin, elevation)

Modified files:
- src/controller/rules/rulefactory.ts: added threecushion-drill case
- src/controller/rules/rules.ts: added optional initialController() to the Rules interface
- src/controller/init.ts: uses initialController() when available, falls back to PlaceBall
- src/controller/aim.ts: onFirst clears ball traces and sets button text
- src/container/browsercontainer.ts: reads &drill flag, passes threecushion-drill as effective ruletype, instantiates DrillPanel
- src/model/table.ts: pocket and knuckle detection now guarded by TableGeometry.hasPockets - balls were disappearing into pool-table pocket positions at the corners of the carom table
- src/model/physics/cushion.ts: added corner bounce for hasPockets=false; previous logic had a gap where both X and Y out of bounds caused the ball to escape the table
- dist/css/index.css: added drill-panel, drill-btn and related styles