### PR TITLE
Compact Exam Layout

### DIFF
--- a/dist/exam/exam.css
+++ b/dist/exam/exam.css
@@ -23,7 +23,7 @@ body {
 
 header {
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 
 header h1 a {
@@ -43,8 +43,8 @@ header h1 a:hover {
   top: 0.5rem;
   z-index: 100;
   background: #fff;
-  padding: 0.75rem 1rem;
-  margin: 0 auto 0.75rem;
+  padding: 0.4rem 1rem;
+  margin: 0 auto 0.5rem;
   max-width: 800px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
@@ -52,16 +52,16 @@ header h1 a:hover {
 
 .summary {
   max-width: 800px;
-  margin: 0 auto 1rem;
+  margin: 0 auto 0.5rem;
   background: #fff;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
 }
 
 body > h2 {
   max-width: 1200px;
-  margin: 1.5rem auto 0.5rem;
+  margin: 1rem auto 0.5rem;
   padding: 0 0.75rem;
 }
 
@@ -151,9 +151,9 @@ body > h2 {
 
 .question-block {
   max-width: 1200px;
-  margin: 0 auto 1rem;
+  margin: 0 auto 0.75rem;
   background: #fff;
-  padding: 0.75rem;
+  padding: 0.5rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
   display: flex;


### PR DESCRIPTION
Reduced vertical padding and margins on the title, H1, assessment bar, and other top-level elements in `dist/exam/exam.css` to improve space efficiency and fit more content on the screen.

---
*PR created automatically by Jules for task [4458912701201535837](https://jules.google.com/task/4458912701201535837) started by @tailuge*