### PR TITLE
Refine warpClearanceR logic and update warp.html

### DIFF
--- a/dist/warp.html
+++ b/dist/warp.html
@@ -54,17 +54,6 @@
         padding: 5px;
         width: 60px;
       }
-      #analysis {
-        background: #1a1a1a;
-        padding: 20px;
-        border-radius: 8px;
-        border-left: 4px solid #8be9fd;
-      }
-      h2 { color: #8be9fd; }
-      h3 { color: #50fa7b; margin-top: 20px; }
-      ul { padding-left: 20px; }
-      li { margin-bottom: 10px; }
-      code { background: #333; padding: 2px 4px; border-radius: 4px; }
     </style>
   </head>
   <body>
@@ -80,31 +69,6 @@
     <canvas id="plotCanvas" width="800" height="400"></canvas>
     <div id="log"></div>
 
-    <div id="analysis">
-      <h2>Analysis & Explanation</h2>
-      <p>
-        The <code>warpClearanceR</code> parameter defines a "safety zone" around balls and cushions.
-        When balls are outside this zone, the engine calculates a <code>minTime</code> to the next possible collision
-        using a conservative linear approximation: <code>t = (dist - 2R) / (vA + vB)</code>.
-      </p>
-
-      <h3>Why values < 2 show improved speedup?</h3>
-      <p>
-        Physical balls with radius <code>R</code> cannot have a center-to-center distance less than <code>2R</code> without overlapping.
-        When <code>warpClearanceR < 2</code>, the safety check (<code>distance < clearance</code>) fails to trigger
-        even when balls are at the point of contact. This allows the warping engine to remain active right up until the collision occurs,
-        maximizing the "leap" size.
-        Values &lt; 2 essentially remove the safety buffer that would otherwise force the engine back to
-        standard <code>stepSize</code> integration as balls approach each other.
-      </p>
-
-      <h3>Assumptions & Possible Errors</h3>
-      <ul>
-        <li><strong>Linear Approximation:</strong> <code>calcMinWarpTime</code> assumes balls move in straight lines at constant velocity. While accurate for rolling balls, it doesn't account for path curvature due to spin or friction. The engine compensates by using the full velocity magnitude for its conservative estimate.</li>
-        <li><strong>Numerical Precision:</strong> Warping extremely close to the <code>2R</code> boundary may lead to minor overlaps due to floating-point precision, relying on the collision resolver to "snap" balls back to contact.</li>
-        <li><strong>Missed Transitions:</strong> Large time leaps might bypass the exact moment a ball transitions between states (e.g., stopping exactly at the pocket edge), though the engine currently restricts warping to the <code>Rolling</code> state to minimize this risk.</li>
-      </ul>
-    </div>
 
     <script type="module">
       import { runBatch } from "./ww.js"
@@ -115,8 +79,8 @@
       const runBtn = document.getElementById("runBtn")
       const stepInput = document.getElementById("stepInput")
 
-      const minX = 0.25
-      const maxX = 4.25
+      const minX = 1.5
+      const maxX = 10.0
       const rangeX = maxX - minX
 
       const defaultConfig = {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -34,8 +34,12 @@ function ballToCushionDist(b: Ball): number {
   )
 }
 
-function anyCushionTooClose(rollingBalls: Ball[], clearance: number): boolean {
-  return rollingBalls.some((b) => ballToCushionDist(b) <= clearance)
+function anyCushionTooClose(
+  rollingBalls: Ball[],
+  clearance: number,
+  R: number
+): boolean {
+  return rollingBalls.some((b) => ballToCushionDist(b) <= clearance - R)
 }
 
 function anyBallTooClose(
@@ -85,7 +89,7 @@ function getFastWarpTime(table: Table, R: number, clearance: number): number {
     return 0
   }
 
-  if (anyCushionTooClose(rollingBalls, clearance)) {
+  if (anyCushionTooClose(rollingBalls, clearance, R)) {
     return 0
   }
 


### PR DESCRIPTION
This change refines the time-warping physics logic and updates the associated analysis tool.

Key changes:
1.  **Physics Worker Refinement**: In `src/worker.ts`, the `warpClearanceR` safety buffer is now differentiated between balls and cushions. Cushion proximity checks now subtract 1 radius (R) from the clearance threshold, effectively checking for a gap of `(warpClearanceR - 1) * R`. This aligns the cushion safety margin with the ball-to-ball margin (where `2R` is the physical contact distance).
2.  **Analysis Tool Update**: `dist/warp.html` has been updated to support a wider analysis range on the x-axis (from `1.5` to `10.0` units of R).
3.  **UI Cleanup**: The descriptive explanation block in `dist/warp.html` was removed to provide a cleaner, data-focused interface.

Tests were run to ensure no regressions in physics behavior, and visual verification was performed to confirm the UI changes.

---
*PR created automatically by Jules for task [4581514479592646448](https://jules.google.com/task/4581514479592646448) started by @tailuge*