### PR TITLE
Simplify SVG Trajectory Paths

### DIFF
--- a/dist/diagrams/svg.js
+++ b/dist/diagrams/svg.js
@@ -106,6 +106,49 @@ function generateBilliardTable() {
 
 // ——— Trajectory rendering ———
 
+function simplifyPath(path, cosTolerance = 0.999998477, minLength = 0.01 * R) {
+  if (path.length < 3) return path
+
+  const compressed = [path[0]]
+  let spanStart = path[0]
+  let last = path[1]
+
+  for (let i = 2; i < path.length; i++) {
+    const next = path[i]
+
+    const d1x = last[0] - spanStart[0]
+    const d1y = last[1] - spanStart[1]
+    const d1mag = Math.sqrt(d1x * d1x + d1y * d1y)
+
+    const d2x = next[0] - last[0]
+    const d2y = next[1] - last[1]
+    const d2mag = Math.sqrt(d2x * d2x + d2y * d2y)
+
+    if (d1mag < minLength || d2mag < minLength) {
+      last = next
+      continue
+    }
+
+    const u1x = d1x / d1mag
+    const u1y = d1y / d1mag
+    const u2x = d2x / d2mag
+    const u2y = d2y / d2mag
+
+    const dot = u1x * u2x + u1y * u2y
+
+    if (dot >= cosTolerance) {
+      last = next
+    } else {
+      compressed.push(last)
+      spanStart = last
+      last = next
+    }
+  }
+
+  compressed.push(last)
+  return compressed
+}
+
 function renderTrajectories(trajectoriesGroup, results) {
   let svgContent = ""
 
@@ -125,7 +168,8 @@ function renderTrajectories(trajectoriesGroup, results) {
 
       if (path.length < 2) return
 
-      const points = path.map((p) => `${p[0]},${p[1]}`).join(" ")
+      const simplifiedPath = simplifyPath(path)
+      const points = simplifiedPath.map((p) => `${p[0]},${p[1]}`).join(" ")
       svgContent += `  <polyline points="${points}" class="trajectory-line" />\n`
     })
   })


### PR DESCRIPTION
I have implemented a path simplification algorithm in `dist/diagrams/svg.js` to reduce the number of points in ball trajectories.

The algorithm works by combining collinear spans. It maintains a `spanStart` and compares the direction of the current segment against the overall span using a normalized dot product (cosine). This approach is more robust than comparing consecutive segments as it prevents accumulated drift.

Key changes:
- Created a modular `simplifyPath` function in `dist/diagrams/svg.js`.
- Used a default `cosTolerance` of 0.999998477 (corresponding to 0.1°).
- Used a default `minLength` of 0.01 * R to handle small movements.
- Updated `renderTrajectories` to apply this simplification before generating SVG polyline points.

I have verified the implementation by running the existing test suite and visually inspecting the generated diagrams via a Playwright-captured screenshot.

---
*PR created automatically by Jules for task [749048718293576814](https://jules.google.com/task/749048718293576814) started by @tailuge*