### PR TITLE
Update simEdit in Fit Tooling when optimization stops

### DIFF
--- a/dist/fit/viewer.html
+++ b/dist/fit/viewer.html
@@ -321,9 +321,18 @@
             "Check at least one param"
           return
         }
+
+        try {
+          loadedData.sim = JSON.parse(document.getElementById("simEdit").value)
+        } catch (e) {
+          document.getElementById("status").textContent = "Invalid sim JSON"
+          return
+        }
+
         abortController = new AbortController()
         document.getElementById("optBtn").disabled = true
         document.getElementById("stopBtn").disabled = false
+        document.getElementById("simEdit").disabled = true
         document.getElementById("optStatus").textContent = "iter 0"
         rmseHistory = []
         drawRMSEGraph(document.getElementById("rmseCanvas"), rmseHistory)
@@ -345,17 +354,13 @@
             }
             updateParamDisplay(name, val)
           }
-          document.getElementById("simEdit").value = JSON.stringify(
-            loadedData.sim,
-            null,
-            2
-          )
         }
 
         try {
-          const runOptimise = document.getElementById("optimiserSelect").value === "pso"
-            ? runOptimisePSO
-            : runOptimiseNM
+          const runOptimise =
+            document.getElementById("optimiserSelect").value === "pso"
+              ? runOptimisePSO
+              : runOptimiseNM
           await runOptimise(
             loadedData.sim,
             loadedData.truth,
@@ -369,8 +374,16 @@
             `Error: ${err.message}`
         }
 
+        document.getElementById("simEdit").value = JSON.stringify(
+          loadedData.sim,
+          null,
+          2
+        )
+        await onRunSim()
+
         document.getElementById("optBtn").disabled = false
         document.getElementById("stopBtn").disabled = true
+        document.getElementById("simEdit").disabled = false
       }
 
       document.getElementById("stopBtn").onclick = () => {


### PR DESCRIPTION
This change improves the Fit Tooling's optimization workflow in `viewer.html`. It ensures that manual edits to the simulation JSON are preserved by reading them before the process starts. During optimization, the JSON field is disabled to prevent inconsistent states and reduce computational overhead. Once the optimization process completes or is manually stopped, the JSON is updated with the final parameters and the 2D visualization is refreshed to match.

---
*PR created automatically by Jules for task [10737261034233592201](https://jules.google.com/task/10737261034233592201) started by @tailuge*