### PR TITLE
Eliminate high-frequency .clone() calls in physics loops

### DIFF
--- a/src/model/physics/collisionthrow.ts
+++ b/src/model/physics/collisionthrow.ts
@@ -4,6 +4,15 @@ import { Collision } from "./collision"
 import { I, m, R } from "./constants"
 import { exp } from "../../utils/utils"
 
+const ab_v = new Vector3()
+const abTangent_v = new Vector3()
+const vPoint_v = new Vector3()
+const vRelTangentialVec_v = new Vector3()
+const impulseTangential_v = new Vector3()
+const impulseNormal_v = new Vector3()
+const angularImpulse_v = new Vector3()
+const temp_v = new Vector3()
+
 /**
  * Based on
  * https://billiards.colostate.edu/technical_proofs/new/TP_A-14.pdf
@@ -21,23 +30,25 @@ export class CollisionThrow {
     const contact = Collision.positionsAtContact(a, b)
     a.ballmesh?.trace.forceTrace(contact.a)
     b.ballmesh?.trace.forceTrace(contact.b)
-    const ab = contact.b.sub(contact.a).normalize()
-    const abTangent = new Vector3(-ab.y, ab.x, 0)
+    const ab = ab_v.subVectors(contact.b, contact.a).normalize()
+    const abTangent = abTangent_v.set(-ab.y, ab.x, 0)
 
     const e = 0.925
-    const vPoint = a.vel
-      .clone()
+    const vPoint = vPoint_v
+      .copy(a.vel)
       .sub(b.vel)
       .add(
-        ab
-          .clone()
+        temp_v
+          .copy(ab)
           .multiplyScalar(-R)
           .cross(a.rvel)
-          .sub(ab.clone().multiplyScalar(R).cross(b.rvel))
       )
+      .sub(temp_v.copy(ab).multiplyScalar(R).cross(b.rvel))
 
     const vRelNormalMag = ab.dot(vPoint)
-    const vRelTangentialVec = vPoint.clone().addScaledVector(ab, -vRelNormalMag)
+    const vRelTangentialVec = vRelTangentialVec_v
+      .copy(vPoint)
+      .addScaledVector(ab, -vRelNormalMag)
     const vRelMag = vRelTangentialVec.length()
 
     const μ = this.dynamicFriction(vRelMag)
@@ -46,21 +57,19 @@ export class CollisionThrow {
     this.normalImpulse = (-(1 + e) * vRelNormalMag) / (2 / m)
 
     // Tangential impulse (frictional constraint)
-    let impulseTangential = new Vector3(0, 0, 0)
+    const impulseTangential = impulseTangential_v.set(0, 0, 0)
     if (vRelMag > 1e-8) {
       const maxJt_friction = μ * Math.abs(this.normalImpulse)
       const maxJt_stick = (m / 7) * vRelMag
       const jtMag = Math.min(maxJt_friction, maxJt_stick)
-      impulseTangential = vRelTangentialVec
-        .clone()
-        .multiplyScalar(-jtMag / vRelMag)
+      impulseTangential.copy(vRelTangentialVec).multiplyScalar(-jtMag / vRelMag)
       this.tangentialImpulse = impulseTangential.dot(abTangent)
     } else {
       this.tangentialImpulse = 0
     }
 
     // Impulse vectors
-    const impulseNormal = ab.clone().multiplyScalar(this.normalImpulse)
+    const impulseNormal = impulseNormal_v.copy(ab).multiplyScalar(this.normalImpulse)
 
     // Apply impulses to linear velocities (constrained to XY plane)
     a.vel
@@ -79,7 +88,10 @@ export class CollisionThrow {
     // For ball B, the impulse is -Jt and it acts at rB = -R * ab
     // Torque for B: tauB = rB x (-Jt) = (-R * ab) x (-Jt) = (R * ab) x Jt
     // Thus both balls receive the SAME angular impulse.
-    const angularImpulse = ab.clone().multiplyScalar(R).cross(impulseTangential)
+    const angularImpulse = angularImpulse_v
+      .copy(ab)
+      .multiplyScalar(R)
+      .cross(impulseTangential)
 
     a.rvel.addScaledVector(angularImpulse, 1 / I)
     b.rvel.addScaledVector(angularImpulse, 1 / I)

--- a/src/model/physics/physics.ts
+++ b/src/model/physics/physics.ts
@@ -55,9 +55,12 @@ export function forceRoll(v, w) {
   w.setZ(wz)
 }
 
+const vr_v = new Vector3()
+const wr_v = new Vector3()
+
 export function rotateApplyUnrotate(theta, v, w, model) {
-  const vr = v.clone().applyAxisAngle(up, theta)
-  const wr = w.clone().applyAxisAngle(up, theta)
+  const vr = vr_v.copy(v).applyAxisAngle(up, theta)
+  const wr = wr_v.copy(w).applyAxisAngle(up, theta)
 
   const delta = model(vr, wr)
 

--- a/src/model/physics/stronge.ts
+++ b/src/model/physics/stronge.ts
@@ -22,6 +22,17 @@ export type StrongeParams = {
   omega_ratio: number
 }
 
+const R_n̂_v = new Vector3()
+const ω_cross_R_n̂_v = new Vector3()
+const V_c_v = new Vector3()
+const V_c_tangential_v = new Vector3()
+const t̂_v = new Vector3()
+const v_new_v = new Vector3()
+const negative_n̂_v = new Vector3()
+const Δv_t_t̂_v = new Vector3()
+const torque_dir_v = new Vector3()
+const ω_new_v = new Vector3()
+
 /**
  * Resolve a ball-cushion collision and return velocity deltas, not final state.
  *
@@ -37,9 +48,9 @@ export function stronge(
   const { R: radius, m: mass, I: inertia } = params
 
   // 1. Contact velocity at cushion contact point: V_c = v - (ω × R n̂)
-  const R_n̂ = n̂.clone().multiplyScalar(radius)
-  const ω_cross_R_n̂ = new Vector3().crossVectors(ω, R_n̂)
-  const V_c = v.clone().sub(ω_cross_R_n̂)
+  const R_n̂ = R_n̂_v.copy(n̂).multiplyScalar(radius)
+  const ω_cross_R_n̂ = ω_cross_R_n̂_v.crossVectors(ω, R_n̂)
+  const V_c = V_c_v.copy(v).sub(ω_cross_R_n̂)
 
   // 2. Decompose into normal/tangent scalars.
   // TypeScript chooses t̂ in the direction of the tangential contact velocity,
@@ -47,9 +58,11 @@ export function stronge(
   // a non-positive v_t0 to the scalar solver. The sign conversion happens around
   // the resolve() call below.
   const v_n0 = n̂.dot(V_c) // < 0 (ball approaching cushion)
-  const V_c_tangential = V_c.clone().addScaledVector(n̂, -v_n0) // V_c - (V_c·n̂)n̂
+  const V_c_tangential = V_c_tangential_v.copy(V_c).addScaledVector(n̂, -v_n0) // V_c - (V_c·n̂)n̂
   const v_t_mag = V_c_tangential.length()
-  const t̂ = v_t_mag > 0 ? V_c_tangential.normalize() : new Vector3()
+  const t̂ = t̂_v.copy(V_c_tangential)
+  if (v_t_mag > 0) t̂.normalize()
+  else t̂.set(0, 0, 0)
   const v_t0 = v_t_mag // >= 0; solver expects v_t0/v_n0 ratio with v_n0 < 0
 
   // 3. Scalar solver expects v_t0 <= 0 (same sign convention as v_n0 < 0).
@@ -63,20 +76,20 @@ export function stronge(
   const Δv_t = (v_tf - v_t0) / β_t
 
   // 5. Apply linear changes
-  const v_new = v.clone().addScaledVector(n̂, Δv_n).addScaledVector(t̂, Δv_t)
+  const v_new = v_new_v.copy(v).addScaledVector(n̂, Δv_n).addScaledVector(t̂, Δv_t)
   v_new.z = 0 // project back onto table plane (rvw[1][2] = 0.0 in Python)
 
   // 6. Apply angular change: Δω = (m * R / I) * (-n̂ × Δv_t t̂)
-  const negative_n̂ = n̂.clone().negate()
-  const Δv_t_t̂ = t̂.clone().multiplyScalar(Δv_t)
-  const torque_dir = new Vector3().crossVectors(negative_n̂, Δv_t_t̂)
+  const negative_n̂ = negative_n̂_v.copy(n̂).negate()
+  const Δv_t_t̂ = Δv_t_t̂_v.copy(t̂).multiplyScalar(Δv_t)
+  const torque_dir = torque_dir_v.crossVectors(negative_n̂, Δv_t_t̂)
 
   const inertiaFactor = (mass * radius) / inertia
-  const ω_new = ω.clone().addScaledVector(torque_dir, inertiaFactor)
+  const ω_new = ω_new_v.copy(ω).addScaledVector(torque_dir, inertiaFactor)
 
   return {
-    v: v_new.sub(v),
-    w: ω_new.sub(ω),
+    v: new Vector3().copy(v_new).sub(v),
+    w: new Vector3().copy(ω_new).sub(ω),
   }
 }
 


### PR DESCRIPTION
Eliminated high-frequency `.clone()` calls in physics hot paths (`collisionthrow.ts`, `stronge.ts`, and `physics.ts`) by using module-level reusable `Vector3` instances and `.copy()`/`.set()` methods. This optimization targets functions called more than once per frame to reduce memory allocations and garbage collection overhead while maintaining identical mathematical results. Verified via unit tests.

---
*PR created automatically by Jules for task [1948645978239286611](https://jules.google.com/task/1948645978239286611) started by @tailuge*