### PR TITLE
Do not prepend text before share URL

### DIFF
--- a/src/utils/shorten.ts
+++ b/src/utils/shorten.ts
@@ -35,7 +35,6 @@ export function shorten(url, action) {
 export function share(url) {
   const shareData = {
     title: "Billiards",
-    text: `Replay break`,
     url: url,
   }
   if (navigator.canShare?.(shareData)) {


### PR DESCRIPTION
This change removes the `text` field (`Replay break`) from the object passed to the Web Share API (`navigator.share`) in `src/utils/shorten.ts`. On mobile browsers and certain messaging applications, including this text property caused it to be prepended directly before the shared URL (without proper spacing), producing strings like "Replay breakhttps://scoreboard-tailuge.vercel.app/api/replay/647". Removing it ensures only the URL (and optionally the title) is shared, resolving the issue perfectly. All existing tests compile and pass successfully.

---
*PR created automatically by Jules for task [394604117017545623](https://jules.google.com/task/394604117017545623) started by @tailuge*