### PR TITLE
Use clock-face spin offsets in solution search tool

### DIFF
--- a/dist/fit/solution.html
+++ b/dist/fit/solution.html
@@ -242,6 +242,12 @@
       const R = 0.03275
       const maxPower = 160 * R
 
+      const clock = (h) => ({
+        ox: 0.4 * Math.cos((h * Math.PI) / 6),
+        oy: -0.4 * Math.sin((h * Math.PI) / 6),
+      })
+      const OFFSETS = [12, 1, 3, 5, 7, 9, 11].map(clock)
+
       const progressBar = document.getElementById("progress-bar")
       const statProgress = document.getElementById("stat-progress")
       const statFound = document.getElementById("stat-found")
@@ -359,16 +365,13 @@
         for (const a of extraAngles) angles.push(a)
 
         const powerPercents = [0.3, 0.5, 0.85]
-        const offsetValues = [-0.4, 0.0, 0.4]
 
         const tasks = []
         for (const angle of angles) {
           for (const pPct of powerPercents) {
             const power = pPct * maxPower
-            for (const ox of offsetValues) {
-              for (const oy of offsetValues) {
-                tasks.push({ angle, power, ox, oy })
-              }
+            for (const { ox, oy } of OFFSETS) {
+              tasks.push({ angle, power, ox, oy })
             }
           }
         }


### PR DESCRIPTION
The spin offset search in `dist/fit/solution.html` was refactored to use a more specific and efficient set of circular offsets. Instead of a 3x3 grid, it now samples seven positions on a clock face (radius 0.4) for hours 12, 1, 3, 5, 7, 9, and 11. This change improves the search quality by focusing on realistic spin positions and slightly reduces the total number of simulation tasks.

Key changes:
- Implemented a `clock` helper function where `clock(12)` maps to `(0.4, 0)` and increments clockwise.
- Created a static `OFFSETS` array to compute these values once.
- Updated the task generation logic in `startSearch` to iterate over these pre-computed offsets.
- Verified the fix via Playwright and confirmed that core physics tests still pass.

---
*PR created automatically by Jules for task [13452520648857969668](https://jules.google.com/task/13452520648857969668) started by @tailuge*