### PR TITLE
Fix simple lint errors (unused vars and redundant types)

### DIFF
--- a/src/controller/end.ts
+++ b/src/controller/end.ts
@@ -12,9 +12,9 @@ export class End extends Controller {
     return "End"
   }
 
-  private readonly result?: MatchResult | undefined
+  private readonly result?: MatchResult
 
-  constructor(container: Container, result?: MatchResult | undefined) {
+  constructor(container: Container, result?: MatchResult) {
     super(container)
     this.result = result
   }

--- a/src/controller/placeallballs.ts
+++ b/src/controller/placeallballs.ts
@@ -101,7 +101,9 @@ export class PlaceAllBalls extends ControllerBase {
       this.isDragging = false
       try {
         canvas.releasePointerCapture(e.pointerId)
-      } catch (_) {}
+      } catch {
+        // Ignore errors if pointer capture cannot be released
+      }
     }
 
     canvas.addEventListener("pointerdown", onPointerDown)

--- a/src/events/chatevent.ts
+++ b/src/events/chatevent.ts
@@ -11,7 +11,7 @@ export interface LineData {
 export class ChatEvent extends GameEvent {
   sender
   message
-  line?: LineData | undefined
+  line?: LineData
 
   constructor(sender, message, line?: LineData) {
     super()

--- a/src/events/notificationevent.ts
+++ b/src/events/notificationevent.ts
@@ -5,9 +5,9 @@ import { NotificationData } from "../view/notification"
 
 export class NotificationEvent extends GameEvent {
   data: NotificationData | string
-  duration?: number | undefined
+  duration?: number
 
-  constructor(data: NotificationData | string, duration?: number | undefined) {
+  constructor(data: NotificationData | string, duration?: number) {
     super()
     this.data = data
     this.duration = duration

--- a/src/events/placeballevent.ts
+++ b/src/events/placeballevent.ts
@@ -11,10 +11,10 @@ export interface RespotBody {
 
 export class PlaceBallEvent extends GameEvent {
   pos
-  respot?: RespotBody | undefined
-  useStartPos?: boolean | undefined
+  respot?: RespotBody
+  useStartPos?: boolean
 
-  constructor(pos, respot?: RespotBody | undefined, useStartPos?: boolean) {
+  constructor(pos, respot?: RespotBody, useStartPos?: boolean) {
     super()
     this.pos = pos
     this.respot = respot

--- a/src/model/previewshot.ts
+++ b/src/model/previewshot.ts
@@ -33,7 +33,7 @@ export function previewShot(table: Table): boolean {
       table.updateBallMesh(dt)
     }
     success = true
-  } catch (_) {
+  } catch {
     // physics error (e.g. depth exceeded for close-together balls) — restore below
   } finally {
     table.balls.forEach((b, i) => {

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -35,15 +35,15 @@ export type CushionModelName =
 /** One outcome as returned by the worker (ballA/ballB are ids, frames discarded). */
 export interface SimOutcome {
   type: string
-  ballA?: number | undefined
-  ballB?: number | undefined
-  speed?: number | undefined
-  t?: number | undefined
+  ballA?: number
+  ballB?: number
+  speed?: number
+  t?: number
 }
 
 /** A request posted to the worker. */
 export interface WorkerConfig {
-  id?: number | string | undefined
+  id?: number | string
   ruleType: string
   balls: BallPos[]
   cushionModel: string

--- a/src/view/notification.ts
+++ b/src/view/notification.ts
@@ -9,13 +9,13 @@ export interface NotificationHighBreak {
 export interface NotificationData {
   type: "Foul" | "GameOver" | "Info"
   title: string
-  subtext?: string | undefined
-  matchScore?: string | undefined
-  highBreaks?: NotificationHighBreak[] | undefined
-  extra?: string | undefined
-  duration?: number | undefined
-  icon?: string | undefined
-  extraClass?: string | undefined
+  subtext?: string
+  matchScore?: string
+  highBreaks?: NotificationHighBreak[]
+  extra?: string
+  duration?: number
+  icon?: string
+  extraClass?: string
 }
 
 export type NotificationActionHandlers = Record<string, () => void>


### PR DESCRIPTION
This PR addresses several simple lint errors identified by ESLint, focusing on unused variables and redundant type declarations.

Changes:
- **Optional Catch Binding**: Updated catch blocks in `src/controller/placeallballs.ts` and `src/model/previewshot.ts` to use `catch {}` instead of `catch (_) {}` to resolve unused variable warnings.
- **Empty Block Handling**: Added an explanatory comment to an empty catch block in `src/controller/placeallballs.ts` to resolve `no-empty` and `sonarjs/no-ignored-exceptions` errors.
- **Redundant Optional Types**: Cleaned up multiple files where optional properties were explicitly typed with `| undefined`, which is redundant when using the `?` specifier. Affected files include `src/controller/end.ts`, `src/events/chatevent.ts`, `src/events/notificationevent.ts`, `src/events/placeballevent.ts`, `src/sensitivity.ts`, and `src/view/notification.ts`.

All changes were verified by running the project's ESLint configuration and ensuring the full Jest test suite passes.

---
*PR created automatically by Jules for task [6856511548848233220](https://jules.google.com/task/6856511548848233220) started by @tailuge*