### PR TITLE
Silence usage logging errors

### DIFF
--- a/src/utils/usage.ts
+++ b/src/utils/usage.ts
@@ -12,13 +12,7 @@ export function logusage() {
   fetch(url, {
     method: "PUT",
     mode: "cors",
+  }).catch(() => {
+    /* silent */
   })
-    .then((response) => {
-      if (!response.ok) {
-        console.error("HTTP error:", response.status, response.statusText)
-      }
-    })
-    .catch((error) => {
-      console.error("Fetch error for", url, error)
-    })
 }


### PR DESCRIPTION
This change silences all error logging for the usage tracking API call in `src/utils/usage.ts`. It removes the `.then()` block that was logging HTTP errors and updates the `.catch()` block to be an empty function. This ensures that failures to reach the scoreboard API do not clutter the console with "TypeError: Failed to fetch" or other error messages, as requested.

---
*PR created automatically by Jules for task [6602606664931198680](https://jules.google.com/task/6602606664931198680) started by @tailuge*