### PR TITLE
Fix Spectate Hit crash in Three-Cushion

### DIFF
--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -95,6 +95,7 @@ export class Spectate extends ControllerBase {
     this.container.table.updateFromSerialised(event.tablejson)
     this.container.table.cue.updateAimInput()
     this.container.table.outcome = []
+    this.container.table.proximityIndicator.hide()
     this.container.table.hit()
     return this
   }

--- a/src/utils/proximity.ts
+++ b/src/utils/proximity.ts
@@ -29,7 +29,7 @@ function updateProximityOutcome(
   if (indicator.hitTarget) return
   const lastOutcome = outcome[outcome.length - 1]
   const involved = (o: Outcome) =>
-    o.type === OutcomeType.Collision &&
+    o?.type === OutcomeType.Collision &&
     ((o.ballA === cueball && o.ballB === indicator.target) ||
       (o.ballB === cueball && o.ballA === indicator.target))
   if (involved(lastOutcome)) {


### PR DESCRIPTION
This PR fixes a crash that occurred when spectating a Three-Cushion match. The crash was caused by the proximity logic attempting to access properties of a non-existent last outcome during the first frames of a spectated hit, compounded by state from previous shots not being cleared.

Changes:
- Added optional chaining in `src/utils/proximity.ts` to safely handle empty outcome arrays.
- Added `proximityIndicator.hide()` to `Spectate.handleHit` in `src/controller/spectate.ts` to ensure clean state for every spectated shot.

---
*PR created automatically by Jules for task [13762060997554999873](https://jules.google.com/task/13762060997554999873) started by @tailuge*