### PR TITLE
Interactive Line Drawing for SVG Diagrams

### DIFF
--- a/dist/diagrams/svg.html
+++ b/dist/diagrams/svg.html
@@ -76,11 +76,40 @@
         stroke: #000;
         stroke-width: 0.002;
       }
+
+      #edit-mode-toggle {
+        padding: 0.5rem 1rem;
+        font-size: 1rem;
+        cursor: pointer;
+        background: #fff;
+        border: 1px solid #ccc;
+        border-radius: 0.25rem;
+        transition: background 0.2s;
+      }
+
+      #edit-mode-toggle.active {
+        background: #000;
+        color: #fff;
+        border-color: #000;
+      }
+
+      .manual-line {
+        fill: none;
+        stroke: #000;
+        stroke-width: 0.003;
+        stroke-dasharray: 0.06 0.03;
+      }
+
+      .snap-indicator {
+        fill: rgba(0, 0, 0, 0.2);
+        stroke: none;
+      }
     </style>
   </head>
   <body>
     <header>
       <h1>Billiards Diagrams</h1>
+      <button id="edit-mode-toggle">Toggle Edit Mode</button>
     </header>
 
     <main>
@@ -150,8 +179,14 @@
     </main>
 
     <script type="module">
-      import { initDiagrams } from "./svg.js"
+      import { initDiagrams, toggleEditMode } from "./svg.js"
       initDiagrams()
+
+      const toggleBtn = document.getElementById("edit-mode-toggle")
+      toggleBtn.addEventListener("click", () => {
+        const isActive = toggleEditMode()
+        toggleBtn.classList.toggle("active", isActive)
+      })
     </script>
   </body>
 </html>

--- a/dist/diagrams/svg.js
+++ b/dist/diagrams/svg.js
@@ -18,6 +18,15 @@
 import { SimulationRunner } from "../ww.js"
 import { parseShots, parseJsonShots, maxPower } from "./dsl.js"
 
+// ——— State management ———
+
+let isEditMode = false
+
+export function toggleEditMode() {
+  isEditMode = !isEditMode
+  return isEditMode
+}
+
 // ——— Table geometry (SI meters) ———
 
 const R = 0.03275
@@ -104,6 +113,130 @@ function generateBilliardTable() {
     viewBox: `${f6(viewBoxX)} ${f6(viewBoxY)} ${f6(viewBoxWidth)} ${f6(viewBoxHeight)}`,
     content: svgContent,
   }
+}
+
+// ——— Coordinate and Diamond utilities ———
+
+function toSvgCoords(svg, event) {
+  const pt = svg.createSVGPoint()
+  pt.x = event.clientX
+  pt.y = event.clientY
+  const svgP = pt.matrixTransform(svg.getScreenCTM().inverse())
+  return { x: svgP.x, y: svgP.y }
+}
+
+function getDiamonds() {
+  const gridInterval = (2 * X) / 8
+  const diamonds = []
+
+  for (let i = -4; i <= 4; i++) {
+    const x = i * gridInterval
+    diamonds.push({ x, y: -Y - dOffset })
+    diamonds.push({ x, y: Y + dOffset })
+  }
+  for (let i = -2; i <= 2; i++) {
+    const y = i * gridInterval
+    diamonds.push({ x: -X - dOffset, y })
+    diamonds.push({ x: X + dOffset, y })
+  }
+  return diamonds
+}
+
+// ——— Editing and Snapping logic ———
+
+function getNearestDiamond(diamonds, coords) {
+  let nearest = null
+  let minDistance = Infinity
+
+  for (const d of diamonds) {
+    const dx = coords.x - d.x
+    const dy = coords.y - d.y
+    const dist = Math.sqrt(dx * dx + dy * dy)
+    if (dist < minDistance) {
+      minDistance = dist
+      nearest = d
+    }
+  }
+
+  if (minDistance <= 2 * R) {
+    return nearest
+  }
+  return null
+}
+
+function enableEditing(el, setup) {
+  const { svg, manualLinesGroup, editingGroup } = setup
+  const diamonds = getDiamonds()
+
+  let activeLine = null
+  let startPoint = null
+
+  // Create snap point indicator
+  const snapPoint = document.createElementNS(SVG_NS, "circle")
+  snapPoint.setAttribute("r", String(R))
+  snapPoint.classList.add("snap-indicator")
+  snapPoint.style.display = "none"
+  editingGroup.appendChild(snapPoint)
+
+  svg.addEventListener("mousemove", (e) => {
+    if (!isEditMode) {
+      snapPoint.style.display = "none"
+      return
+    }
+
+    const mouse = toSvgCoords(svg, e)
+    const nearest = getNearestDiamond(diamonds, mouse)
+
+    if (nearest) {
+      snapPoint.setAttribute("cx", String(nearest.x))
+      snapPoint.setAttribute("cy", String(nearest.y))
+      snapPoint.style.display = "block"
+    } else {
+      snapPoint.style.display = "none"
+    }
+
+    if (activeLine) {
+      const end = nearest || mouse
+      activeLine.setAttribute("x2", String(end.x))
+      activeLine.setAttribute("y2", String(end.y))
+    }
+  })
+
+  svg.addEventListener("mousedown", (e) => {
+    if (!isEditMode) return
+
+    const mouse = toSvgCoords(svg, e)
+    const nearest = getNearestDiamond(diamonds, mouse)
+
+    if (nearest) {
+      startPoint = nearest
+      activeLine = document.createElementNS(SVG_NS, "line")
+      activeLine.setAttribute("x1", String(nearest.x))
+      activeLine.setAttribute("y1", String(nearest.y))
+      activeLine.setAttribute("x2", String(nearest.x))
+      activeLine.setAttribute("y2", String(nearest.y))
+      activeLine.classList.add("manual-line")
+      editingGroup.appendChild(activeLine)
+    }
+  })
+
+  svg.addEventListener("mouseup", (e) => {
+    if (!activeLine) return
+
+    const mouse = toSvgCoords(svg, e)
+    const nearest = getNearestDiamond(diamonds, mouse)
+
+    if (nearest && (nearest.x !== startPoint.x || nearest.y !== startPoint.y)) {
+      activeLine.setAttribute("x2", String(nearest.x))
+      activeLine.setAttribute("y2", String(nearest.y))
+      manualLinesGroup.appendChild(activeLine)
+    } else {
+      activeLine.remove()
+    }
+
+    activeLine = null
+    startPoint = null
+  })
 }
 
 // ——— Trajectory rendering ———
@@ -260,6 +393,20 @@ function setupSvgRoot(el) {
     el.appendChild(insetGroup)
   }
 
+  let manualLinesGroup = el.querySelector(".manual-lines-group")
+  if (!manualLinesGroup) {
+    manualLinesGroup = document.createElementNS(SVG_NS, "g")
+    manualLinesGroup.classList.add("manual-lines-group")
+    el.appendChild(manualLinesGroup)
+  }
+
+  let editingGroup = el.querySelector(".editing-group")
+  if (!editingGroup) {
+    editingGroup = document.createElementNS(SVG_NS, "g")
+    editingGroup.classList.add("editing-group")
+    el.appendChild(editingGroup)
+  }
+
   const statusEl = el.querySelector(".worker-status") || createSvgStatusText(el)
 
   return {
@@ -268,6 +415,8 @@ function setupSvgRoot(el) {
     trajectoriesGroup,
     ballsGroup,
     insetGroup,
+    manualLinesGroup,
+    editingGroup,
     statusEl,
     isSvgRoot: true,
   }
@@ -294,6 +443,7 @@ function createSvgStatusText(svg) {
 
 async function runElement(el) {
   const setup = setupSvgRoot(el)
+  enableEditing(el, setup)
 
   const { svg, tableGroup, trajectoriesGroup } = setup
   const { statusEl } = setup


### PR DESCRIPTION
Implemented an interactive "Edit Mode" for the SVG billiard diagrams. Users can now toggle Edit Mode to draw dashed lines between table diamonds. The implementation features:
- Precise mouse-to-SVG coordinate transformation.
- Automatic snapping to the nearest diamond when within a 2R radius.
- Visual feedback via a snap indicator (hover circle).
- Click-and-drag interaction to create dashed lines (long dashes).
- Integration with the existing SVG generation and simulation lifecycle.

---
*PR created automatically by Jules for task [8948252076819316753](https://jules.google.com/task/8948252076819316753) started by @tailuge*