### PR TITLE
Add 'track all' balls mode to Fit Tooling

### DIFF
--- a/dist/fit/optimise.js
+++ b/dist/fit/optimise.js
@@ -15,7 +15,7 @@ const getValue = (simConfig, name) => {
 const decode = (norm, specs) =>
   Object.fromEntries(specs.map((s, i) => [s.name, s.min + Math.max(0, Math.min(1, norm[i])) * (s.max - s.min)]))
 
-function runSimSync(simConfig, truth) {
+function runSimSync(simConfig, truth, trackAll = false) {
   const result = window.simulateSync(simConfig)
   const simStep = simConfig.stepSize ?? 0.001953125
   const simTracks = {}
@@ -26,13 +26,13 @@ function runSimSync(simConfig, truth) {
   }
   const trackKeys = Object.keys(simTracks)
   const track0len = simTracks[0]?.length ?? 'MISSING'
-  const rawRmse = truth ? computeRMSE(truth, simTracks, simStep) : 'NO_TRUTH'
+  const rawRmse = truth ? computeRMSE(truth, simTracks, simStep, trackAll) : 'NO_TRUTH'
   console.log(`[runSimSync] frames=${result.frames.length} trackKeys=${JSON.stringify(trackKeys)} track0len=${track0len} truth=${!!truth} rawRmse=${rawRmse}`)
   const rmse = truth ? rawRmse : null
   return { simTracks, simStep, frames: result.frames, rmse }
 }
 
-function makeTarget(simConfig, truth, specs) {
+function makeTarget(simConfig, truth, specs, trackAll = false) {
   let lastRmse = Infinity
   const target = (norm) => {
     const tuned = decode(norm, specs)
@@ -47,7 +47,7 @@ function makeTarget(simConfig, truth, specs) {
         config.params[name] = val
       }
     }
-    const { rmse } = runSimSync(config, truth)
+    const { rmse } = runSimSync(config, truth, trackAll)
     lastRmse = rmse ?? Infinity
     console.log('[opt] trial tuned:', JSON.stringify(tuned), '→ rmse:', lastRmse)
     return lastRmse
@@ -62,9 +62,9 @@ function makeInitial(simConfig, specs) {
   })
 }
 
-export async function runOptimiseNM(simConfig, truth, specs, onStep, signal) {
+export async function runOptimiseNM(simConfig, truth, specs, onStep, signal, trackAll = false) {
   const initial = makeInitial(simConfig, specs)
-  const target = makeTarget(simConfig, truth, specs)
+  const target = makeTarget(simConfig, truth, specs, trackAll)
   const opt = new Simplex(target, initial, {})
 
   let iter = 0
@@ -79,9 +79,9 @@ export async function runOptimiseNM(simConfig, truth, specs, onStep, signal) {
   }
 }
 
-export async function runOptimisePSO(simConfig, truth, specs, onStep, signal) {
+export async function runOptimisePSO(simConfig, truth, specs, onStep, signal, trackAll = false) {
   const initial = makeInitial(simConfig, specs)
-  const target = makeTarget(simConfig, truth, specs)
+  const target = makeTarget(simConfig, truth, specs, trackAll)
 
   const opt = new pso.Optimizer()
   opt.setOptions({ inertiaWeight: 0.8, social: 0.4, personal: 0.4, pressure: 0.5 })

--- a/dist/fit/plot.js
+++ b/dist/fit/plot.js
@@ -5,7 +5,7 @@ export const HALF_H = 0.03275 * 46.18 / 2
 const COLORS = ['#000', '#b8860b', '#c00']
 const SIM_COLORS = ['rgba(0,100,255,0.5)', 'rgba(255,140,0,0.7)', 'rgba(200,0,0,0.7)']
 
-export function redraw(canvas, truth, simTracks, simStep) {
+export function redraw(canvas, truth, simTracks, simStep, trackAll = false) {
   const W = canvas.width
   const H = canvas.height
   const ctx = canvas.getContext('2d')
@@ -32,6 +32,7 @@ export function redraw(canvas, truth, simTracks, simStep) {
     ctx.strokeStyle = 'rgba(255,0,0,0.25)'
     ctx.lineWidth = 1
     for (const { ball, t, x, y } of truth) {
+      if (!trackAll && ball !== 0) continue
       const track = simTracks[ball]
       if (!track) continue
       const s = interpolateTrack(track, t, simStep)

--- a/dist/fit/rmse.js
+++ b/dist/fit/rmse.js
@@ -8,14 +8,17 @@ export function interpolateTrack(track, t, simStep) {
   return { x: a.x + alpha * (b.x - a.x), y: a.y + alpha * (b.y - a.y) }
 }
 
-export function computeRMSE(truth, simTracks, simStep) {
-  const track0 = simTracks[0]
-  if (!track0) return null
-  const mover = truth.filter(s => s.ball === 0)
-  if (mover.length === 0) return 0
-  const sse = mover.reduce((sum, { t, x, y }) => {
-    const s = interpolateTrack(track0, t, simStep)
-    return sum + (x - s.x) ** 2 + (y - s.y) ** 2
-  }, 0)
-  return Math.sqrt(sse / mover.length)
+export function computeRMSE(truth, simTracks, simStep, trackAll = false) {
+  const relevant = trackAll ? truth : truth.filter(s => s.ball === 0)
+  if (relevant.length === 0) return 0
+  let sse = 0
+  let count = 0
+  for (const { ball, t, x, y } of relevant) {
+    const track = simTracks[ball]
+    if (!track) continue
+    const s = interpolateTrack(track, t, simStep)
+    sse += (x - s.x) ** 2 + (y - s.y) ** 2
+    count++
+  }
+  return count > 0 ? Math.sqrt(sse / count) : null
 }

--- a/dist/fit/sim.js
+++ b/dist/fit/sim.js
@@ -1,7 +1,7 @@
 import { SimulationRunner } from '../ww.js'
 import { computeRMSE } from './rmse.js'
 
-export async function runSim(simConfig, truth) {
+export async function runSim(simConfig, truth, trackAll = false) {
   const runner = new SimulationRunner('../worker.js', false)
   const result = await runner.spawn(simConfig)
   const simStep = simConfig.stepSize ?? 0.001953125
@@ -11,6 +11,6 @@ export async function runSim(simConfig, truth) {
       ;(simTracks[b.id] ??= []).push({ x: b.pos[0], y: b.pos[1] })
     }
   }
-  const rmse = truth ? computeRMSE(truth, simTracks, simStep) : null
+  const rmse = truth ? computeRMSE(truth, simTracks, simStep, trackAll) : null
   return { simTracks, simStep, frames: result.frames, rmse }
 }

--- a/dist/fit/viewer.html
+++ b/dist/fit/viewer.html
@@ -64,6 +64,7 @@
             <option value="nm">Nelder-Mead</option>
             <option value="pso">PSO</option>
           </select>
+          <label style="display:flex; align-items:center; gap:2px"><input type="checkbox" id="trackAll">track all</label>
           <button id="optBtn" disabled>Optimise</button>
           <button id="stopBtn" disabled>Stop</button>
         </div>
@@ -160,7 +161,8 @@
 
       function updateDrawing() {
         if (!loadedData) return
-        redraw(canvas, loadedData.truth, simTracks, simStep)
+        const trackAll = document.getElementById("trackAll").checked
+        redraw(canvas, loadedData.truth, simTracks, simStep, trackAll)
       }
 
       function buildParamRows(sim) {
@@ -278,6 +280,7 @@
       async function onRunSim() {
         const btn = document.getElementById("simBtn")
         const status = document.getElementById("status")
+        const trackAll = document.getElementById("trackAll").checked
         let sim
         try {
           sim = JSON.parse(document.getElementById("simEdit").value)
@@ -291,7 +294,7 @@
         status.textContent = "Running..."
         try {
           const t0 = performance.now()
-          const result = await runSim(loadedData.sim, loadedData.truth)
+          const result = await runSim(loadedData.sim, loadedData.truth, trackAll)
           status.textContent = `Shot done in ${Math.round(performance.now() - t0)}ms — ${result.frames.length} steps`
           simStep = result.simStep
           simTracks = result.simTracks
@@ -305,9 +308,11 @@
       }
 
       document.getElementById("simBtn").onclick = onRunSim
+      document.getElementById("trackAll").onchange = updateDrawing
 
       document.getElementById("optBtn").onclick = async () => {
         const specs = getSpecs()
+        const trackAll = document.getElementById("trackAll").checked
         if (specs.length === 0) {
           document.getElementById("optStatus").textContent =
             "Check at least one param"
@@ -353,7 +358,8 @@
             loadedData.truth,
             specs,
             onStep,
-            abortController.signal
+            abortController.signal,
+            trackAll
           )
         } catch (err) {
           document.getElementById("optStatus").textContent =


### PR DESCRIPTION
This change adds a "track all" toggle to the Billiards Fit Tooling. When enabled, the Root Mean Square Error (RMSE) calculation and the "View Shot" visualization will include all balls instead of just the primary mover (ball 0). This is useful for optimizing physics parameters that affect multi-ball collisions.

---
*PR created automatically by Jules for task [2454746452282127897](https://jules.google.com/task/2454746452282127897) started by @tailuge*