### PR TITLE
Fix missing timezone in SEO uploadDate

### DIFF
--- a/dist/blog1.html
+++ b/dist/blog1.html
@@ -83,7 +83,7 @@
           "thumbnailUrl": "https://tailuge.github.io/billiards/dist/images/seo.jpg",
           "contentUrl": "https://youtu.be/bAeiRQcQuyg",
           "embedUrl": "https://www.youtube.com/embed/bAeiRQcQuyg",
-          "uploadDate": "2026-04-30"
+          "uploadDate": "2026-04-30T00:00:00+00:00"
         }
       }
     </script>

--- a/dist/blog2.html
+++ b/dist/blog2.html
@@ -77,7 +77,7 @@
           "thumbnailUrl": "https://tailuge.github.io/billiards/dist/images/celebrate.jpg",
           "contentUrl": "https://youtu.be/bAeiRQcQuyg",
           "embedUrl": "https://www.youtube.com/embed/bAeiRQcQuyg",
-          "uploadDate": "2026-04-30"
+          "uploadDate": "2026-04-30T00:00:00+00:00"
         }
       }
     </script>

--- a/dist/blog3.html
+++ b/dist/blog3.html
@@ -78,7 +78,7 @@
           "thumbnailUrl": "https://tailuge.github.io/billiards/dist/images/mathavangraphs.jpg",
           "contentUrl": "https://youtu.be/bAeiRQcQuyg",
           "embedUrl": "https://www.youtube.com/embed/bAeiRQcQuyg",
-          "uploadDate": "2026-04-30"
+          "uploadDate": "2026-04-30T00:00:00+00:00"
         }
       }
     </script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -85,7 +85,7 @@
           "thumbnailUrl": "https://tailuge.github.io/billiards/dist/images/billiards.png",
           "contentUrl": "https://youtu.be/bAeiRQcQuyg",
           "embedUrl": "https://www.youtube.com/embed/bAeiRQcQuyg",
-          "uploadDate": "2026-04-30"
+          "uploadDate": "2026-04-30T00:00:00+00:00"
         }
       }
     </script>

--- a/dist/practice.html
+++ b/dist/practice.html
@@ -77,7 +77,7 @@
           "thumbnailUrl": "https://tailuge.github.io/billiards/dist/images/practiceback.png",
           "contentUrl": "https://youtu.be/bAeiRQcQuyg",
           "embedUrl": "https://www.youtube.com/embed/bAeiRQcQuyg",
-          "uploadDate": "2026-04-30"
+          "uploadDate": "2026-04-30T00:00:00+00:00"
         }
       }
     </script>


### PR DESCRIPTION
This PR fixes a validation error in the structured SEO data where the `uploadDate` property was missing a timezone.

Changes:
- Modified `uploadDate` in `dist/index.html`
- Modified `uploadDate` in `dist/blog1.html`
- Modified `uploadDate` in `dist/blog2.html`
- Modified `uploadDate` in `dist/blog3.html`
- Modified `uploadDate` in `dist/practice.html`

The date format was updated from `YYYY-MM-DD` to `YYYY-MM-DDTHH:mm:ss+00:00`.

Verification:
- Confirmed changes using `grep`.
- Ran the project's full test suite using `yarn test` (after generating the required `version.ts` file), and all 550 tests passed.

---
*PR created automatically by Jules for task [7182697764314628088](https://jules.google.com/task/7182697764314628088) started by @tailuge*