### PR TITLE
Improve Collision Throw Accuracy (Alciatore CIT)

### DIFF
--- a/src/diagram/throw_gpt4o.ts
+++ b/src/diagram/throw_gpt4o.ts
@@ -2,10 +2,9 @@ import { Vector3 } from "three"
 import { Ball } from "../model/ball"
 import { up, zero } from "../utils/three-utils"
 import { Collision } from "../model/physics/collision"
+import { R } from "../model/physics/constants"
 
 export class CollisionThrowPlot {
-  public static readonly R: number = 0.029 // ball radius in meters
-
   // Friction parameters
   private static readonly a: number = 0.01 // Minimum friction coefficient
   private static readonly b: number = 0.108 // Range of friction variation
@@ -30,27 +29,32 @@ export class CollisionThrowPlot {
     ϕ: number
   ): number {
     return Math.sqrt(
-      Math.pow(v * Math.sin(ϕ) - ωz * CollisionThrowPlot.R, 2) +
-        Math.pow(Math.cos(ϕ) * ωx * CollisionThrowPlot.R, 2)
+      Math.pow(v * Math.sin(ϕ) - ωz * R, 2) +
+        Math.pow(Math.cos(ϕ) * ωx * R, 2)
     )
   }
 
-  public throwAngle(v: number, ωx: number, ωz: number, ϕ: number): number {
+  public throwAngle(
+    v: number,
+    ωx: number,
+    ωz: number,
+    ϕ: number,
+    e: number = 0.925
+  ): number {
     const vRel = this.relativeVelocity(v, ωx, ωz, ϕ)
     const μ = this.dynamicFriction(vRel)
+    const e_factor = (1 + e) / 2
     const numerator =
-      Math.min((μ * v * Math.cos(ϕ)) / vRel, 1 / 7) *
-      (v * Math.sin(ϕ) - CollisionThrowPlot.R * ωz)
-    const denominator = v * Math.cos(ϕ)
+      Math.min((μ * e_factor * v * Math.cos(ϕ)) / vRel, 1 / 7) *
+      (v * Math.sin(ϕ) - R * ωz)
+    const denominator = e_factor * v * Math.cos(ϕ)
     this.log(`inputs:v=${v}, ωx=${ωx}, ωz=${ωz}, ϕ=${ϕ}`)
     this.log(`   v * Math.sin(ϕ) =${v * Math.sin(ϕ)}`)
-    this.log(`   CollisionThrow.R * ωz =${CollisionThrowPlot.R * ωz}`)
+    this.log(`   R * ωz =${R * ωz}`)
     this.log(
-      `   Math.min((μ * v * Math.cos(ϕ)) / vRel, 1 / 7) =${Math.min((μ * v * Math.cos(ϕ)) / vRel, 1 / 7)}`
+      `   Math.min((μ * e_factor * v * Math.cos(ϕ)) / vRel, 1 / 7) =${Math.min((μ * e_factor * v * Math.cos(ϕ)) / vRel, 1 / 7)}`
     )
-    this.log(
-      `   (v * Math.sin(ϕ) - CollisionThrow.R * ωz) =${v * Math.sin(ϕ) - CollisionThrowPlot.R * ωz}`
-    )
+    this.log(`   (v * Math.sin(ϕ) - R * ωz) =${v * Math.sin(ϕ) - R * ωz}`)
     this.log("")
     this.log("vRel = ", vRel)
     this.log("μ = ", μ)
@@ -70,7 +74,7 @@ export class CollisionThrowPlot {
     a.vel.copy(new Vector3(0, v, 0))
     a.rvel.copy(new Vector3(ωx, 0, ωz))
 
-    const straight = new Vector3(0, 2 * CollisionThrowPlot.R)
+    const straight = new Vector3(0, 2 * R)
     const bpos = straight.applyAxisAngle(up, ϕ)
     const b = new Ball(bpos)
 

--- a/src/model/physics/collisionthrow.ts
+++ b/src/model/physics/collisionthrow.ts
@@ -37,51 +37,52 @@ export class CollisionThrow {
       )
 
     const vRelNormalMag = ab.dot(vPoint)
-    const vRel = vPoint.addScaledVector(ab, -vRelNormalMag)
-    const vRelMag = vRel.length()
-    const vRelTangential = abTangent.dot(vRel) // slip velocity perpendicular to line of impact
+    const vRelTangentialVec = vPoint.clone().addScaledVector(ab, -vRelNormalMag)
+    const vRelMag = vRelTangentialVec.length()
 
     const μ = this.dynamicFriction(vRelMag)
-
-    // let normalImpulse = vRelNormalMag;
-    // let tangentialImpulse = Math.min((μ * vRelNormalMag) / vRelMag, 1 / 7) * (-vRelTangential)
-    // matches paper when throwAngle = Math.atan2(tangentialImpulse, normalImpulse)
 
     // Normal impulse (inelastic collision)
     this.normalImpulse = (-(1 + e) * vRelNormalMag) / (2 / m)
 
     // Tangential impulse (frictional constraint)
-    this.tangentialImpulse =
-      0.3 *
-      Math.min((μ * Math.abs(this.normalImpulse)) / vRelMag, 1 / 7) *
-      -vRelTangential
+    let impulseTangential = new Vector3(0, 0, 0)
+    if (vRelMag > 1e-8) {
+      const maxJt_friction = μ * Math.abs(this.normalImpulse)
+      const maxJt_stick = (m / 7) * vRelMag
+      const jtMag = Math.min(maxJt_friction, maxJt_stick)
+      impulseTangential = vRelTangentialVec
+        .clone()
+        .multiplyScalar(-jtMag / vRelMag)
+      this.tangentialImpulse = impulseTangential.dot(abTangent)
+    } else {
+      this.tangentialImpulse = 0
+    }
 
     // Impulse vectors
     const impulseNormal = ab.clone().multiplyScalar(this.normalImpulse)
-    const impulseTangential = abTangent
-      .clone()
-      .multiplyScalar(this.tangentialImpulse)
 
-    // Apply impulses to linear velocities
+    // Apply impulses to linear velocities (constrained to XY plane)
     a.vel
       .addScaledVector(impulseNormal, 1 / m)
       .addScaledVector(impulseTangential, 1 / m)
+    a.vel.z = 0
     b.vel
       .addScaledVector(impulseNormal, -1 / m)
       .addScaledVector(impulseTangential, -1 / m)
+    b.vel.z = 0
 
     // Angular velocity updates
-    const angularImpulseA = ab
-      .clone()
-      .multiplyScalar(-R)
-      .cross(impulseTangential)
-    const angularImpulseB = ab
-      .clone()
-      .multiplyScalar(R)
-      .cross(impulseTangential)
+    // Jt is the tangential impulse applied TO ball A.
+    // The force acts at the contact point relative to ball A: rA = R * ab
+    // Torque for A: tauA = rA x Jt = (R * ab) x Jt
+    // For ball B, the impulse is -Jt and it acts at rB = -R * ab
+    // Torque for B: tauB = rB x (-Jt) = (-R * ab) x (-Jt) = (R * ab) x Jt
+    // Thus both balls receive the SAME angular impulse.
+    const angularImpulse = ab.clone().multiplyScalar(R).cross(impulseTangential)
 
-    a.rvel.addScaledVector(angularImpulseA, 1 / I)
-    b.rvel.addScaledVector(angularImpulseB, 1 / I)
+    a.rvel.addScaledVector(angularImpulse, 1 / I)
+    b.rvel.addScaledVector(angularImpulse, 1 / I)
 
     return vRelNormalMag
   }

--- a/test/model/physics/collisionthrow.spec.ts
+++ b/test/model/physics/collisionthrow.spec.ts
@@ -1,0 +1,27 @@
+
+import { expect as chaiExpect } from "chai"
+import { CollisionThrowPlot } from "../../../src/diagram/throw_gpt4o";
+
+describe("CollisionThrow Accuracy", () => {
+  const model = new CollisionThrowPlot();
+
+  function check(v, wx, wz, phiDeg) {
+    const phi = phiDeg * Math.PI / 180;
+    const expected = model.throwAngle(v, wx, wz, phi) * 180 / Math.PI;
+    const actual = model.plot(v, wx, wz, phi) * 180 / Math.PI;
+
+    console.log(`v=${v}, wx=${wx}, wz=${wz}, phi=${phiDeg}: Expected=${expected.toFixed(4)}, Actual=${actual.toFixed(4)}, Ratio=${(actual/expected).toFixed(4)}`);
+
+    chaiExpect(actual).to.be.closeTo(expected, 1e-4, `Failed for v=${v}, wx=${wx}, wz=${wz}, phi=${phiDeg}`);
+  }
+
+  it("matches paper formula for various inputs", () => {
+    check(1, 0, 0, 15);
+    check(1, 0, 0, 30);
+    check(1, 0, 0, 45);
+    check(0.5, 0, 0, 30);
+    check(2, 0, 0, 30);
+    check(1, 20, 0, 30);
+    check(1, 0, 20, 30);
+  });
+});


### PR DESCRIPTION
I have reviewed and improved the collision throw (CIT) implementation to align with Alciatore's research.

Key improvements:
- Removed an undocumented 0.3 multiplier that was artificially reducing throw.
- Corrected the sticking (gearing) limit to `(m/7) * vRelMag`, which is physically derived from the moment of inertia of a sphere.
- Updated the tangential impulse to be a 3D vector, allowing the engine to correctly process throw effects from top-spin, back-spin, and side-spin simultaneously.
- Explicitly constrained the resulting linear velocities to the XY plane (`vel.z = 0`) to maintain 2D gameplay while still allowing vertical impulses to transfer spin.
- Fixed the angular impulse logic to ensure that torque is applied consistently to both balls involved in the collision.
- Updated the diagnostic plotter and added a new unit test suite that verifies the engine's output against the analytical equations for throw angle, accounting for the inelastic coefficient of restitution.

---
*PR created automatically by Jules for task [8032147573940746585](https://jules.google.com/task/8032147573940746585) started by @tailuge*