### PR TITLE
Refine Warp Clearance Analysis Tool

### DIFF
--- a/dist/warp.html
+++ b/dist/warp.html
@@ -9,12 +9,15 @@
         background: #111;
         color: #eee;
         padding: 10px;
+        max-width: 900px;
+        margin: 0 auto;
       }
       canvas {
         background: #000;
         border: 1px solid #444;
         display: block;
         margin-bottom: 10px;
+        width: 100%;
       }
       #log {
         font-size: 10px;
@@ -22,24 +25,86 @@
         overflow-y: auto;
         background: #222;
         padding: 5px;
+        margin-bottom: 20px;
+      }
+      .controls {
+        margin-bottom: 20px;
+        display: flex;
+        gap: 20px;
+        align-items: center;
       }
       button {
-        padding: 10px;
+        padding: 10px 20px;
         cursor: pointer;
         background: #444;
         color: #fff;
         border: 1px solid #666;
       }
+      button:hover {
+        background: #555;
+      }
       button:disabled {
         opacity: 0.5;
+        cursor: not-allowed;
       }
+      input {
+        background: #222;
+        color: #eee;
+        border: 1px solid #444;
+        padding: 5px;
+        width: 60px;
+      }
+      #analysis {
+        background: #1a1a1a;
+        padding: 20px;
+        border-radius: 8px;
+        border-left: 4px solid #8be9fd;
+      }
+      h2 { color: #8be9fd; }
+      h3 { color: #50fa7b; margin-top: 20px; }
+      ul { padding-left: 20px; }
+      li { margin-bottom: 10px; }
+      code { background: #333; padding: 2px 4px; border-radius: 4px; }
     </style>
   </head>
   <body>
     <h1>Warp Clearance Analysis</h1>
+
+    <div class="controls">
+      <label>Step Size (X-axis):
+        <input type="number" id="stepInput" value="0.2" min="0.01" max="0.5" step="0.01">
+      </label>
+      <button id="runBtn">Run Analysis</button>
+    </div>
+
     <canvas id="plotCanvas" width="800" height="400"></canvas>
-    <button id="runBtn">Run Analysis</button>
     <div id="log"></div>
+
+    <div id="analysis">
+      <h2>Analysis & Explanation</h2>
+      <p>
+        The <code>warpClearanceR</code> parameter defines a "safety zone" around balls and cushions.
+        When balls are outside this zone, the engine calculates a <code>minTime</code> to the next possible collision
+        using a conservative linear approximation: <code>t = (dist - 2R) / (vA + vB)</code>.
+      </p>
+
+      <h3>Why values < 2 show improved speedup?</h3>
+      <p>
+        Physical balls with radius <code>R</code> cannot have a center-to-center distance less than <code>2R</code> without overlapping.
+        When <code>warpClearanceR < 2</code>, the safety check (<code>distance < clearance</code>) fails to trigger
+        even when balls are at the point of contact. This allows the warping engine to remain active right up until the collision occurs,
+        maximizing the "leap" size.
+        Values &lt; 2 essentially remove the safety buffer that would otherwise force the engine back to
+        standard <code>stepSize</code> integration as balls approach each other.
+      </p>
+
+      <h3>Assumptions & Possible Errors</h3>
+      <ul>
+        <li><strong>Linear Approximation:</strong> <code>calcMinWarpTime</code> assumes balls move in straight lines at constant velocity. While accurate for rolling balls, it doesn't account for path curvature due to spin or friction. The engine compensates by using the full velocity magnitude for its conservative estimate.</li>
+        <li><strong>Numerical Precision:</strong> Warping extremely close to the <code>2R</code> boundary may lead to minor overlaps due to floating-point precision, relying on the collision resolver to "snap" balls back to contact.</li>
+        <li><strong>Missed Transitions:</strong> Large time leaps might bypass the exact moment a ball transitions between states (e.g., stopping exactly at the pocket edge), though the engine currently restricts warping to the <code>Rolling</code> state to minimize this risk.</li>
+      </ul>
+    </div>
 
     <script type="module">
       import { runBatch } from "./ww.js"
@@ -48,6 +113,11 @@
       const ctx = canvas.getContext("2d")
       const logEl = document.getElementById("log")
       const runBtn = document.getElementById("runBtn")
+      const stepInput = document.getElementById("stepInput")
+
+      const minX = 0.25
+      const maxX = 4.25
+      const rangeX = maxX - minX
 
       const defaultConfig = {
         ruleType: "threecushion",
@@ -105,12 +175,12 @@
         ctx.lineTo(w - pad, h - pad)
         ctx.stroke()
 
-        // X-axis labels (warpClearanceR 1 to 4)
-        for (let x = 1; x <= 4; x += 0.5) {
-          const px = pad + ((x - 1) / 3) * (w - 2 * pad)
-          ctx.fillText(x.toFixed(1), px, h - pad + 15)
+        // X-axis labels
+        for (let x = minX; x <= maxX; x += 0.5) {
+          const px = pad + ((x - minX) / rangeX) * (w - 2 * pad)
+          ctx.fillText(x.toFixed(2), px, h - pad + 15)
         }
-        ctx.fillText("warpClearanceR", w / 2, h - 10)
+        ctx.fillText("warpClearanceR (Units of R)", w / 2, h - 10)
 
         // Y-axis labels (Speedup 1 to 5)
         ctx.textAlign = "right"
@@ -133,7 +203,7 @@
           ctx.lineWidth = 2
           ctx.beginPath()
           dataPoints.forEach((pt, i) => {
-            const px = pad + ((pt.clearance - 1) / 3) * (w - 2 * pad)
+            const px = pad + ((pt.clearance - minX) / rangeX) * (w - 2 * pad)
             const py =
               h - pad - ((pt.speedups[shotIdx] - 1) / 4) * (h - 2 * pad)
             if (i === 0) ctx.moveTo(px, py)
@@ -144,14 +214,15 @@
       }
 
       runBtn.onclick = async () => {
+        const step = parseFloat(stepInput.value) || 0.2
         runBtn.disabled = true
         dataPoints = []
         log("Starting analysis...")
 
-        for (let r = 1.0; r <= 4.01; r += 0.2) {
+        for (let r = minX; r <= maxX + 0.001; r += step) {
           const config = JSON.parse(JSON.stringify(defaultConfig))
           config.warpClearanceR = r
-          log(`Testing warpClearanceR = ${r.toFixed(1)}...`)
+          log(`Testing warpClearanceR = ${r.toFixed(2)}...`)
 
           try {
             const results = await runBatch(config, 3, 0.001745)


### PR DESCRIPTION
This change refines the `dist/warp.html` performance analysis tool. It introduces a configurable step size for the X-axis, expands the analysis range from 0.25 to 4.25 (units of R), and adds a comprehensive text section explaining the underlying physics engine logic. Specifically, it clarifies how `warpClearanceR < 2` bypasses the conservative safety zones, allowing for larger time-leaps (warping) right up to the point of contact, thus increasing the speedup factor. It also lists the engine's core assumptions regarding linear approximation and numerical precision.

---
*PR created automatically by Jules for task [1658729528895468588](https://jules.google.com/task/1658729528895468588) started by @tailuge*