### PR TITLE
Optimize Track Simplification Algorithm with Cushion Protection and Endpoint Preservation

### DIFF
--- a/dist/fit/simplify.js
+++ b/dist/fit/simplify.js
@@ -103,8 +103,40 @@ class MinHeap {
 }
 
 /**
- * Computes the deletion cost of a node by evaluating the maximum Euclidean error
- * over the interval between its predecessor and successor if the node is removed.
+ * Computes the minimum perpendicular distance from point P(px, py) to the line segment connecting A(ax, ay) and B(bx, by).
+ */
+function distanceToLineSegment(px, py, ax, ay, bx, by) {
+  const dx = bx - ax
+  const dy = by - ay
+  const lenSq = dx * dx + dy * dy
+  if (lenSq === 0) {
+    return Math.hypot(px - ax, py - ay)
+  }
+  let t = ((px - ax) * dx + (py - ay) * dy) / lenSq
+  t = Math.max(0, Math.min(1, t))
+  const projX = ax + t * dx
+  const projY = ay + t * dy
+  return Math.hypot(px - projX, py - projY)
+}
+
+/**
+ * Checks if a point (x, y) is within 2R of any of the four cushions of the three-cushion billiard table.
+ */
+function isWithin2ROfCushion(x, y) {
+  const R = 0.03275
+  const tableX = R * 45.18
+  const tableY = R * 22.09
+  const limit = 2 * R
+
+  const distToCushionX = tableX - Math.abs(x)
+  const distToCushionY = tableY - Math.abs(y)
+
+  return distToCushionX <= limit || distToCushionY <= limit
+}
+
+/**
+ * Computes the deletion cost of a node by evaluating the maximum perpendicular distance
+ * of all intermediate points over the interval between its predecessor and successor if the node is removed.
  *
  * @param {ListNode} node - The candidate node.
  * @param {Array} originalSamples - The full array of original samples for this ball.
@@ -114,21 +146,16 @@ function computeDeletionCost(node, originalSamples) {
   if (!node.prev || !node.next) {
     return Infinity
   }
+  if (isWithin2ROfCushion(node.x, node.y)) {
+    return Infinity
+  }
   const p = node.prev
   const s = node.next
-
-  const tempTrack = [
-    { t: p.t, x: p.x, y: p.y },
-    { t: s.t, x: s.x, y: s.y }
-  ]
 
   let maxError = 0
   for (let k = p.index + 1; k < s.index; k++) {
     const orig = originalSamples[k]
-    const { point: interpolated } = interpolateTrack(tempTrack, orig.t, 0)
-    const dx = interpolated.x - orig.x
-    const dy = interpolated.y - orig.y
-    const err = Math.hypot(dx, dy)
+    const err = distanceToLineSegment(orig.x, orig.y, p.x, p.y, s.x, s.y)
     if (err > maxError) {
       maxError = err
     }

--- a/test/simplify.spec.ts
+++ b/test/simplify.spec.ts
@@ -67,4 +67,18 @@ describe("simplifyTruth", () => {
       { ball: 1, t: 1.0, x: 1.0, y: 1.0 },
     ])
   })
+
+  it("should never remove points within 2r of cushion", () => {
+    // Left cushion is at -1.479645.
+    // Point at x = -1.45, y = 0.0 is within 2R (0.0655) of left cushion.
+    // Points are collinear: A(-1.47, 0.0) -> B(-1.45, 0.0) -> C(-1.40, 0.0).
+    const samples = [
+      { ball: 0, t: 0.0, x: -1.47, y: 0.0 },
+      { ball: 0, t: 0.5, x: -1.45, y: 0.0 },
+      { ball: 0, t: 1.0, x: -1.40, y: 0.0 },
+    ]
+    const simplified = simplifyTruth(samples, 0.25)
+    // Point B must not be removed despite being perfectly collinear, because it's within 2R of cushion.
+    expect(simplified).toEqual(samples)
+  })
 })


### PR DESCRIPTION
I have updated the trajectory simplification algorithm in `dist/fit/simplify.js` to satisfy your specifications:
1. **Geometric/Spatial Simplification**: Changed the algorithm's cost metric to use the perpendicular distance from the candidate node to the line segment connecting its predecessor and successor (spatial co-linearity check) instead of the previous time-based interpolation error. This ensures we are properly removing co-linear points with small tolerance regardless of time/friction decelerations.
2. **Cushion Proximity Protection**: Added `isWithin2ROfCushion` check which prevents any point within 2R (0.0655m) of the table cushions from being deleted by returning `Infinity` as their deletion cost.
3. **Endpoint Preservation**: Confirmed and validated that the start and end of ball trajectories are always kept.
4. **Validation and Verification**: All tests have passed successfully, including a new unit test suite explicitly verifying the cushion proximity rule. Frontend verification was also performed and screenshotted using Playwright, confirming correct functionality on the optimizer viewer UI.

---
*PR created automatically by Jules for task [8047316065579350880](https://jules.google.com/task/8047316065579350880) started by @tailuge*