### PR TITLE
Implement Trajectory Simplification in fit/ Directory

### DIFF
--- a/dist/fit/simplify.js
+++ b/dist/fit/simplify.js
@@ -1,0 +1,239 @@
+import { interpolateTrack } from './rmse.js'
+
+/**
+ * Node representation for the doubly-linked list of trajectory points.
+ */
+class ListNode {
+  constructor(index, sample) {
+    this.index = index // Original index in the sorted samples array
+    this.t = sample.t
+    this.x = sample.x
+    this.y = sample.y
+    this.ball = sample.ball
+    this.prev = null
+    this.next = null
+    this.cost = Infinity // Cost of deleting this node
+    this.heapIndex = -1 // Index in the binary min-heap
+  }
+}
+
+/**
+ * An updatable binary min-heap for managing candidate points for deletion.
+ */
+class MinHeap {
+  constructor() {
+    this.data = []
+  }
+
+  size() {
+    return this.data.length
+  }
+
+  push(node) {
+    node.heapIndex = this.data.length
+    this.data.push(node)
+    this.up(this.data.length - 1)
+  }
+
+  pop() {
+    if (this.data.length === 0) return null
+    const min = this.data[0]
+    const last = this.data.pop()
+    if (this.data.length > 0) {
+      this.data[0] = last
+      last.heapIndex = 0
+      this.down(0)
+    }
+    min.heapIndex = -1
+    return min
+  }
+
+  update(node) {
+    const idx = node.heapIndex
+    if (idx !== -1) {
+      this.up(idx)
+      this.down(idx)
+    }
+  }
+
+  remove(node) {
+    const idx = node.heapIndex
+    if (idx !== -1) {
+      const last = this.data.pop()
+      if (idx < this.data.length) {
+        this.data[idx] = last
+        last.heapIndex = idx
+        this.up(idx)
+        this.down(idx)
+      }
+      node.heapIndex = -1
+    }
+  }
+
+  up(i) {
+    while (i > 0) {
+      const p = (i - 1) >> 1
+      if (this.data[i].cost >= this.data[p].cost) break
+      this.swap(i, p)
+      i = p
+    }
+  }
+
+  down(i) {
+    const len = this.data.length
+    while ((i << 1) + 1 < len) {
+      let left = (i << 1) + 1
+      let right = left + 1
+      let best = i
+      if (this.data[left].cost < this.data[best].cost) best = left
+      if (right < len && this.data[right].cost < this.data[best].cost) best = right
+      if (best === i) break
+      this.swap(i, best);
+      i = best
+    }
+  }
+
+  swap(i, j) {
+    const tmp = this.data[i]
+    this.data[i] = this.data[j]
+    this.data[j] = tmp
+    this.data[i].heapIndex = i
+    this.data[j].heapIndex = j
+  }
+}
+
+/**
+ * Computes the deletion cost of a node by evaluating the maximum Euclidean error
+ * over the interval between its predecessor and successor if the node is removed.
+ *
+ * @param {ListNode} node - The candidate node.
+ * @param {Array} originalSamples - The full array of original samples for this ball.
+ * @returns {number} The maximum Euclidean distance error.
+ */
+function computeDeletionCost(node, originalSamples) {
+  if (!node.prev || !node.next) {
+    return Infinity
+  }
+  const p = node.prev
+  const s = node.next
+
+  const tempTrack = [
+    { t: p.t, x: p.x, y: p.y },
+    { t: s.t, x: s.x, y: s.y }
+  ]
+
+  let maxError = 0
+  for (let k = p.index + 1; k < s.index; k++) {
+    const orig = originalSamples[k]
+    const { point: interpolated } = interpolateTrack(tempTrack, orig.t, 0)
+    const dx = interpolated.x - orig.x
+    const dy = interpolated.y - orig.y
+    const err = Math.hypot(dx, dy)
+    if (err > maxError) {
+      maxError = err
+    }
+  }
+  return maxError
+}
+
+/**
+ * Simplifies a single ball's trajectory using the decimation algorithm.
+ *
+ * @param {Array} samples - Array of trajectory samples of form {ball, t, x, y}.
+ * @param {number} tolerance - Tolerance threshold in meters.
+ * @returns {Array} The simplified array of samples.
+ */
+function simplifyBallTrajectory(samples, tolerance) {
+  if (samples.length <= 2) {
+    return samples
+  }
+
+  const n = samples.length
+  const nodes = new Array(n)
+  for (let i = 0; i < n; i++) {
+    nodes[i] = new ListNode(i, samples[i])
+  }
+
+  for (let i = 0; i < n; i++) {
+    if (i > 0) nodes[i].prev = nodes[i - 1]
+    if (i < n - 1) nodes[i].next = nodes[i + 1]
+  }
+
+  const heap = new MinHeap()
+
+  for (let i = 1; i < n - 1; i++) {
+    nodes[i].cost = computeDeletionCost(nodes[i], samples)
+    heap.push(nodes[i])
+  }
+
+  while (heap.size() > 0) {
+    const minNode = heap.pop()
+    if (minNode.cost > tolerance) {
+      break
+    }
+
+    // Permanently remove minNode from the linked list
+    const p = minNode.prev
+    const s = minNode.next
+    p.next = s
+    s.prev = p
+
+    // Recompute cost for predecessor if it is an interior node
+    if (p.prev !== null) {
+      p.cost = computeDeletionCost(p, samples)
+      heap.update(p)
+    }
+
+    // Recompute cost for successor if it is an interior node
+    if (s.next !== null) {
+      s.cost = computeDeletionCost(s, samples)
+      heap.update(s)
+    }
+  }
+
+  // Reconstruct simplified array of samples
+  const result = []
+  let curr = nodes[0]
+  while (curr !== null) {
+    result.push({
+      ball: curr.ball,
+      t: curr.t,
+      x: curr.x,
+      y: curr.y
+    })
+    curr = curr.next
+  }
+
+  return result
+}
+
+/**
+ * Simplifies the multi-ball trajectory data, grouping by ball.
+ *
+ * @param {Array} truth - Original flat trajectory array of [{ball, t, x, y}, ...].
+ * @param {number} toleranceInMm - Configurable tolerance threshold in millimeters.
+ * @returns {Array} The simplified flat trajectory array.
+ */
+export function simplifyTruth(truth, toleranceInMm) {
+  if (!truth || truth.length === 0) return []
+
+  const toleranceInMeters = toleranceInMm / 1000
+
+  // Group by ball ID
+  const groups = {}
+  for (const s of truth) {
+    groups[s.ball] ??= []
+    groups[s.ball].push(s)
+  }
+
+  const simplifiedGroups = []
+  for (const [ballStr, samples] of Object.entries(groups)) {
+    // Sort by timestamp to be absolutely safe
+    samples.sort((a, b) => a.t - b.t)
+    const simplified = simplifyBallTrajectory(samples, toleranceInMeters)
+    simplifiedGroups.push(simplified)
+  }
+
+  // Concatenate simplified trajectories, maintaining ball groupings order
+  return simplifiedGroups.flat()
+}

--- a/dist/fit/viewer.html
+++ b/dist/fit/viewer.html
@@ -26,6 +26,14 @@
       td {
         padding: 0px 2px;
       }
+      .tol-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 2px;
+      }
+      .tol-input {
+        width: 45px;
+      }
     </style>
   </head>
   <body>
@@ -49,6 +57,16 @@
           <button id="simBtn" disabled>View Shot</button>
           <input type="file" id="file" accept=".json" style="display: none" />
           <button id="saveBtn" disabled>Save JSON</button>
+          <button id="simplifyBtn" disabled>Simplify</button>
+          <label class="tol-label"
+            >Tol(mm):<input
+              type="number"
+              id="simplifyTol"
+              value="0.25"
+              min="0"
+              step="0.05"
+              class="tol-input"
+          /></label>
           <button onclick="document.getElementById('file').click()">
             Load
           </button>
@@ -142,6 +160,7 @@
       import { runSim } from "./sim.js"
       import { redraw, HALF_W, HALF_H } from "./plot.js"
       import { runOptimiseNM, runOptimisePSO } from "./optimise.js"
+      import { simplifyTruth } from "./simplify.js"
 
       const W = 720,
         H = Math.round((W * HALF_H) / HALF_W)
@@ -302,6 +321,7 @@
         document.getElementById("simEdit").disabled = false
         document.getElementById("simBtn").disabled = false
         document.getElementById("saveBtn").disabled = false
+        document.getElementById("simplifyBtn").disabled = false
         document.getElementById("optBtn").disabled = false
         document.getElementById("editBtn").disabled = false
         document.getElementById("playBtn").disabled = false
@@ -313,7 +333,9 @@
       const urlFile = new URLSearchParams(window.location.search).get("file")
       const defaultFile = urlFile ?? "simple_shot_545600_stronge.json"
       // Full paths (starting with /) are fetched as-is for file:// protocol usage
-      const fetchUrl = defaultFile.startsWith("/") ? defaultFile : "./" + defaultFile
+      const fetchUrl = defaultFile.startsWith("/")
+        ? defaultFile
+        : "./" + defaultFile
       fetch(fetchUrl)
         .then((r) => r.json())
         .then((data) => {
@@ -356,6 +378,28 @@
       }
 
       document.getElementById("simBtn").onclick = onRunSim
+      document.getElementById("trackAll").onchange = updateDrawing
+
+      document.getElementById("simplifyBtn").onclick = () => {
+        if (!loadedData || !loadedData.truth) return
+        const tolVal = parseFloat(document.getElementById("simplifyTol").value)
+        if (isNaN(tolVal) || tolVal < 0) {
+          document.getElementById("status").textContent =
+            "Invalid tolerance value"
+          return
+        }
+
+        const originalCount = loadedData.truth.length
+        const simplifiedTruth = simplifyTruth(loadedData.truth, tolVal)
+        loadedData.truth = simplifiedTruth
+
+        const newCount = simplifiedTruth.length
+        const pct = ((newCount / originalCount) * 100).toFixed(1)
+        document.getElementById("status").textContent =
+          `Simplified: ${originalCount} -> ${newCount} samples (${pct}%) at ${tolVal}mm`
+
+        updateDrawing()
+      }
       document.getElementById("trackAll").onchange = updateDrawing
 
       document.getElementById("optBtn").onclick = async () => {

--- a/test/simplify.spec.ts
+++ b/test/simplify.spec.ts
@@ -1,0 +1,70 @@
+import { simplifyTruth } from "../dist/fit/simplify"
+
+describe("simplifyTruth", () => {
+  it("should handle empty or undefined input gracefully", () => {
+    expect(simplifyTruth([], 0.25)).toEqual([])
+    expect(simplifyTruth(undefined as any, 0.25)).toEqual([])
+  })
+
+  it("should return the original points if the trajectory has 2 or fewer samples", () => {
+    const samples = [
+      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
+    ]
+    expect(simplifyTruth(samples, 0.25)).toEqual(samples)
+  })
+
+  it("should simplify interior linear points perfectly with low tolerance", () => {
+    // 3 points perfectly aligned: we should be able to remove the middle one
+    const samples = [
+      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 0, t: 0.5, x: 0.5, y: 0.5 },
+      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
+    ]
+    // Reconstruct with 1st and 3rd. Interpolating at t=0.5 gives x=0.5, y=0.5.
+    // Euclidean distance error is 0. This is less than tolerance 0.25mm.
+    // So the middle point should be removed!
+    const simplified = simplifyTruth(samples, 0.25)
+    expect(simplified).toEqual([
+      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
+    ])
+  })
+
+  it("should NOT remove interior points if the error exceeds tolerance", () => {
+    // 3 points where the middle point is offset (not aligned)
+    const samples = [
+      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 0, t: 0.5, x: 1.0, y: 0.0 }, // completely off line
+      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
+    ]
+    // Reconstruct with 1st and 3rd. Interpolating at t=0.5 gives x=0.5, y=0.5.
+    // Euclidean distance error is sqrt((0.5)^2 + (0.5)^2) = 0.707 meters = 707 mm.
+    // This is far greater than tolerance 0.25mm.
+    // So the middle point must be retained!
+    const simplified = simplifyTruth(samples, 0.25)
+    expect(simplified).toEqual(samples)
+  })
+
+  it("should simplify multiple balls independently", () => {
+    const samples = [
+      // Ball 0 linear
+      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 0, t: 0.5, x: 0.5, y: 0.5 },
+      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
+      // Ball 1 with non-linear middle point (not simplified)
+      { ball: 1, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 1, t: 0.5, x: 1.0, y: 0.0 },
+      { ball: 1, t: 1.0, x: 1.0, y: 1.0 },
+    ]
+
+    const simplified = simplifyTruth(samples, 0.25)
+    expect(simplified).toEqual([
+      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
+      { ball: 1, t: 0.0, x: 0.0, y: 0.0 },
+      { ball: 1, t: 0.5, x: 1.0, y: 0.0 },
+      { ball: 1, t: 1.0, x: 1.0, y: 1.0 },
+    ])
+  })
+})


### PR DESCRIPTION
This PR adds trajectory simplification to the Constants Optimiser tool in the `dist/fit` directory. It implements a physics-agnostic decimation algorithm using a custom updatable binary min-heap paired with a doubly linked list, evaluating interior points for removal against the black-box `interpolateTrack` function from `rmse.js` to ensure the maximum Euclidean error remains within a configurable tolerance (e.g. 0.25mm). It integrates this functionality with the `viewer.html` frontend via a "Simplify" button and tolerance input and adds comprehensive unit testing.

---
*PR created automatically by Jules for task [11497286896888802485](https://jules.google.com/task/11497286896888802485) started by @tailuge*