### PR TITLE
Optimize Web Worker lifecycle in ww.html

### DIFF
--- a/dist/ww.html
+++ b/dist/ww.html
@@ -135,6 +135,23 @@
             });
         }
 
+        const worker = new Worker('worker.js');
+
+        worker.onmessage = (e) => {
+            const data = e.data;
+            if (data.type === 'SIM_COMPLETE' || data.type === 'ERROR') {
+                output.textContent = JSON.stringify(data, null, 2);
+                if (data.type === 'SIM_COMPLETE') {
+                    plotResults(data);
+                }
+            }
+        };
+
+        worker.onerror = (e) => {
+            console.error("Worker Global Error:", e);
+            output.textContent = "Worker Global Error: Check console";
+        };
+
         runBtn.onclick = () => {
             output.textContent = "Starting simulation...";
 
@@ -145,23 +162,6 @@
                 output.textContent = "Invalid JSON input: " + e.message;
                 return;
             }
-
-            const worker = new Worker('worker.js');
-
-            worker.onmessage = (e) => {
-                const data = e.data;
-                if (data.type === 'SIM_COMPLETE' || data.type === 'ERROR') {
-                    output.textContent = JSON.stringify(data, null, 2);
-                    if (data.type === 'SIM_COMPLETE') {
-                        plotResults(data);
-                    }
-                }
-            };
-
-            worker.onerror = (e) => {
-                console.error("Worker Global Error:", e);
-                output.textContent = "Worker Global Error: Check console";
-            };
 
             worker.postMessage(config);
         };


### PR DESCRIPTION
This PR optimizes the performance of the technical Web Worker integration example (`dist/ww.html`).

Previously, a new Worker instance was created on every click of the "Run Simulation" button. This caused a significant delay (up to 4 seconds) due to script compilation and physics engine initialization in the browser.

By moving the worker instantiation and its `onmessage`/`onerror` handlers to the global scope, the worker is now preloaded on page load. Subsequent simulation runs are nearly instantaneous, as they only involve a `postMessage` call to the existing worker.

Changes:
- Refactored `dist/ww.html` script to instantiate the worker once at the top level.
- Moved worker event listeners to the global instance.
- Updated `runSim.onclick` to reuse the existing worker.
- Verified fix with a Playwright script and ensured no regressions with existing unit tests.

---
*PR created automatically by Jules for task [13493299719581827822](https://jules.google.com/task/13493299719581827822) started by @tailuge*