### PR TITLE
Show only local high breaks in game-over notification

### DIFF
--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -24,7 +24,17 @@ export abstract class ControllerBase extends Controller {
   }
 
   override handleNotification(event: NotificationEvent): Controller {
-    this.container.notification.show(event.data, event.duration)
+    const data = event.data
+    if (
+      typeof data !== "string" &&
+      data.type === "GameOver" &&
+      !data.highBreaks
+    ) {
+      data.highBreaks = this.container.ballTray
+        .getTopBreaks(3)
+        .map(({ score, hiScoreUri }) => ({ score, url: hiScoreUri }))
+    }
+    this.container.notification.show(data, event.duration)
     return this
   }
 

--- a/src/network/client/matchresult.ts
+++ b/src/network/client/matchresult.ts
@@ -155,7 +155,6 @@ export class MatchResultHelper {
       new NotificationEvent({
         type: "GameOver",
         title: "YOU LOST",
-        highBreaks: this.getHighBreaks(container),
         icon: "🥈",
         extraClass: "is-loser",
         extra: this.getRemoteGameOverButtons(rulename),
@@ -173,7 +172,6 @@ export class MatchResultHelper {
       new NotificationEvent({
         type: "GameOver",
         title: "YOU WON",
-        highBreaks: this.getHighBreaks(container),
         icon: "🏆",
         extraClass: "is-winner",
         extra: this.getRemoteGameOverButtons(rulename),


### PR DESCRIPTION
This change fixes an issue in 2-player games where the game-over notification would show high breaks from both players (or specifically, the opponent's breaks if they won). 

By removing the `highBreaks` field from the `NotificationEvent` that is broadcast to the other player, we ensure that break data is not "leaked" to the opponent. On the receiving end, `ControllerBase.handleNotification` now detects if a `GameOver` notification is missing its `highBreaks` list and populates it from the local `BallTray`. Because the local `BallTray` only records shots and breaks taken by the local player during a multiplayer match, this correctly results in each player seeing only their own best breaks for upload.

I also reverted more complex changes to `BallTray`, `Recorder`, and `MatchResultHelper` that attempted to track `clientId` per break, as the simpler "Notification Privacy" approach combined with local decoration was sufficient and preferred.

---
*PR created automatically by Jules for task [15241300546706487887](https://jules.google.com/task/15241300546706487887) started by @tailuge*