### PR TITLE
Add environment map to ball materials for high LOD

### DIFF
--- a/src/view/ballenvmapfactory.ts
+++ b/src/view/ballenvmapfactory.ts
@@ -1,0 +1,63 @@
+import {
+  CanvasTexture,
+  EquirectangularReflectionMapping,
+  TextureLoader,
+} from "three"
+
+export class BallEnvMapFactory {
+  private static envMap: CanvasTexture | null = null
+
+  static getEnvMap(): CanvasTexture {
+    if (this.envMap) {
+      return this.envMap
+    }
+
+    const canvas = document.createElement("canvas")
+    canvas.width = 512
+    canvas.height = 256
+    const ctx = canvas.getContext("2d")
+
+    if (ctx) {
+      // Simple room placeholder: sky-ish top, dark bottom, some lights
+      const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height)
+      gradient.addColorStop(0, "#222233")
+      gradient.addColorStop(0.5, "#111111")
+      gradient.addColorStop(1, "#222222")
+      ctx.fillStyle = gradient
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      // Fake lights
+      ctx.fillStyle = "#ffffff"
+      ctx.beginPath()
+      ctx.arc(128, 64, 20, 0, Math.PI * 2)
+      ctx.fill()
+
+      ctx.fillStyle = "#ffffcc"
+      ctx.beginPath()
+      ctx.arc(384, 80, 15, 0, Math.PI * 2)
+      ctx.fill()
+    }
+
+    this.envMap = new CanvasTexture(canvas)
+    this.envMap.mapping = EquirectangularReflectionMapping
+
+    // Try to load room.jpg
+    if (typeof process === "undefined") {
+      new TextureLoader().load(
+        "room.jpg",
+        (texture) => {
+          if (this.envMap) {
+            this.envMap.image = texture.image
+            this.envMap.needsUpdate = true
+          }
+        },
+        undefined,
+        () => {
+          // Silent fail as it is a placeholder
+        }
+      )
+    }
+
+    return this.envMap
+  }
+}

--- a/src/view/ballmaterialfactory.ts
+++ b/src/view/ballmaterialfactory.ts
@@ -7,6 +7,7 @@ import {
 import { R } from "../model/physics/constants"
 import { BallTextureFactory } from "./balltexturefactory"
 import { BallCubeTextureFactory } from "./ballcubetexturefactory"
+import { BallEnvMapFactory } from "./ballenvmapfactory"
 import { Session } from "../network/client/session"
 
 export class BallMaterialFactory {
@@ -16,7 +17,8 @@ export class BallMaterialFactory {
   > = new Map()
 
   static createTexturedDotsMaterial(color: Color): MeshPhysicalMaterial {
-    const key = `texturedDots_${color.getHex()}`
+    const lod = Session.getLod()
+    const key = `texturedDots_${color.getHex()}_lod${lod}`
     if (this.materialCache.has(key)) {
       return this.materialCache.get(key) as MeshPhysicalMaterial
     }
@@ -29,6 +31,7 @@ export class BallMaterialFactory {
       clearcoat: 1.0,
       clearcoatRoughness: 0.02,
       reflectivity: 0.25,
+      envMap: lod >= 4 ? BallEnvMapFactory.getEnvMap() : null,
     })
 
     material.onBeforeCompile = (shader: any) => {
@@ -59,7 +62,8 @@ export class BallMaterialFactory {
   }
 
   static createDottedMaterial(color: Color): MeshPhongMaterial {
-    const key = `dotted_${color.getHex()}`
+    const lod = Session.getLod()
+    const key = `dotted_${color.getHex()}_lod${lod}`
     if (this.materialCache.has(key)) {
       return this.materialCache.get(key) as MeshPhongMaterial
     }
@@ -73,6 +77,7 @@ export class BallMaterialFactory {
       specular: 0x555533,
       transparent: false,
       depthWrite: true,
+      envMap: lod >= 4 ? BallEnvMapFactory.getEnvMap() : null,
     })
     this.materialCache.set(key, material)
     return material
@@ -83,7 +88,8 @@ export class BallMaterialFactory {
     color: Color,
     size = 256
   ): MeshStandardMaterial {
-    const key = `projected_${label}_${color.getHex()}_${size}`
+    const lod = Session.getLod()
+    const key = `projected_${label}_${color.getHex()}_${size}_lod${lod}`
     if (this.materialCache.has(key)) {
       return this.materialCache.get(key) as MeshStandardMaterial
     }
@@ -95,7 +101,7 @@ export class BallMaterialFactory {
     )
 
     const material =
-      Session.getLod() <= 1
+      lod <= 1
         ? new MeshStandardMaterial({
             color: color,
             roughness: 0.5,
@@ -111,6 +117,7 @@ export class BallMaterialFactory {
             clearcoat: 1.0,
             clearcoatRoughness: 0.02,
             reflectivity: 0.25,
+            envMap: lod >= 4 ? BallEnvMapFactory.getEnvMap() : null,
           })
 
     material.onBeforeCompile = (shader: any) => {

--- a/test/view/ballmaterialfactory.spec.ts
+++ b/test/view/ballmaterialfactory.spec.ts
@@ -1,9 +1,19 @@
 import { expect } from "chai"
-import { Color, MeshPhysicalMaterial, MeshStandardMaterial } from "three"
+import {
+  Color,
+  MeshPhongMaterial,
+  MeshPhysicalMaterial,
+  MeshStandardMaterial,
+} from "three"
 import { BallMaterialFactory } from "../../src/view/ballmaterialfactory"
 import { R } from "../../src/model/physics/constants"
+import { Session } from "../../src/network/client/session"
 
 describe("BallMaterialFactory", () => {
+  beforeEach(() => {
+    Session.reset()
+  })
+
   it("creates a projected material with correct uniforms", () => {
     const color = new Color(0xff0000)
     const label = 8
@@ -67,5 +77,36 @@ describe("BallMaterialFactory", () => {
     expect(shader.fragmentShader).to.contain(
       "textureCube(uCubeMap, normalize(vLocalPos))"
     )
+  })
+
+  it("applies environment map when LOD >= 4", () => {
+    Session.init("test", "player", "table", false, false, false, 4)
+    const color = new Color(0xffffff)
+
+    const dotted = BallMaterialFactory.createDottedMaterial(color)
+    expect(dotted).to.be.an.instanceOf(MeshPhongMaterial)
+    expect(dotted.envMap).to.not.be.null
+
+    const textured = BallMaterialFactory.createTexturedDotsMaterial(color)
+    expect(textured).to.be.an.instanceOf(MeshPhysicalMaterial)
+    expect(textured.envMap).to.not.be.null
+
+    const projected = BallMaterialFactory.createProjectedMaterial(1, color)
+    expect(projected).to.be.an.instanceOf(MeshPhysicalMaterial)
+    expect(projected.envMap).to.not.be.null
+  })
+
+  it("does not apply environment map when LOD < 4", () => {
+    Session.init("test", "player", "table", false, false, false, 3)
+    const color = new Color(0xffffff)
+
+    const dotted = BallMaterialFactory.createDottedMaterial(color)
+    expect(dotted.envMap).to.be.null
+
+    const textured = BallMaterialFactory.createTexturedDotsMaterial(color)
+    expect(textured.envMap).to.be.null
+
+    const projected = BallMaterialFactory.createProjectedMaterial(1, color)
+    expect(projected.envMap).to.be.null
   })
 })


### PR DESCRIPTION
This PR introduces an environment map to the ball materials to enhance lighting and reflections when the Level of Detail (LOD) is set to 4 or higher.

Key changes:
- Created `BallEnvMapFactory` which generates a procedural `CanvasTexture` as a placeholder for a room environment. It also attempts to load an external `room.jpg` image if available.
- Modified `BallMaterialFactory` to inject the environment map into `MeshPhysicalMaterial`, `MeshPhongMaterial`, and `MeshStandardMaterial` when `Session.getLod() >= 4`.
- Updated the material caching mechanism in `BallMaterialFactory` to include the LOD in the cache keys, ensuring that materials are correctly regenerated when the detail level changes.
- Added comprehensive unit tests in `test/view/ballmaterialfactory.spec.ts` to verify the LOD-based application of the environment map.

Verification:
- Ran unit tests: `yarn jest test/view/ballmaterialfactory.spec.ts` (All passed).
- Performed visual verification using Playwright to confirm the application of the environment map at LOD 4 and its absence at LOD 1.

---
*PR created automatically by Jules for task [15254596638874027460](https://jules.google.com/task/15254596638874027460) started by @tailuge*