### PR TITLE
Color-coded ball symbols in solution patterns

### DIFF
--- a/dist/fit/solution.html
+++ b/dist/fit/solution.html
@@ -54,6 +54,16 @@
 
       .pattern-col {
         font-family: monospace;
+        font-size: 1rem;
+      }
+
+      .ball-1 {
+        color: #ffd700;
+        text-shadow: 0 0 1px #000;
+      }
+
+      .ball-2 {
+        color: #f00;
       }
 
       .empty-msg {
@@ -494,13 +504,14 @@
             const patternStr = data.outcomes
               .slice(0, patternEnd)
               .filter((o) => o.ballA === 0 || o.ballB === 0)
-              .map((o) =>
-                o.type === "Cushion"
-                  ? o.cushion ?? "⌻"
-                  : o.type === "Collision"
-                    ? "◉"
-                    : o.type.toLowerCase()
-              )
+              .map((o) => {
+                if (o.type === "Cushion") return o.cushion ?? "⌻"
+                if (o.type === "Collision") {
+                  const otherId = o.ballA === 0 ? o.ballB : o.ballA
+                  return `◉${otherId}`
+                }
+                return o.type.toLowerCase()
+              })
               .join("")
 
             let entry = patterns.get(patternStr)
@@ -520,6 +531,13 @@
 
         let currentActiveLink = null
         let diagramLoading = false
+
+        function renderPattern(pattern) {
+          return pattern.replace(
+            /◉(\d+)/g,
+            (_, id) => `<span class="ball-${id}">◉</span>`
+          )
+        }
 
         async function showDiagram(task) {
           if (diagramLoading) return
@@ -578,7 +596,7 @@
                 })
                 .join("")
               tr.innerHTML = `
-                            <td class="pattern-col">${pattern}</td>
+                            <td class="pattern-col">${renderPattern(pattern)}</td>
                             <td><span class="sol-links">${linksHtml}</span></td>
                             <td class="count-col">${entry.count}</td>
                         `


### PR DESCRIPTION
This change enhances the `solution.html` search tool by adding color-coding to the shot patterns. 

Previously, all ball collisions were represented by a monochrome `◉` symbol. Now, the patterns distinguish between hitting the yellow ball (ID 1) and the red ball (ID 2). 

Key changes:
- Defined `.ball-1` (Yellow with a slight shadow for visibility) and `.ball-2` (Red) CSS classes.
- Updated the pattern string generation logic to append the hit ball's ID to the collision symbol (e.g., `◉1`).
- Added a `renderPattern` helper function that uses a regular expression to convert these internal markers into styled HTML `<span>` elements.
- Integrated the renderer into the results table display.

This allows users to immediately see the hit sequence (e.g., Yellow-Cushion-Red vs Red-Cushion-Yellow) in the summary tables.

---
*PR created automatically by Jules for task [8058371269560177793](https://jules.google.com/task/8058371269560177793) started by @tailuge*