### PR TITLE
Refactor export and analysis buttons to work in end state

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -40,6 +40,7 @@ import { PlayShot } from "../controller/playshot"
 import { WatchAim } from "../controller/watchaim"
 import { WatchShot } from "../controller/watchshot"
 import { BallTray } from "../view/ball-tray"
+import { ExportUtils } from "../utils/export-utils"
 
 type ActivePlayer = 0 | 1 | 2
 
@@ -309,15 +310,9 @@ export class Container {
   }
 
   updateLastShot() {
-    this.lastShotInit = JSON.stringify(this.table.shortSerialise())
-    const aim = this.table.cue!.aim
-    this.lastShotData = JSON.stringify({
-      cueBallId: aim.i,
-      angle: aim.angle,
-      power: aim.power,
-      offset: { x: aim.offset.x, y: aim.offset.y },
-      elevation: aim.elevation || 0,
-    })
+    const snapshot = ExportUtils.captureSnapshot(this.table)
+    this.lastShotInit = snapshot.init
+    this.lastShotData = snapshot.shot
   }
 
   updateController(controller: Controller) {

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -87,6 +87,9 @@ export class Container {
   private hudActivePlayer: ActivePlayer = 0
   private wasReplay: boolean = false
 
+  lastShotInit?: string
+  lastShotData?: string
+
   last = performance.now()
   readonly step = 0.001953125 * 1
 
@@ -305,6 +308,18 @@ export class Container {
     })
   }
 
+  updateLastShot() {
+    this.lastShotInit = JSON.stringify(this.table.shortSerialise())
+    const aim = this.table.cue!.aim
+    this.lastShotData = JSON.stringify({
+      cueBallId: aim.i,
+      angle: aim.angle,
+      power: aim.power,
+      offset: { x: aim.offset.x, y: aim.offset.y },
+      elevation: aim.elevation || 0,
+    })
+  }
+
   updateController(controller: Controller) {
     this.wasReplay = this.wasReplay || controller instanceof Replay
     if (controller !== this.controller) {
@@ -328,7 +343,9 @@ export class Container {
           (this.wasReplay && controller instanceof End)
       )
       this.menu?.setAnalysisVisible(
-        controller instanceof Replay && this.rules.rulename === "threecushion"
+        (controller instanceof Replay ||
+          (this.wasReplay && controller instanceof End)) &&
+          this.rules.rulename === "threecushion"
       )
       const isTwoPlayer =
         !this.isSinglePlayer &&

--- a/src/controller/replay.ts
+++ b/src/controller/replay.ts
@@ -27,8 +27,7 @@ export class Replay extends ControllerBase {
   timer
   init
   diagram?: boolean
-  currentInit = ""
-  currentShot = ""
+
   constructor(container, init, shots, _retry = false, delay = 1500, diagram?) {
     super(container)
     this.init = init
@@ -131,6 +130,7 @@ export class Replay extends ControllerBase {
       this.container.view.camera.mode === this.container.view.camera.topView
     this.container.table.cueball.pos.copy(aim.pos)
     this.container.table.cue.aim = aim
+    this.container.updateLastShot()
     this.container.table.cue.updateAimInput()
     this.container.table.cue.t = 1
     this.container.view.camera.suggestMode(
@@ -149,21 +149,9 @@ export class Replay extends ControllerBase {
   }
 
   override handleHit(_: HitEvent) {
-    this.snapshotBeforeHit()
+    this.container.updateLastShot()
     this.hit()
     return this
-  }
-
-  private snapshotBeforeHit() {
-    this.currentInit = JSON.stringify(this.container.table.shortSerialise())
-    const aim = this.container.table.cue!.aim
-    this.currentShot = JSON.stringify({
-      cueBallId: aim.i,
-      angle: aim.angle,
-      power: aim.power,
-      offset: { x: aim.offset.x, y: aim.offset.y },
-      elevation: aim.elevation || 0,
-    })
   }
 
   override handleStationary(_) {

--- a/src/utils/export-utils.ts
+++ b/src/utils/export-utils.ts
@@ -1,0 +1,41 @@
+import { Table } from "../model/table"
+
+export interface ShotSnapshot {
+  init: string
+  shot: string
+}
+
+export class ExportUtils {
+  static captureSnapshot(table: Table): ShotSnapshot {
+    const init = JSON.stringify(table.shortSerialise())
+    const aim = table.cue!.aim
+    const shot = JSON.stringify({
+      cueBallId: aim.i,
+      angle: aim.angle,
+      power: aim.power,
+      offset: { x: aim.offset.x, y: aim.offset.y },
+      elevation: aim.elevation || 0,
+    })
+    return { init, shot }
+  }
+
+  static getExportUrl(
+    isAnalysis: boolean,
+    rulename: string,
+    init: string,
+    shot: string
+  ): string {
+    const base = isAnalysis
+      ? "https://velikodimov.github.io/billiards/dist/index.html"
+      : "diagrams/export.html"
+    const params = new URLSearchParams()
+    params.set("ruletype", rulename)
+    if (isAnalysis) {
+      params.set("practice", "")
+      params.set("analysis", "")
+    }
+    params.set("init", init)
+    params.set("initShot", shot)
+    return `${base}?${params.toString()}`
+  }
+}

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -2,6 +2,7 @@ import { Container } from "../container/container"
 import { getButton } from "../utils/dom"
 import { Session } from "../network/client/session"
 import { ConcedeEvent } from "../events/concedeevent"
+import { ExportUtils } from "../utils/export-utils"
 
 export class Menu {
   container: Container
@@ -89,18 +90,13 @@ export class Menu {
     const init = this.container.lastShotInit
     const shot = this.container.lastShotData
     if (init && shot) {
-      const base = isAnalysis
-        ? "https://velikodimov.github.io/billiards/dist/index.html"
-        : "diagrams/export.html"
-      const params = new URLSearchParams()
-      params.set("ruletype", this.container.rules.rulename)
-      if (isAnalysis) {
-        params.set("practice", "")
-        params.set("analysis", "")
-      }
-      params.set("init", init)
-      params.set("initShot", shot)
-      window.open(`${base}?${params.toString()}`, "_blank")
+      const url = ExportUtils.getExportUrl(
+        isAnalysis,
+        this.container.rules.rulename,
+        init,
+        shot
+      )
+      window.open(url, "_blank")
     }
   }
 

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -2,7 +2,6 @@ import { Container } from "../container/container"
 import { getButton } from "../utils/dom"
 import { Session } from "../network/client/session"
 import { ConcedeEvent } from "../events/concedeevent"
-import { Replay } from "../controller/replay"
 
 export class Menu {
   container: Container
@@ -26,34 +25,11 @@ export class Menu {
     this.analysis = this.getElement("analysis")
 
     if (this.analysis) {
-      this.analysis.onclick = () => {
-        const replay = this.container.controller as Replay
-        if (replay.currentInit && replay.currentShot) {
-          const base = "https://velikodimov.github.io/billiards/dist/index.html"
-          const params = new URLSearchParams()
-          params.set("ruletype", this.container.rules.rulename)
-          params.set("practice", "")
-          // Open the full-page shot analysis view directly (was drill mode).
-          params.set("analysis", "")
-          params.set("init", replay.currentInit)
-          params.set("initShot", replay.currentShot)
-          window.open(`${base}?${params.toString()}`, "_blank")
-        }
-      }
+      this.analysis.onclick = () => this.handleExport(true)
     }
 
     if (this.diagram) {
-      this.diagram.onclick = () => {
-        const replay = this.container.controller as Replay
-        if (replay.currentInit && replay.currentShot) {
-          const base = "diagrams/export.html"
-          const params = new URLSearchParams()
-          params.set("ruletype", this.container.rules.rulename)
-          params.set("init", replay.currentInit)
-          params.set("initShot", replay.currentShot)
-          window.open(`${base}?${params.toString()}`, "_blank")
-        }
-      }
+      this.diagram.onclick = () => this.handleExport(false)
     }
 
     this.setShareVisible(false)
@@ -106,6 +82,25 @@ export class Menu {
           }
         )
       }
+    }
+  }
+
+  private handleExport(isAnalysis: boolean) {
+    const init = this.container.lastShotInit
+    const shot = this.container.lastShotData
+    if (init && shot) {
+      const base = isAnalysis
+        ? "https://velikodimov.github.io/billiards/dist/index.html"
+        : "diagrams/export.html"
+      const params = new URLSearchParams()
+      params.set("ruletype", this.container.rules.rulename)
+      if (isAnalysis) {
+        params.set("practice", "")
+        params.set("analysis", "")
+      }
+      params.set("init", init)
+      params.set("initShot", shot)
+      window.open(`${base}?${params.toString()}`, "_blank")
     }
   }
 


### PR DESCRIPTION
Refactored the shot snapshot logic into the Container class and updated the Menu component to use these persisted values. This ensures that the diagram (export) and analysis (spyglass) buttons remain visible and functional in the End controller state following a replay, as requested. Also removed duplicate code by centralizing the export handling logic.

---
*PR created automatically by Jules for task [5325304072155535854](https://jules.google.com/task/5325304072155535854) started by @tailuge*