### PR TITLE
Fix DataCloneError and update Three-Cushion exam behavior

### DIFF
--- a/dist/exam/threecushion.html
+++ b/dist/exam/threecushion.html
@@ -305,19 +305,14 @@
 
           if (configs.length > 0) {
             const config = configs[0];
-            // The game expects a replay state with 'init' balls (flat array) and 'shots' array.
-            const replayState = {
-              init: config.balls.flatMap((b) => [b.pos.x, b.pos.y]),
-              shots: [
-                {
-                  ...config.shot,
-                  i: config.shot.cueBallId,
-                  pos: config.balls[config.shot.cueBallId].pos,
-                },
-              ],
+            const init = config.balls.flatMap((b) => [b.pos.x, b.pos.y]);
+            const initShot = {
+              ...config.shot,
+              i: config.shot.cueBallId,
+              pos: config.balls[config.shot.cueBallId].pos,
             };
-            const stateStr = JSON.stringify(replayState);
-            const url = `../index.html?ruletype=threecushion&exam=true&state=${encodeURIComponent(stateStr)}`;
+
+            const url = `../index.html?ruletype=threecushion&exam=true&practice=true&init=${encodeURIComponent(JSON.stringify(init))}&initShot=${encodeURIComponent(JSON.stringify(initShot))}`;
             iframe.src = url;
             overlay.classList.add("active");
             outcomeDisplay.style.display = "none";
@@ -336,6 +331,12 @@
             li.textContent = `${o.type}: ${o.ballA?.id}${o.ballB ? " -> " + o.ballB.id : ""} (${o.incidentSpeed.toFixed(2)})`;
             outcomeList.appendChild(li);
           });
+
+          // Close the iframe after a short delay so the user can see the final state
+          setTimeout(() => {
+            overlay.classList.remove("active");
+            iframe.src = "";
+          }, 1500);
         }
       });
 

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -256,7 +256,10 @@ export class Container {
       this.table.cue.hittingAnimation = false
       if (globalThis.parent !== (globalThis as any)) {
         globalThis.parent.postMessage(
-          { type: "stationary", outcome: this.table.outcome },
+          {
+            type: "stationary",
+            outcome: this.table.outcome.map((o) => o.serialise()),
+          },
           "*"
         )
       }

--- a/src/model/outcome.ts
+++ b/src/model/outcome.ts
@@ -171,4 +171,14 @@ export class Outcome {
     })
     return outcomes
   }
+
+  serialise() {
+    return {
+      type: this.type,
+      timestamp: this.timestamp,
+      incidentSpeed: this.incidentSpeed,
+      ballA: this.ballA ? { id: this.ballA.id } : null,
+      ballB: this.ballB ? { id: this.ballB.id } : null,
+    }
+  }
 }


### PR DESCRIPTION
This PR addresses three main issues:
1. **DataCloneError**: Fixed a crash occurring when `postMessage` attempted to clone complex objects (like Three.js instances) within the `outcome` array. Outcomes are now serialized into plain objects before being sent.
2. **Exam Mode**: Updated `threecushion.html` to launch the game in regular "Aim" mode (practice mode) by passing `init` and `initShot` parameters instead of a full `state` object.
3. **UX Improvement**: The game iframe in the three-cushion exam now automatically closes 1.5 seconds after the balls become stationary, providing a smoother transition back to the question list.

---
*PR created automatically by Jules for task [4896999787584927635](https://jules.google.com/task/4896999787584927635) started by @tailuge*