### PR TITLE
Centralize SVG diagram styles and fix PNG export consistency

### DIFF
--- a/dist/css/ball-colors.css
+++ b/dist/css/ball-colors.css
@@ -166,3 +166,34 @@
 .threecushion .trajectory-line {
   stroke: #000;
 }
+
+/* SVG Diagram Shared Styles */
+.table-stroke {
+  fill: none;
+  stroke: #000;
+  stroke-width: 0.004;
+}
+
+.grid-line {
+  stroke: #ccc;
+  stroke-width: 0.002;
+  stroke-dasharray: 0.008 0.008;
+}
+
+.manual-line {
+  fill: none;
+  stroke: #4f4f4f;
+  stroke-width: 0.001;
+  stroke-dasharray: 0.06 0.03;
+}
+
+.fine-stroke {
+  fill: none;
+  stroke: #000;
+  stroke-width: 0.001;
+}
+
+.worker-status {
+  pointer-events: none;
+  user-select: none;
+}

--- a/dist/diagrams/export.html
+++ b/dist/diagrams/export.html
@@ -56,18 +56,6 @@
         margin: 0 auto;
       }
 
-      .table-stroke {
-        fill: none;
-        stroke: #000;
-        stroke-width: 0.004;
-      }
-
-      .grid-line {
-        stroke: #ccc;
-        stroke-width: 0.002;
-        stroke-dasharray: 0.008 0.008;
-      }
-
       #controls {
         margin-top: 0.4rem;
         text-align: center;
@@ -97,19 +85,6 @@
         background: #000;
         color: #fff;
         border-color: #000;
-      }
-
-      .manual-line {
-        fill: none;
-        stroke: #4f4f4f;
-        stroke-width: 0.001;
-        stroke-dasharray: 0.06 0.03;
-      }
-
-      .fine-stroke {
-        fill: none;
-        stroke: #000;
-        stroke-width: 0.001;
       }
 
       .snap-indicator {
@@ -280,27 +255,6 @@
         background: #fff;
         border-radius: 0.25rem;
       }
-      .table-stroke {
-        fill: none;
-        stroke: #000;
-        stroke-width: 0.004;
-      }
-      .grid-line {
-        stroke: #ccc;
-        stroke-width: 0.002;
-        stroke-dasharray: 0.008 0.008;
-      }
-      .manual-line {
-        fill: none;
-        stroke: #000;
-        stroke-width: 0.003;
-        stroke-dasharray: 0.06 0.03;
-      }
-      .fine-stroke {
-        fill: none;
-        stroke: #000;
-        stroke-width: 0.001;
-      }
     </style>
   </head>
   <body>
@@ -409,14 +363,24 @@
           clone.removeAttribute("data-json-shots")
           clone.removeAttribute("data-figure")
 
-          // Embed page CSS into the SVG so it renders standalone
-          const pageStyle = document.querySelector("style")
-          if (pageStyle) {
+          // Embed all page CSS rules into the SVG so it renders standalone correctly
+          let combinedCss = ""
+          for (const sheet of document.styleSheets) {
+            try {
+              for (const rule of sheet.cssRules) {
+                combinedCss += rule.cssText + "\n"
+              }
+            } catch (e) {
+              console.warn("Could not read stylesheet rules:", e)
+            }
+          }
+
+          if (combinedCss) {
             const svgStyle = document.createElementNS(
               "http://www.w3.org/2000/svg",
               "style"
             )
-            svgStyle.textContent = pageStyle.textContent
+            svgStyle.textContent = combinedCss
             clone.insertBefore(svgStyle, clone.firstChild)
           }
 

--- a/dist/diagrams/svg.html
+++ b/dist/diagrams/svg.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Billiards Trajectory — SVG Diagrams</title>
+    <link rel="stylesheet" href="../css/ball-colors.css" />
     <style>
       *,
       *::before,
@@ -21,7 +22,7 @@
           Roboto,
           sans-serif;
         background: #f0f0f0;
-        color: #000000;
+        color: #000;
         min-height: 100vh;
         padding: 0.25rem;
       }
@@ -57,31 +58,6 @@
         height: auto;
         background: #fff;
         border-radius: 0.25rem;
-      }
-
-      .table-stroke {
-        fill: #fff;
-        stroke: #000;
-        stroke-width: 0.004;
-      }
-
-      .grid-line {
-        stroke: #ccc;
-        stroke-width: 0.002;
-        stroke-dasharray: 0.008 0.008;
-      }
-
-      .trajectory-line {
-        fill: none;
-        stroke: #000;
-        stroke-width: 0.002;
-      }
-
-      .manual-line {
-        fill: none;
-        stroke: #4f4f4f;
-        stroke-width: 0.001;
-        stroke-dasharray: 0.06 0.03;
       }
     </style>
   </head>

--- a/dist/diagrams/svg.js
+++ b/dist/diagrams/svg.js
@@ -315,14 +315,6 @@ function moveManualElements(el, manualLinesGroup) {
   existing.forEach((line) => manualLinesGroup.appendChild(line));
 }
 
-function injectManualLineStyles() {
-  if (document.getElementById("manual-line-styles")) return;
-  const style = document.createElement("style");
-  style.id = "manual-line-styles";
-  style.textContent = `.manual-line { fill: none; stroke: #000; stroke-width: 0.002; }`;
-  document.head.appendChild(style);
-}
-
 export function setupSvgRoot(el) {
   if (!el.getAttribute("xmlns")) {
     el.setAttribute("xmlns", SVG_NS);
@@ -497,7 +489,6 @@ function setStatus(el, message) {
  * Renders the table and runs any data-shots simulations.
  */
 export function initDiagrams(ruletype) {
-  injectManualLineStyles();
   const divs = document.querySelectorAll(".billiards-table");
   if (divs.length === 0) {
     console.warn("No .billiards-table elements found on page");

--- a/dist/exam/exam.css
+++ b/dist/exam/exam.css
@@ -190,31 +190,12 @@ body > h2 {
   border-radius: 4px;
 }
 
-/* SVG styles from svg.html */
-.table-stroke {
-  fill: none;
-  stroke: #000;
-  stroke-width: 0.004;
-}
-
-.grid-line {
-  stroke: #ccc;
-  stroke-width: 0.002;
-  stroke-dasharray: 0.008 0.008;
-}
-
+/* SVG Diagram Style Overrides */
 .manual-line {
-  fill: none;
-  stroke: #4f4f4f;
-  stroke-width: 0.001;
-  stroke-dasharray: 0.06 0.03;
   opacity: 0.5;
 }
 
 .fine-stroke {
-  fill: none;
-  stroke: #000;
-  stroke-width: 0.001;
   stroke-dasharray: 0.06 0.03;
 }
 


### PR DESCRIPTION
This change centralizes SVG diagram styling into a single CSS file (`dist/css/ball-colors.css`) and fixes an issue where exported PNG diagrams in `export.html` had inconsistent styling (incorrect fills). The PNG export logic now robustly embeds all active document styles into the generated image, ensuring it perfectly matches the live view. Redundant, hardcoded styles have been removed from various HTML and CSS files to maintain a single source of truth for diagram appearance.

---
*PR created automatically by Jules for task [11869678942707000100](https://jules.google.com/task/11869678942707000100) started by @tailuge*