### PR TITLE
Cap simulation warp time to 25x step size

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -187,7 +187,7 @@ export function simulateSync(config: any): any {
     const warpTime = getFastWarpTime(table, R, warpClearanceR * R)
     const dt =
       warpTime > stepSize
-        ? Math.floor(warpTime / stepSize) * stepSize
+        ? Math.min(Math.floor(warpTime / stepSize) * stepSize, 25 * stepSize)
         : stepSize
 
     table.advance(dt)


### PR DESCRIPTION
This PR modifies the simulation loop in `src/worker.ts` to enforce a maximum warp time of 25x the `stepSize`. Previously, the warp time could grow indefinitely based on the proximity of balls and cushions. This change improves simulation stability by limiting the maximum delta time in a single iteration.

---
*PR created automatically by Jules for task [10676380611500357761](https://jules.google.com/task/10676380611500357761) started by @tailuge*