### PR TITLE
Exam UI: Move quit button and resize iframe

### DIFF
--- a/dist/exam/exam.css
+++ b/dist/exam/exam.css
@@ -35,6 +35,12 @@ header {
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
 }
 
+body > h2 {
+  max-width: 1200px;
+  margin: 1.5rem auto 0.5rem;
+  padding: 0 0.75rem;
+}
+
 .summary h2 {
   margin-bottom: 0.5rem;
 }
@@ -57,30 +63,39 @@ header {
 .assessment.beginner {
   color: #ef4444;
 }
+
 .assessment.novice {
   color: #f97316;
 }
+
 .assessment.learner {
   color: #f59e0b;
 }
+
 .assessment.developing {
   color: #eab308;
 }
+
 .assessment.intermediate {
   color: #84cc16;
 }
+
 .assessment.competent {
   color: #22c55e;
 }
+
 .assessment.proficient {
   color: #10b981;
 }
+
 .assessment.advanced {
   color: #14b8a6;
 }
+
 .assessment.expert {
   color: #06b6d4;
 }
+
 .assessment.master {
   color: #8b5cf6;
 }
@@ -204,28 +219,32 @@ header {
 
 @keyframes ring-expand-green {
   0% {
-    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.8);
+    box-shadow: 0 0 0 0 rgb(34 197 94 / 80%);
     color: inherit;
   }
+
   50% {
     color: #16a34a;
   }
+
   100% {
-    box-shadow: 0 0 0 20px rgba(34, 197, 94, 0);
+    box-shadow: 0 0 0 20px rgb(34 197 94 / 0%);
     color: inherit;
   }
 }
 
 @keyframes ring-expand-red {
   0% {
-    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.8);
+    box-shadow: 0 0 0 0 rgb(239 68 68 / 80%);
     color: inherit;
   }
+
   50% {
     color: #dc2626;
   }
+
   100% {
-    box-shadow: 0 0 0 20px rgba(239, 68, 68, 0);
+    box-shadow: 0 0 0 20px rgb(239 68 68 / 0%);
     color: inherit;
   }
 }
@@ -236,12 +255,6 @@ header {
 
 .q-stats.updated.q-fail {
   animation: ring-expand-red 2s ease-out 2;
-}
-
-body > h2 {
-  max-width: 1200px;
-  margin: 1.5rem auto 0.5rem;
-  padding: 0 0.75rem;
 }
 
 .reset-btn {
@@ -277,8 +290,8 @@ body > h2 {
 }
 
 .iframe-container {
-  width: 75%;
-  height: 75%;
+  width: 80%;
+  height: 80%;
   background: #000;
   position: relative;
   border-radius: 8px;
@@ -293,13 +306,13 @@ body > h2 {
 
 .close-btn {
   position: absolute;
-  top: 2px;
-  right: 2px;
+  top: 10px;
+  right: 10px;
   background: #fff;
   color: #000;
   border: none;
-  padding: 2px 4px;
+  padding: 4px 8px;
   cursor: pointer;
-  border-radius: 2px;
+  border-radius: 4px;
   font-weight: bold;
 }

--- a/dist/exam/snooker.html
+++ b/dist/exam/snooker.html
@@ -75,8 +75,8 @@
     </div>
 
     <div id="gameOverlay">
+      <button class="close-btn" id="closeGame">Quit</button>
       <div class="iframe-container">
-        <button class="close-btn" id="closeGame">Quit</button>
         <iframe id="gameIframe" src=""></iframe>
       </div>
     </div>

--- a/dist/exam/threecushion.html
+++ b/dist/exam/threecushion.html
@@ -202,8 +202,8 @@
     </div>
 
     <div id="gameOverlay">
+      <button class="close-btn" id="closeGame">Quit</button>
       <div class="iframe-container">
-        <button class="close-btn" id="closeGame">Quit</button>
         <iframe id="gameIframe" src=""></iframe>
       </div>
     </div>


### PR DESCRIPTION
This change improves the exam module's user interface by moving the 'Quit' button out of the game iframe container and placing it at the top-right corner of the overlay for better accessibility. Additionally, the iframe container is enlarged from 75% to 80% to provide a better viewing experience. CSS linting and formatting were also addressed as part of this update.

---
*PR created automatically by Jules for task [5988009499234652954](https://jules.google.com/task/5988009499234652954) started by @tailuge*