### PR TITLE
Show initial table state in solution.html

### DIFF
--- a/dist/fit/solution.html
+++ b/dist/fit/solution.html
@@ -252,6 +252,97 @@
       const setupBtn = document.getElementById("setup-btn")
       const analysisBtn = document.getElementById("analysis-btn")
       let currentConfig = null
+      let currentActiveLink = null
+      let diagramLoading = false
+
+      function renderPattern(pattern) {
+        return pattern.replace(
+          /◉(\d+)/g,
+          (_, id) => `<span class="ball-${id}">◉</span>`
+        )
+      }
+
+      async function showDiagram(task) {
+        if (diagramLoading) return
+        diagramLoading = true
+        try {
+          const balls = []
+          for (let i = 0; i < ballPositions.length; i += 2) {
+            balls.push({
+              id: i / 2,
+              pos: { x: ballPositions[i], y: ballPositions[i + 1], z: 0 },
+            })
+          }
+          const config = [
+            {
+              balls,
+              cushionModel,
+              ruleType: "threecushion",
+              shot: {
+                cueBallId: 0,
+                angle: +task.angle.toFixed(6),
+                power: +task.power.toFixed(6),
+                offset: {
+                  x: +task.ox.toFixed(6),
+                  y: +task.oy.toFixed(6),
+                  z: 0,
+                },
+                elevation: 0,
+              },
+            },
+          ]
+          diagramSvg.dataset.jsonShots = JSON.stringify(config)
+          currentConfig = config
+          diagramSvg
+            .querySelectorAll(
+              ".table-group, .trajectories-group, .balls-group, .inset-group"
+            )
+            .forEach((g) => g.remove())
+          await initDiagrams()
+        } finally {
+          diagramLoading = false
+        }
+      }
+
+      function renderTable(tbody, sortedPatterns) {
+        tbody.innerHTML = ""
+        if (sortedPatterns.length === 0) {
+          tbody.innerHTML =
+            '<tr><td colspan="3" class="empty-msg">None</td></tr>'
+        } else {
+          for (const [pattern, entry] of sortedPatterns) {
+            const tr = document.createElement("tr")
+            const linksHtml = entry.solutions
+              .map((sol, i) => {
+                const encoded = encodeURIComponent(JSON.stringify(sol))
+                return `<a class="sol-link" data-task="${encoded}" title="#${i + 1}: a=${sol.angle.toFixed(3)} p=${sol.power.toFixed(3)} ox=${sol.ox.toFixed(2)} oy=${sol.oy.toFixed(2)}">⇗</a>`
+              })
+              .join("")
+            tr.innerHTML = `
+                            <td class="pattern-col">${renderPattern(pattern)}</td>
+                            <td><span class="sol-links">${linksHtml}</span></td>
+                            <td class="count-col">${entry.count}</td>
+                        `
+            tbody.appendChild(tr)
+          }
+        }
+      }
+
+      // Delegated click handler for inline diagram links
+      document.addEventListener("click", async (e) => {
+        const link = e.target.closest(".sol-link")
+        if (!link || !link.dataset.task) return
+        e.preventDefault()
+        e.stopPropagation()
+
+        // Update active state
+        if (currentActiveLink) currentActiveLink.classList.remove("active")
+        link.classList.add("active")
+        currentActiveLink = link
+
+        const task = JSON.parse(decodeURIComponent(link.dataset.task))
+        await showDiagram(task)
+      })
 
       setupBtn.addEventListener("click", () => {
         if (!currentConfig) return
@@ -311,15 +402,12 @@
         }
       }
 
-      // Init empty diagram
-      initDiagrams()
-
-      if (
-        initParam &&
-        ballPositions.length >= 6 &&
-        !ballPositions.some(isNaN)
-      ) {
+      if (initParam && ballPositions.length >= 6 && !ballPositions.some(isNaN)) {
+        await showDiagram({ angle: 0, power: 0.01, ox: 0, oy: 0 })
         startSearch()
+      } else {
+        // Init empty diagram
+        initDiagrams()
       }
 
       async function startSearch() {
@@ -526,98 +614,6 @@
             })
           }
         }
-
-        let currentActiveLink = null
-        let diagramLoading = false
-
-        function renderPattern(pattern) {
-          return pattern.replace(
-            /◉(\d+)/g,
-            (_, id) => `<span class="ball-${id}">◉</span>`
-          )
-        }
-
-        async function showDiagram(task) {
-          if (diagramLoading) return
-          diagramLoading = true
-          try {
-            const balls = []
-            for (let i = 0; i < ballPositions.length; i += 2) {
-              balls.push({
-                id: i / 2,
-                pos: { x: ballPositions[i], y: ballPositions[i + 1], z: 0 },
-              })
-            }
-            const config = [
-              {
-                balls,
-                cushionModel,
-                ruleType: "threecushion",
-                shot: {
-                  cueBallId: 0,
-                  angle: +task.angle.toFixed(6),
-                  power: +task.power.toFixed(6),
-                  offset: {
-                    x: +task.ox.toFixed(6),
-                    y: +task.oy.toFixed(6),
-                    z: 0,
-                  },
-                  elevation: 0,
-                },
-              },
-            ]
-            diagramSvg.dataset.jsonShots = JSON.stringify(config)
-            currentConfig = config
-            diagramSvg
-              .querySelectorAll(
-                ".table-group, .trajectories-group, .balls-group, .inset-group"
-              )
-              .forEach((g) => g.remove())
-            await initDiagrams()
-          } finally {
-            diagramLoading = false
-          }
-        }
-
-        function renderTable(tbody, sortedPatterns) {
-          tbody.innerHTML = ""
-          if (sortedPatterns.length === 0) {
-            tbody.innerHTML =
-              '<tr><td colspan="3" class="empty-msg">None</td></tr>'
-          } else {
-            for (const [pattern, entry] of sortedPatterns) {
-              const tr = document.createElement("tr")
-              const linksHtml = entry.solutions
-                .map((sol, i) => {
-                  const encoded = encodeURIComponent(JSON.stringify(sol))
-                  return `<a class="sol-link" data-task="${encoded}" title="#${i + 1}: a=${sol.angle.toFixed(3)} p=${sol.power.toFixed(3)} ox=${sol.ox.toFixed(2)} oy=${sol.oy.toFixed(2)}">⇗</a>`
-                })
-                .join("")
-              tr.innerHTML = `
-                            <td class="pattern-col">${renderPattern(pattern)}</td>
-                            <td><span class="sol-links">${linksHtml}</span></td>
-                            <td class="count-col">${entry.count}</td>
-                        `
-              tbody.appendChild(tr)
-            }
-          }
-        }
-
-        // Delegated click handler for inline diagram links
-        document.addEventListener("click", async (e) => {
-          const link = e.target.closest(".sol-link")
-          if (!link || !link.dataset.task) return
-          e.preventDefault()
-          e.stopPropagation()
-
-          // Update active state
-          if (currentActiveLink) currentActiveLink.classList.remove("active")
-          link.classList.add("active")
-          currentActiveLink = link
-
-          const task = JSON.parse(decodeURIComponent(link.dataset.task))
-          await showDiagram(task)
-        })
 
         function finishSearch() {
           updateUI()


### PR DESCRIPTION
This change implements an initial render of the billiard table in `solution.html` when an `init` parameter is present. By calling `showDiagram` with a minimal-power shot (0.01 power) before the search computation begins, the balls are displayed in their starting positions immediately. This provides better user feedback while the worker-based search is running.

Key changes:
- Extracted `showDiagram`, `renderTable`, `renderPattern`, and related state variables to the module scope.
- Added logic to await `showDiagram` before `startSearch` if `initParam` is valid.
- Maintained compatibility with existing solution links and setup/analysis buttons.

---
*PR created automatically by Jules for task [6458058800907488416](https://jules.google.com/task/6458058800907488416) started by @tailuge*