### PR TITLE
Update Eight-Ball rules for pocketing opponent balls

### DIFF
--- a/src/controller/rules/eightball.ts
+++ b/src/controller/rules/eightball.ts
@@ -258,6 +258,7 @@ export class EightBall implements Rules {
       return this.respotEightBallFoul()
     }
 
+    const myGroupBefore = session.p1type
     if (session.p1type === 0) {
       const solids = pots.filter((b) => b.label! >= 1 && b.label! <= 7)
       const stripes = pots.filter((b) => b.label! >= 9 && b.label! <= 15)
@@ -286,6 +287,14 @@ export class EightBall implements Rules {
     this.container.sendEvent(scoreEvent)
 
     this.container.sendEvent(new WatchEvent(table.serialise()))
+
+    if (myGroupBefore !== 0) {
+      const myGroupPotted = pots.some((b) => this.isMyType(b, myGroupBefore))
+      if (!myGroupPotted) {
+        return this.handleMiss()
+      }
+    }
+
     return new Aim(this.container)
   }
 

--- a/test/rules/eightball.spec.ts
+++ b/test/rules/eightball.spec.ts
@@ -8,6 +8,8 @@ import { EightBall } from "../../src/controller/rules/eightball"
 import { Assets } from "../../src/view/assets"
 import { initDom } from "../view/dom"
 import { PlaceBall } from "../../src/controller/placeball"
+import { Aim } from "../../src/controller/aim"
+import { WatchAim } from "../../src/controller/watchaim"
 import { End } from "../../src/controller/end"
 import { Session } from "../../src/network/client/session"
 import { ScoreEvent } from "../../src/events/scoreevent"
@@ -272,5 +274,50 @@ describe("EightBall Rules", () => {
     })
     const candidate = eightball.nextCandidateBall()
     expect(candidate?.label).to.equal(8)
+  })
+
+  it("should continue turn if both own and opponent balls are potted (own hit first)", () => {
+    Session.getInstance().p1type = 1 // Solids
+    const myBall = container.table.balls.find((b) => b.label === 1)!
+    const opponentBall = container.table.balls.find((b) => b.label === 9)!
+
+    const outcome = [
+      Outcome.collision(container.table.cueball, myBall, 1),
+      Outcome.pot(myBall, 1),
+      Outcome.pot(opponentBall, 2),
+    ]
+
+    const nextController = eightball.update(outcome)
+    expect(nextController).to.be.an.instanceof(Aim)
+  })
+
+  it("should end turn if only opponent ball is potted (own hit first)", () => {
+    container.isSinglePlayer = false
+    Session.getInstance().p1type = 1 // Solids
+    const myBall = container.table.balls.find((b) => b.label === 1)!
+    const opponentBall = container.table.balls.find((b) => b.label === 9)!
+
+    const outcome = [
+      Outcome.collision(container.table.cueball, myBall, 1),
+      Outcome.pot(opponentBall, 1),
+    ]
+
+    const nextController = eightball.update(outcome)
+    // Should return WatchAim or handleMiss result which is WatchAim for multiplayer
+    expect(nextController).to.be.an.instanceof(WatchAim)
+  })
+
+  it("should continue turn if any ball potted on open table", () => {
+    Session.getInstance().p1type = 0 // Open table
+    const ball1 = container.table.balls.find((b) => b.label === 1)!
+    const ball9 = container.table.balls.find((b) => b.label === 9)!
+
+    const outcome = [
+      Outcome.collision(container.table.cueball, ball1, 1),
+      Outcome.pot(ball9, 1),
+    ]
+
+    const nextController = eightball.update(outcome)
+    expect(nextController).to.be.an.instanceof(Aim)
   })
 })


### PR DESCRIPTION
This PR updates the Eight-Ball rules to align with standard tournament play regarding pocketing opponent balls.

Key changes:
- If a player has a group assigned (solids or stripes), they must pocket at least one ball from their own group to continue their turn, even if they pocket an opponent's ball legally (by hitting their own group first).
- If no balls from their own group are pocketed, but the shot was otherwise legal, the turn ends (but it is not a foul).
- The "open table" behavior remains unchanged: pocketing any ball (other than the 8-ball or cue ball) continues the turn.
- Comprehensive unit tests have been added to verify these scenarios.

---
*PR created automatically by Jules for task [11030236296046284089](https://jules.google.com/task/11030236296046284089) started by @tailuge*