### PR TITLE
Add itch.io launcher pages for speedrun and pool

### DIFF
--- a/dist/itch/itch-pool.html
+++ b/dist/itch/itch-pool.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Pool Billiards - Free Online 8-Ball and 9-Ball Game</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://billiards.tailuge.workers.dev/favicon.png"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Play free online 8-ball and 9-ball pool with realistic physics. Open source browser game featuring multiplayer and practice modes."
+    />
+    <meta
+      name="keywords"
+      content="pool, 8-ball, 9-ball, billiards, free, open source, browser game, 台球, 8球, 9球, bilyar, bida, billiards online, 8 ball pool"
+    />
+    <meta name="robots" content="index,follow" />
+    <link
+      rel="canonical"
+      href="https://billiards.tailuge.workers.dev/itch/itch-pool.html"
+    />
+    <meta
+      property="og:title"
+      content="Pool Billiards - Free Online 8-Ball and 9-Ball Game"
+    />
+    <meta
+      property="og:description"
+      content="Play free online 8-ball and 9-ball pool with realistic physics. Realistic simulation in your browser."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://billiards.tailuge.workers.dev/itch/itch-pool.html"
+    />
+    <meta
+      property="og:image"
+      content="https://billiards.tailuge.workers.dev/assets/nineball.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Pool Billiards - Free Online 8-Ball and 9-Ball"
+    />
+    <meta
+      name="twitter:description"
+      content="Play pool online with accurate physics. Open source and browser-based 8-ball and 9-ball."
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "VideoGame",
+        "name": "Pool Billiards",
+        "url": "https://billiards.tailuge.workers.dev/itch/itch-pool.html",
+        "image": "https://billiards.tailuge.workers.dev/assets/nineball.png",
+        "description": "Open source pool simulation game with realistic physics. Play 8-ball and 9-ball.",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "Web",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Break Builder",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://billiards.tailuge.workers.dev/favicon.png"
+          }
+        },
+        "creator": {
+          "@type": "Person",
+          "name": "tailuge"
+        }
+      }
+    </script>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        background: radial-gradient(circle at center, #0a3d25 0%, #030712 100%);
+        color: #fff;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px;
+        overflow: hidden;
+      }
+      .launcher-box {
+        width: 100%;
+        max-width: 480px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: center;
+      }
+      .header-group {
+        text-align: center;
+        margin-bottom: 2px;
+      }
+      .header-title {
+        font-size: 20px;
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: #fff;
+        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+      }
+      .header-langs {
+        font-size: 11px;
+        font-weight: 700;
+        color: #10b981;
+        margin-top: 2px;
+        letter-spacing: 0.05em;
+        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+      }
+      .grid-primary {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 10px;
+        width: 100%;
+      }
+      .btn-3d {
+        position: relative;
+        background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.25),
+          0 1px 3px rgba(0, 0, 0, 0.4),
+          0 6px 12px -3px rgba(0, 0, 0, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-bottom: 5px solid #040811;
+        border-radius: 12px;
+        text-decoration: none;
+        color: inherit;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transition: all 0.1s cubic-bezier(0.25, 0.8, 0.25, 1);
+      }
+      .btn-3d::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 50%;
+        background: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.08) 0%,
+          transparent 100%
+        );
+        pointer-events: none;
+      }
+      .btn-3d:active {
+        transform: translateY(3px);
+        border-bottom-width: 2px;
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.15),
+          0 2px 4px rgba(0, 0, 0, 0.5);
+      }
+      .img-container {
+        position: relative;
+        height: 80px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 6px;
+        background: rgba(16, 185, 129, 0.03);
+      }
+      .img-container img {
+        max-height: 100%;
+        max-width: 100%;
+        object-fit: contain;
+        filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.5));
+        transition: transform 0.2s;
+      }
+      .btn-3d:hover img {
+        transform: scale(1.08);
+      }
+      .lang-card {
+        padding: 8px 10px;
+        background: rgba(2, 6, 23, 0.7);
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        font-size: 10px;
+      }
+      .lang-card p {
+        margin: 0;
+        border-left: 2px solid #475569;
+        padding-left: 5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: #cbd5e1;
+      }
+      .lang-card p.primary {
+        border-color: #10b981;
+        font-weight: bold;
+        color: #fff;
+      }
+      .btn-3d:hover p.primary {
+        color: #10b981;
+      }
+      .grid-secondary {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+        width: 100%;
+        margin-top: 2px;
+      }
+      .sub-3d {
+        position: relative;
+        background: linear-gradient(180deg, #0f172a 0%, #020617 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.15),
+          0 4px 10px -2px rgba(0, 0, 0, 0.5);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-bottom: 4px solid #02040a;
+        border-radius: 12px;
+        text-decoration: none;
+        color: inherit;
+        text-align: center;
+        padding: 8px 6px;
+        transition: all 0.1s ease;
+      }
+      .sub-3d:active {
+        transform: translateY(2px);
+        border-bottom-width: 2px;
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.1),
+          0 2px 4px rgba(0, 0, 0, 0.4);
+      }
+      .sub-title {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 5px;
+        font-weight: bold;
+        font-size: 12px;
+        color: #f1f5f9;
+      }
+      .sub-3d:hover .sub-title {
+        color: #10b981;
+      }
+      .sub-emoji {
+        font-size: 13px;
+        line-height: 1;
+      }
+      .sub-langs {
+        font-size: 8.5px;
+        color: #94a3b8;
+        margin-top: 2px;
+      }
+      @media (max-width: 480px) {
+        .header-title {
+          font-size: 18px;
+        }
+        .header-langs {
+          font-size: 10px;
+        }
+        .img-container {
+          height: 72px;
+        }
+        .lang-card {
+          font-size: 9px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="launcher-box">
+      <div class="header-group">
+        <h1 class="header-title">Pool Billiards</h1>
+        <div class="header-langs">
+          Pool • 8球 • Bilyar
+        </div>
+      </div>
+      <div class="grid-primary">
+        <a
+          href="https://billiards.tailuge.workers.dev/?ruletype=eightball&userName=Itchy"
+          class="btn-3d"
+        >
+          <div class="img-container">
+            <img
+              src="https://billiards.tailuge.workers.dev/assets/eightball.png"
+              alt="8-Ball Pool"
+            />
+          </div>
+          <div class="lang-card">
+            <p class="primary">8-Ball Pool</p>
+            <p>8球台球</p>
+            <p>8-Ball Bilyar</p>
+          </div>
+        </a>
+        <a
+          href="https://billiards.tailuge.workers.dev/?ruletype=nineball&userName=Itchy"
+          class="btn-3d"
+        >
+          <div class="img-container">
+            <img
+              src="https://billiards.tailuge.workers.dev/assets/nineball.png"
+              alt="9-Ball Pool"
+            />
+          </div>
+          <div class="lang-card">
+            <p class="primary">9-Ball Pool</p>
+            <p>9球台球</p>
+            <p>9-Ball Bilyar</p>
+          </div>
+        </a>
+      </div>
+      <div class="grid-secondary">
+        <a href="https://billiards.tailuge.workers.dev/lobby" class="sub-3d">
+          <div class="sub-title">
+            <span class="sub-emoji">🏠</span>
+            <span>Lobby</span>
+          </div>
+          <p class="sub-langs">大厅 • Lobby</p>
+        </a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/dist/itch/itch-speedrun.html
+++ b/dist/itch/itch-speedrun.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Speedrun Billiards - Fast-Paced Online Billiards Challenge</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://billiards.tailuge.workers.dev/favicon.png"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Play speedrun billiards online. Clear the table as fast as you can in this high-speed billiards challenge. Open source browser game."
+    />
+    <meta
+      name="keywords"
+      content="speedrun, billiards, pool, fast-paced, online game, browser game, free, 8-ball, 9-ball, carom, 스피드런, 당구, スピードラン, ビリヤード, Hizli bilardo, bilyar"
+    />
+    <meta name="robots" content="index,follow" />
+    <link
+      rel="canonical"
+      href="https://billiards.tailuge.workers.dev/itch/itch-speedrun.html"
+    />
+    <meta
+      property="og:title"
+      content="Speedrun Billiards - Fast-Paced Online Billiards Challenge"
+    />
+    <meta
+      property="og:description"
+      content="Play speedrun billiards online. Clear the table as fast as you can in this high-speed billiards challenge."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://billiards.tailuge.workers.dev/itch/itch-speedrun.html"
+    />
+    <meta
+      property="og:image"
+      content="https://billiards.tailuge.workers.dev/assets/speedrun.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Speedrun Billiards - Fast-Paced Online Billiards Challenge"
+    />
+    <meta
+      name="twitter:description"
+      content="Play speedrun billiards online with accurate physics. Open source and browser-based."
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "VideoGame",
+        "name": "Speedrun Billiards",
+        "url": "https://billiards.tailuge.workers.dev/itch/itch-speedrun.html",
+        "image": "https://billiards.tailuge.workers.dev/assets/speedrun.png",
+        "description": "Fast-paced billiards simulation game. Clear the table as fast as possible.",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "Web",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Break Builder",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://billiards.tailuge.workers.dev/favicon.png"
+          }
+        },
+        "creator": {
+          "@type": "Person",
+          "name": "tailuge"
+        }
+      }
+    </script>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+        background: radial-gradient(circle at center, #0a3d25 0%, #030712 100%);
+        color: #fff;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px;
+        overflow: hidden;
+      }
+      .launcher-box {
+        width: 100%;
+        max-width: 480px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: center;
+      }
+      .header-group {
+        text-align: center;
+        margin-bottom: 2px;
+      }
+      .header-title {
+        font-size: 20px;
+        font-weight: 900;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: #fff;
+        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
+      }
+      .grid-primary {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+        width: 100%;
+      }
+      .btn-3d {
+        position: relative;
+        background: linear-gradient(180deg, #1e293b 0%, #0f172a 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.25),
+          0 1px 3px rgba(0, 0, 0, 0.4),
+          0 6px 12px -3px rgba(0, 0, 0, 0.6);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-bottom: 5px solid #040811;
+        border-radius: 12px;
+        text-decoration: none;
+        color: inherit;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transition: all 0.1s cubic-bezier(0.25, 0.8, 0.25, 1);
+      }
+      .btn-3d::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 50%;
+        background: linear-gradient(
+          180deg,
+          rgba(255, 255, 255, 0.08) 0%,
+          transparent 100%
+        );
+        pointer-events: none;
+      }
+      .btn-3d:active {
+        transform: translateY(3px);
+        border-bottom-width: 2px;
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.15),
+          0 2px 4px rgba(0, 0, 0, 0.5);
+      }
+      .img-container {
+        position: relative;
+        height: 120px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 6px;
+        background: rgba(16, 185, 129, 0.03);
+      }
+      .img-container img {
+        max-height: 100%;
+        max-width: 100%;
+        object-fit: contain;
+        filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.5));
+        transition: transform 0.2s;
+      }
+      .btn-3d:hover img {
+        transform: scale(1.08);
+      }
+      .lang-card {
+        padding: 12px 16px;
+        background: rgba(2, 6, 23, 0.7);
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        font-size: 14px;
+        text-align: center;
+      }
+      .lang-card p.primary {
+        font-weight: bold;
+        color: #fff;
+      }
+      .btn-3d:hover p.primary {
+        color: #10b981;
+      }
+      .grid-secondary {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+        width: 100%;
+        margin-top: 2px;
+      }
+      .sub-3d {
+        position: relative;
+        background: linear-gradient(180deg, #0f172a 0%, #020617 100%);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.15),
+          0 4px 10px -2px rgba(0, 0, 0, 0.5);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-bottom: 4px solid #02040a;
+        border-radius: 12px;
+        text-decoration: none;
+        color: inherit;
+        text-align: center;
+        padding: 8px 6px;
+        transition: all 0.1s ease;
+      }
+      .sub-3d:active {
+        transform: translateY(2px);
+        border-bottom-width: 2px;
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.1),
+          0 2px 4px rgba(0, 0, 0, 0.4);
+      }
+      .sub-title {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 5px;
+        font-weight: bold;
+        font-size: 12px;
+        color: #f1f5f9;
+      }
+      .sub-3d:hover .sub-title {
+        color: #10b981;
+      }
+      .sub-emoji {
+        font-size: 13px;
+        line-height: 1;
+      }
+      @media (max-width: 480px) {
+        .header-title {
+          font-size: 18px;
+        }
+        .img-container {
+          height: 100px;
+        }
+        .lang-card {
+          font-size: 12px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="launcher-box">
+      <div class="header-group">
+        <h1 class="header-title">Speedrun Billiards</h1>
+      </div>
+      <div class="grid-primary">
+        <a
+          href="https://billiards.tailuge.workers.dev/speedrun/"
+          class="btn-3d"
+        >
+          <div class="img-container">
+            <img
+              src="https://billiards.tailuge.workers.dev/assets/speedrun.png"
+              alt="Speedrun Billiards"
+            />
+          </div>
+          <div class="lang-card">
+            <p class="primary">Play Speedrun</p>
+          </div>
+        </a>
+      </div>
+      <div class="grid-secondary">
+        <a href="https://billiards.tailuge.workers.dev/lobby" class="sub-3d">
+          <div class="sub-title">
+            <span class="sub-emoji">🏠</span>
+            <span>Lobby</span>
+          </div>
+        </a>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Created two new landing pages in `dist/itch/` to serve as launchers for itch.io. 

1. `itch-speedrun.html`: A focused launcher for the speedrun mode. It features a single large play button and a lobby button. On-screen text is English-only as requested, while SEO keywords retain multi-lingual terms.
2. `itch-pool.html`: A multi-mode launcher for 8-ball and 9-ball pool. It includes on-screen multi-lingual support for English, Chinese, and Tagalog, targeting the most popular regions for pool billiards.

Both pages use absolute URLs for all assets and game links to ensure compatibility when hosted on itch.io or other platforms. The design maintains consistency with the existing `itch-three.html` launcher.

---
*PR created automatically by Jules for task [3723611994648964355](https://jules.google.com/task/3723611994648964355) started by @tailuge*