### PR TITLE
Fix crash on rematch in 2-player games

### DIFF
--- a/src/controller/aim.ts
+++ b/src/controller/aim.ts
@@ -85,14 +85,20 @@ export class Aim extends ControllerBase {
   }
 
   override handleBreak(breakEvent: BreakEvent): Controller {
-    return new Replay(
-      this.container,
-      breakEvent.init,
-      breakEvent.shots,
-      breakEvent.retry,
-      1500,
-      breakEvent.diagram
-    )
+    if (breakEvent.shots?.length > 0) {
+      return new Replay(
+        this.container,
+        breakEvent.init,
+        breakEvent.shots,
+        breakEvent.retry,
+        1500,
+        breakEvent.diagram
+      )
+    }
+    if (breakEvent.init) {
+      this.container.table.updateFromShortSerialised(breakEvent.init)
+    }
+    return this
   }
 
   playShot() {

--- a/src/controller/end.ts
+++ b/src/controller/end.ts
@@ -71,7 +71,7 @@ export class End extends Controller {
   }
 
   override handleBreak(event: BreakEvent): Controller {
-    if (event.init) {
+    if (event.shots?.length > 0) {
       this.container.table.updateFromShortSerialised(event.init)
       return new Replay(
         this.container,
@@ -81,6 +81,10 @@ export class End extends Controller {
         1000,
         event.diagram
       )
+    }
+    if (event.init) {
+      this.container.table.updateFromShortSerialised(event.init)
+      return new Aim(this.container)
     }
     return this
   }

--- a/src/controller/init.ts
+++ b/src/controller/init.ts
@@ -78,7 +78,7 @@ export class Init extends ControllerBase {
   }
 
   override handleBreak(event: BreakEvent): Controller {
-    if (event.init) {
+    if (event.shots?.length > 0) {
       this.container.table.updateFromShortSerialised(event.init)
       return new Replay(
         this.container,
@@ -88,6 +88,10 @@ export class Init extends ControllerBase {
         1500,
         event.diagram
       )
+    }
+    if (event.init) {
+      this.container.table.updateFromShortSerialised(event.init)
+      return new Aim(this.container)
     }
     if (Session.isPracticeMode() && Session.hasInitParam()) {
       this.container.table.cueball.fround()

--- a/src/controller/replay.ts
+++ b/src/controller/replay.ts
@@ -34,7 +34,7 @@ export class Replay extends ControllerBase {
     this.init = init
     this.diagram = diagram
     console.log(`init: ${JSON.stringify(init)}`)
-    this.shots = [...shots]
+    this.shots = shots ? [...shots] : []
     this.firstShot = this.shots[0]
     this.delay = diagram ? 0 : delay
     this.container.table.showTraces(true)

--- a/src/events/breakevent.ts
+++ b/src/events/breakevent.ts
@@ -7,7 +7,7 @@ export class BreakEvent extends GameEvent {
   shots
   diagram
   retry
-  constructor(init?, shots?, diagram?) {
+  constructor(init?, shots = [], diagram?) {
     super()
     this.init = init
     this.shots = shots


### PR DESCRIPTION
Fixed a crash occurring during rematches in 2-player games. The issue was twofold:
1. The `Replay` controller was being initialized even for state-only synchronization events (which have no shots).
2. The `Replay` constructor was spreading the `shots` parameter without a null/undefined check, causing a `TypeError`.

Changes:
- Initialized `shots` to an empty array in the `BreakEvent` constructor.
- Added a defensive spread `shots ? [...shots] : []` in the `Replay` constructor.
- Updated `handleBreak` in `Aim`, `Init`, and `End` controllers to only transition to `Replay` if `shots` are present; otherwise, they update the table state and transition to `Aim`.

---
*PR created automatically by Jules for task [6045589340604019635](https://jules.google.com/task/6045589340604019635) started by @tailuge*