### PR TITLE
Conditional proximity scoring for Three-Cushion

### DIFF
--- a/src/controller/rules/threecushion.ts
+++ b/src/controller/rules/threecushion.ts
@@ -70,7 +70,7 @@ export class ThreeCushion implements Rules {
     this.tableGeometry()
     CameraTop.zoomFactor = 0.92
     const table = new Table(this.rack())
-    table.proximityEnabled = true
+    table.proximityEnabled = Session.isPracticeMode()
     this.cueball = table.cueball
     return table
   }
@@ -149,6 +149,9 @@ export class ThreeCushion implements Rules {
   getAmountScored(outcome: Outcome[]): number {
     if (!Outcome.isThreeCushionPoint(this.cueball, outcome)) {
       return 0
+    }
+    if (!Session.isPracticeMode()) {
+      return 1
     }
     return Outcome.getProximityScore(this.cueball, outcome) || 1
   }

--- a/test/rules/threecushion.spec.ts
+++ b/test/rules/threecushion.spec.ts
@@ -24,7 +24,7 @@ describe("ThreeCushion", () => {
   const rule = "threecushion"
 
   beforeEach(function (done) {
-    Session.init("test-client", "TestPlayer", "test-table", false)
+    Session.init("test-client", "TestPlayer", "test-table", false, false, true)
     container = new Container({
       element: undefined,
       log: (_) => {},
@@ -233,6 +233,37 @@ describe("ThreeCushion", () => {
       ])
       expect(score1).to.equal(1)
     })
+
+    it("returns 1 when three-cushion point scored and practice mode is false", () => {
+      Session.reset()
+      Session.init(
+        "test-client",
+        "TestPlayer",
+        "test-table",
+        false,
+        false,
+        false
+      )
+      const balls = container.table.balls
+      const R = require("../../src/model/physics/constants").R
+      const outcome: Outcome[] = [
+        Outcome.collision(balls[0], balls[1], 1),
+        Outcome.cushion(balls[0], 1),
+        Outcome.cushion(balls[0], 1),
+        Outcome.cushion(balls[0], 1),
+        Outcome.proximity(balls[0], balls[2], 1.5 * R, 1),
+      ]
+      expect(container.rules.getAmountScored(outcome)).to.equal(1)
+    })
+  })
+
+  it("ThreeCushion proximityEnabled is false when practice mode is false", (done) => {
+    Session.reset()
+    Session.init("test-client", "TestPlayer", "test-table", false, false, false)
+    const rules = RuleFactory.create(rule, container)
+    const table = rules.table()
+    expect(table.proximityEnabled).to.be.false
+    done()
   })
 
   it("ThreeCushion otherPlayersCueBall and nextCandidateBall", (done) => {


### PR DESCRIPTION
In three-cushion billiards, proximity scoring (awarding 1-3 points based on how close the cue ball stops to the final target) is now conditionally disabled.

Key changes:
- `src/controller/rules/threecushion.ts`: `table.proximityEnabled` and `getAmountScored` now check `Session.isPracticeMode()`. If practice mode is off, proximity detection is disabled and all valid points award exactly 1 point.
- `test/rules/threecushion.spec.ts`: Added test cases for `practice=false` and updated default test initialization to maintain existing test coverage for proximity scoring.
- Verified via Playwright that `window.container.table.proximityEnabled` correctly reflects the `practice` URL parameter.

---
*PR created automatically by Jules for task [10463639989039904358](https://jules.google.com/task/10463639989039904358) started by @tailuge*