### PR TITLE
Remove SVG rotation and scale to 90% on mobile in solution.html

### DIFF
--- a/dist/fit/solution.html
+++ b/dist/fit/solution.html
@@ -152,20 +152,14 @@
         }
 
         .diagram-col {
-          height: 121vw;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          overflow: hidden;
           min-width: unset;
           flex: none;
           width: 100%;
         }
 
         .diagram-wrapper {
-          width: 120vw;
-          transform: rotate(90deg);
-          flex-shrink: 0;
+          width: 90%;
+          margin: 0 auto;
         }
       }
     </style>
@@ -629,11 +623,12 @@
           )
 
           const ballFirst = sortedPatterns.filter(([p]) => p.startsWith("◉"))
-          const cushionFirst = sortedPatterns.filter(([p]) =>
-            p.startsWith("L") ||
-            p.startsWith("l") ||
-            p.startsWith("S") ||
-            p.startsWith("s")
+          const cushionFirst = sortedPatterns.filter(
+            ([p]) =>
+              p.startsWith("L") ||
+              p.startsWith("l") ||
+              p.startsWith("S") ||
+              p.startsWith("s")
           )
 
           renderTable(resultsBodyBall, ballFirst)


### PR DESCRIPTION
The billiard diagram in `solution.html` was previously rotated 90 degrees on mobile devices to fit the screen. This change removes the rotation and instead scales the diagram down to 90% of the container width, providing a more natural viewing experience on narrow screens while keeping the diagram upright.

---
*PR created automatically by Jules for task [8390738803357588565](https://jules.google.com/task/8390738803357588565) started by @tailuge*