### PR TITLE
Optimize sensitivity analysis by disabling trajectory recording

### DIFF
--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -53,6 +53,8 @@ export interface WorkerConfig {
   }
   stepSize?: number
   maxIterations?: number
+  recordTrajectory?: boolean
+  warpClearanceR?: number
 }
 
 /** Result of a single simulation (frames intentionally dropped). */
@@ -87,6 +89,7 @@ export function buildWorkerConfig(
       offset: { x: shot.offsetX, y: shot.offsetY },
       elevation: shot.elevation,
     },
+    recordTrajectory: false,
   }
 }
 


### PR DESCRIPTION
This change optimizes the sensitivity analysis by leveraging the `recordTrajectory` flag in the worker simulation. By setting it to `false` in `buildWorkerConfig`, we avoid unnecessary trajectory data generation and transmission, focusing only on the outcomes required for the analysis.

Key changes:
- Updated `WorkerConfig` interface in `src/sensitivity.ts` to include `recordTrajectory` and `warpClearanceR`.
- Modified `buildWorkerConfig` in `src/sensitivity.ts` to explicitly set `recordTrajectory: false`.
- Verified changes via `yarn build` and `yarn test`.

---
*PR created automatically by Jules for task [7889087564132801038](https://jules.google.com/task/7889087564132801038) started by @tailuge*