### PR TITLE
Fix DSL spin parsing and SVG visualization

### DIFF
--- a/dist/diagrams/dsl.js
+++ b/dist/diagrams/dsl.js
@@ -86,7 +86,7 @@ function parseSpin(clockStr, strengthStr) {
   const angle = hour * (Math.PI / 6)
   const s = parseStrength(strengthStr)
   return {
-    x: Math.sin(angle) * s * 0.45,
+    x: -Math.sin(angle) * s * 0.45,
     y: Math.cos(angle) * s * 0.45,
   }
 }

--- a/dist/diagrams/svg.js
+++ b/dist/diagrams/svg.js
@@ -353,7 +353,7 @@ function renderInset(insetGroup, config) {
 
   // Spin dot (cue tip position)
   // offset.x/y are -0.5 to 0.5, scaled to half the ball radius.
-  const dx = offset.x * ballR;
+  const dx = -offset.x * ballR;
   const dy = -offset.y * ballR;
   svgContent += `  <circle cx="${dx}" cy="${dy}" r="${dotR}" fill="#000" />\n`;
 


### PR DESCRIPTION
The 3 o'clock spin parsing in `dsl.js` was producing a positive `offsetX`, which contradicted the project's convention where positive `offsetX` represents left-hand English (9 o'clock). 

This change:
1.  Updates `parseSpin` in `dist/diagrams/dsl.js` to negate the `x` component of the spin offset.
2.  Updates `renderInset` in `dist/diagrams/svg.js` to negate `offset.x` when calculating the visual position of the spin dot, ensuring that right-hand English (now negative `offsetX`) still correctly renders on the right side of the ball.

Verified with numerical tests and visual inspection of generated SVG diagrams.

---
*PR created automatically by Jules for task [13284172695591690526](https://jules.google.com/task/13284172695591690526) started by @tailuge*