### PR TITLE
Add spin and power inset to SVG diagrams

### DIFF
--- a/dist/diagrams/dsl.js
+++ b/dist/diagrams/dsl.js
@@ -33,7 +33,7 @@ const X = tableX + R // 1.512395 — half-width of playing area
 const Y = tableY + R // 0.7561975 — half-height of playing area
 const gridInterval = (2 * X) / 8 // 0.37809875
 const dOffset = 0.1 // diamond offset from cushion nose
-const maxPower = 160 * R // 5.24 m/s
+export const maxPower = 160 * R // 5.24 m/s
 
 // Default physics params (matching ww.html)
 const defaultParams = {

--- a/dist/diagrams/svg.js
+++ b/dist/diagrams/svg.js
@@ -16,7 +16,7 @@
  */
 
 import { SimulationRunner } from "../ww.js"
-import { parseShots } from "./dsl.js"
+import { parseShots, maxPower } from "./dsl.js"
 
 // ——— Table geometry (SI meters) ———
 
@@ -125,6 +125,37 @@ function renderTrajectories(trajectoriesGroup, results) {
   trajectoriesGroup.innerHTML = svgContent
 }
 
+function renderInset(insetGroup, config) {
+  const ballR = 0.04
+  const dotR = 0.005
+  const barW = 0.08
+  const barH = 0.01
+
+  const { offset, power } = config.shot
+
+  let svgContent = ""
+
+  // Cue ball circle
+  svgContent += `  <circle cx="0" cy="0" r="${ballR}" fill="#fff" stroke="#000" stroke-width="0.002" />\n`
+
+  // Spin dot
+  // offset.x/y are -0.5 to 0.5. We map them to the ballR.
+  const dx = (offset.x / 0.5) * ballR
+  const dy = (-offset.y / 0.5) * ballR
+  svgContent += `  <circle cx="${dx}" cy="${dy}" r="${dotR}" fill="red" />\n`
+
+  // Power bar background
+  const bx = -barW / 2
+  const by = ballR + 0.015
+  svgContent += `  <rect x="${bx}" y="${by}" width="${barW}" height="${barH}" fill="none" stroke="#000" stroke-width="0.002" />\n`
+
+  // Power bar fill
+  const fillW = (power / maxPower) * barW
+  svgContent += `  <rect x="${bx}" y="${by}" width="${fillW}" height="${barH}" fill="#4ade80" />\n`
+
+  insetGroup.innerHTML = svgContent
+}
+
 // ——— Element setup helpers ———
 
 function setupSvgRoot(el) {
@@ -146,9 +177,27 @@ function setupSvgRoot(el) {
     el.appendChild(trajectoriesGroup)
   }
 
+  let insetGroup = el.querySelector(".inset-group")
+  if (!insetGroup) {
+    insetGroup = document.createElementNS(SVG_NS, "g")
+    insetGroup.classList.add("inset-group")
+    // Position top-left inside frame
+    const ix = -X - fOffset + 0.06
+    const iy = -Y - fOffset + 0.06
+    insetGroup.setAttribute("transform", `translate(${ix}, ${iy})`)
+    el.appendChild(insetGroup)
+  }
+
   const statusEl = el.querySelector(".worker-status") || createSvgStatusText(el)
 
-  return { svg: el, tableGroup, trajectoriesGroup, statusEl, isSvgRoot: true }
+  return {
+    svg: el,
+    tableGroup,
+    trajectoriesGroup,
+    insetGroup,
+    statusEl,
+    isSvgRoot: true,
+  }
 }
 
 function createSvgStatusText(svg) {
@@ -207,6 +256,7 @@ async function runElement(el) {
     const figure = el.dataset.figure?.trim()
     setStatus(statusEl, figure || "")
     renderTrajectories(trajectoriesGroup, results)
+    renderInset(setup.insetGroup, configs[0])
   } catch (err) {
     setStatus(statusEl, `Error: ${err.message}`)
     console.error("Simulation failed:", err)

--- a/dist/diagrams/svg.js
+++ b/dist/diagrams/svg.js
@@ -181,10 +181,6 @@ function setupSvgRoot(el) {
   if (!insetGroup) {
     insetGroup = document.createElementNS(SVG_NS, "g")
     insetGroup.classList.add("inset-group")
-    // Position top-left inside frame
-    const ix = -X - fOffset + 0.06
-    const iy = -Y - fOffset + 0.06
-    insetGroup.setAttribute("transform", `translate(${ix}, ${iy})`)
     el.appendChild(insetGroup)
   }
 
@@ -204,8 +200,8 @@ function createSvgStatusText(svg) {
   const textY = Y + fOffset + 0.12
   const text = document.createElementNS(SVG_NS, "text")
   text.classList.add("worker-status")
-  text.setAttribute("text-anchor", "middle")
-  text.setAttribute("x", "0")
+  text.setAttribute("text-anchor", "end")
+  text.setAttribute("x", String(X + fOffset - 0.12))
   text.setAttribute("y", String(textY))
   text.setAttribute("font-size", "0.1")
   text.setAttribute("font-family", "ui-monospace, monospace")
@@ -257,6 +253,19 @@ async function runElement(el) {
     setStatus(statusEl, figure || "")
     renderTrajectories(trajectoriesGroup, results)
     renderInset(setup.insetGroup, configs[0])
+
+    // Align inset to the right of the status text
+    try {
+      const bbox = statusEl.getBBox()
+      const ix = bbox.x + bbox.width + 0.06
+      const iy = parseFloat(statusEl.getAttribute("y")) - 0.02
+      setup.insetGroup.setAttribute("transform", `translate(${ix}, ${iy})`)
+    } catch (e) {
+      // Fallback positioning if getBBox is unavailable
+      const ix = X + fOffset - 0.05
+      const iy = Y + fOffset + 0.1
+      setup.insetGroup.setAttribute("transform", `translate(${ix}, ${iy})`)
+    }
   } catch (err) {
     setStatus(statusEl, `Error: ${err.message}`)
     console.error("Simulation failed:", err)


### PR DESCRIPTION
This change adds a small inset to each SVG diagram in SVG.html showing the cue ball spin hit point and a power indicator. The hit point is derived from the offset of the first trajectory in the diagram, and the power indicator shows the shot power relative to the maximum power.

---
*PR created automatically by Jules for task [3524745858590197034](https://jules.google.com/task/3524745858590197034) started by @tailuge*