### PR TITLE
Optimize Proximity Indicator Performance and Positioning

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -106,6 +106,7 @@ export class Container {
     this.rules = RuleFactory.create(ruletype, this)
     this.table = this.rules.table()
     this.view = new View(element, this.table, assets)
+    this.view.prepareTable(this.table)
     this.table.cue.aimInputs = new AimInputs(this)
     if (keyboard) {
       this.keyboard = keyboard

--- a/src/view/proximityindicator.ts
+++ b/src/view/proximityindicator.ts
@@ -12,11 +12,15 @@ import {
   PlaneGeometry,
   CanvasTexture,
   LinearFilter,
+  WebGLRenderer,
 } from "three"
 import { R } from "../model/physics/constants"
 import { Ball } from "../model/ball"
 
 export class ProximityIndicator {
+  private static atlasTexture: CanvasTexture | null = null
+  private static readonly reusableVec = new Vector3()
+
   readonly group = new Group()
   private readonly borders: LineLoop[] = []
   private readonly fills: Mesh[] = []
@@ -26,6 +30,36 @@ export class ProximityIndicator {
   cushionCount: number = 0
   hitTarget: boolean = false
   private minDistance: number = Infinity
+
+  static prepare(renderer: WebGLRenderer) {
+    if (typeof document === "undefined") return
+    renderer.initTexture(this.getAtlasTexture())
+  }
+
+  private static getAtlasTexture(): CanvasTexture {
+    if (this.atlasTexture) return this.atlasTexture
+
+    const canvas = document.createElement("canvas")
+    canvas.width = 64
+    canvas.height = 192
+    const ctx = canvas.getContext("2d")
+
+    if (ctx) {
+      ctx.clearRect(0, 0, 64, 192)
+      ctx.font = "bold 44px sans-serif"
+      ctx.fillStyle = "#ffffff"
+      ctx.textAlign = "center"
+      ctx.textBaseline = "middle"
+
+      ctx.fillText("+1", 32, 32)
+      ctx.fillText("+2", 32, 96)
+      ctx.fillText("+3", 32, 160)
+    }
+
+    this.atlasTexture = new CanvasTexture(canvas)
+    this.atlasTexture.minFilter = LinearFilter
+    return this.atlasTexture
+  }
 
   constructor() {
     if (typeof document === "undefined") {
@@ -77,45 +111,22 @@ export class ProximityIndicator {
 
   private initTexts() {
     if (this.proximityTexts.length === 0) {
-      const labels = ["+1", "+2", "+3"]
-      labels.forEach((label) => {
-        const textMesh = this.createPlanarText(label)
+      for (let i = 0; i < 3; i++) {
+        const textMesh = this.createPlanarText(i)
         this.proximityTexts.push(textMesh)
         this.group.add(textMesh)
-      })
+      }
     }
   }
 
-  private createTextTexture(text: string): CanvasTexture {
-    const canvas = document.createElement("canvas")
-    canvas.width = 64
-    canvas.height = 64
-    const ctx = canvas.getContext("2d")
-
-    if (ctx) {
-      // Clear background to full transparency
-      ctx.clearRect(0, 0, 64, 64)
-
-      // Text configuration
-      ctx.font = "bold 44px sans-serif"
-      ctx.fillStyle = "#ffffff"
-      ctx.textAlign = "center"
-      ctx.textBaseline = "middle"
-
-      // Render directly in the center of the 64x64 container
-      ctx.fillText(text, 32, 32)
-    }
-
-    const texture = new CanvasTexture(canvas)
-    texture.minFilter = LinearFilter
-    return texture
-  }
-
-  private createPlanarText(text: string): Mesh {
+  private createPlanarText(index: number): Mesh {
     const size = R * 4
     const geometry = new PlaneGeometry(size, size)
 
-    const texture = this.createTextTexture(text)
+    const texture = ProximityIndicator.getAtlasTexture().clone()
+    texture.repeat.set(1, 1 / 3)
+    texture.offset.set(0, (2 - index) / 3)
+    texture.needsUpdate = true
 
     const material = new MeshBasicMaterial({
       map: texture,
@@ -128,9 +139,8 @@ export class ProximityIndicator {
     const textMesh = new Mesh(geometry, material)
 
     // Position flat on the table (X/Y world plane)
-    // Shifted 1.25 * size along Y as per specification
     // Z is set to 0.01 relative to parent group to sit just above rings
-    textMesh.position.set(0, 1.25 * size, 0.01)
+    textMesh.position.set(0, 0, 0.01)
     textMesh.rotation.set(0, 0, 0)
     textMesh.visible = false
 
@@ -142,9 +152,11 @@ export class ProximityIndicator {
     this.group.visible = true
 
     // Dynamic position relative to ball to prevent clipping under cushions
-
-    const sFlipped = new Vector3(-pos.x, -pos.y, 0)
-    const offset = sFlipped.multiplyScalar(R * 4)
+    // Fixed distance 4r from ball center toward table center
+    const offset = ProximityIndicator.reusableVec
+      .set(-pos.x, -pos.y, 0)
+      .normalize()
+      .multiplyScalar(R * 4)
 
     this.proximityTexts.forEach((textMesh) => {
       textMesh.position.set(offset.x, offset.y, 0.01)

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -6,6 +6,7 @@ import { Grid } from "./grid"
 import { renderer } from "../utils/webgl"
 import { Assets } from "./assets"
 import { Snooker } from "../controller/rules/snooker"
+import { ProximityIndicator } from "./proximityindicator"
 
 export class View {
   readonly scene = new Scene()
@@ -81,6 +82,12 @@ export class View {
     }
 
     this.renderer?.render(this.scene, cam.camera)
+  }
+
+  prepareTable(table: Table) {
+    if (this.renderer && table.proximityIndicator) {
+      ProximityIndicator.prepare(this.renderer)
+    }
   }
 
   private initialiseScene() {

--- a/test/view/proximityindicator.spec.ts
+++ b/test/view/proximityindicator.spec.ts
@@ -1,7 +1,8 @@
-import { expect } from "chai"
+import { expect as chaiExpect } from "chai"
 import { initDom } from "./dom"
 import { ProximityIndicator } from "../../src/view/proximityindicator"
 import { R } from "../../src/model/physics/constants"
+import { Vector3 } from "three"
 
 initDom()
 
@@ -14,30 +15,53 @@ describe("ProximityIndicator", () => {
 
   it("fills advance inward as distance decreases", () => {
     indicator.setProximity(3.5 * R) // inside 4R ring only
-    expect(indicator["fills"][0].visible).to.be.true
-    expect(indicator["fills"][1].visible).to.be.false
-    expect(indicator["fills"][2].visible).to.be.false
+    chaiExpect(indicator["fills"][0].visible).to.be.true
+    chaiExpect(indicator["fills"][1].visible).to.be.false
+    chaiExpect(indicator["fills"][2].visible).to.be.false
 
     indicator.setProximity(2.5 * R) // inside 3R ring
-    expect(indicator["fills"][1].visible).to.be.true
-    expect(indicator["fills"][2].visible).to.be.false
+    chaiExpect(indicator["fills"][1].visible).to.be.true
+    chaiExpect(indicator["fills"][2].visible).to.be.false
   })
 
   it("ratchet: fills do not retreat when distance increases", () => {
     indicator.setProximity(2.5 * R) // inside 3R ring
-    expect(indicator["fills"][0].visible).to.be.true
-    expect(indicator["fills"][1].visible).to.be.true
+    chaiExpect(indicator["fills"][0].visible).to.be.true
+    chaiExpect(indicator["fills"][1].visible).to.be.true
 
     indicator.setProximity(3.5 * R) // ball moves away - should not reduce fills
-    expect(indicator["fills"][0].visible).to.be.true
-    expect(indicator["fills"][1].visible).to.be.true
+    chaiExpect(indicator["fills"][0].visible).to.be.true
+    chaiExpect(indicator["fills"][1].visible).to.be.true
   })
 
   it("hide resets ratchet", () => {
     indicator.setProximity(2.5 * R)
     indicator.hide()
     indicator.setProximity(3.5 * R) // after reset, only outer ring
-    expect(indicator["fills"][0].visible).to.be.true
-    expect(indicator["fills"][1].visible).to.be.false
+    chaiExpect(indicator["fills"][0].visible).to.be.true
+    chaiExpect(indicator["fills"][1].visible).to.be.false
+  })
+
+  it("positions text at a fixed distance 4R from ball center toward table center", () => {
+    const pos = new Vector3(1, 1, 0)
+    indicator.showAt(pos)
+
+    indicator["proximityTexts"].forEach((textMesh) => {
+      // Distance from group center (ball center) to textMesh position (XY only)
+      const distanceXY = Math.sqrt(
+        textMesh.position.x ** 2 + textMesh.position.y ** 2
+      )
+      chaiExpect(distanceXY).to.be.closeTo(4 * R, 0.0001)
+
+      // Direction should be toward (0,0,0) from (1,1,0), which is (-1,-1,0)
+      const direction = new Vector3(
+        textMesh.position.x,
+        textMesh.position.y,
+        0
+      ).normalize()
+      const expectedDirection = new Vector3(-1, -1, 0).normalize()
+      chaiExpect(direction.x).to.be.closeTo(expectedDirection.x, 0.0001)
+      chaiExpect(direction.y).to.be.closeTo(expectedDirection.y, 0.0001)
+    })
   })
 })


### PR DESCRIPTION
This change addresses the stuttering issue in the proximity indicator by pre-computing text textures and pre-warming them on the GPU. It also improves the visual consistency by ensuring labels are always at a fixed distance of 4R from the ball center.

---
*PR created automatically by Jules for task [11695367003892291270](https://jules.google.com/task/11695367003892291270) started by @tailuge*