### PR TITLE
Collapsible Sections, Flex Layout, and Slider Improvements in Compare View

### DIFF
--- a/dist/fit/compare.css
+++ b/dist/fit/compare.css
@@ -1,0 +1,169 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f0f0f0;
+  padding: 2px;
+}
+
+.page {
+  margin: 0 auto;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 8px;
+  padding: 8px;
+}
+
+.controls-bar {
+  width: 100%;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.controls-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.constant-group {
+  border: 1px solid #eee;
+  border-radius: 4px;
+  background: #fcfcfc;
+  padding: 4px;
+}
+
+.constant-group[open] {
+  background: #fff;
+  border-color: #ccc;
+}
+
+.group-label {
+  font-weight: 600;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 2px 4px;
+  user-select: none;
+  outline: none;
+}
+
+.group-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 4px;
+}
+
+.constant-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  color: #555;
+  width: 100%;
+}
+
+.constant-row input[type="range"] {
+  appearance: none;
+  flex: 1;
+  height: 4px;
+  background: linear-gradient(
+    to right,
+    #ddd 0%,
+    #ddd var(--tick-percent, 0%),
+    #333 var(--tick-percent, 0%),
+    #333 calc(var(--tick-percent, 0%) + 2px),
+    #ddd calc(var(--tick-percent, 0%) + 2px),
+    #ddd 100%
+  );
+  border-radius: 2px;
+  outline: none;
+}
+
+.constant-row input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #666;
+  cursor: pointer;
+  margin-top: -3px;
+}
+
+.constant-row input[type="range"]::-webkit-slider-thumb:hover {
+  background: #333;
+}
+
+.constant-row input[type="range"]::-moz-range-thumb {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #666;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.constant-row input[type="range"]::-moz-range-thumb:hover {
+  background: #333;
+}
+
+.constant-row span.val {
+  display: inline-block;
+  width: 44px;
+  text-align: right;
+  font-family: monospace;
+  font-size: 10px;
+}
+
+.pair-wrapper {
+  position: relative;
+  width: 600px;
+  max-width: 100%;
+  flex: 0 0 auto;
+}
+
+svg.billiards-table {
+  width: 100%;
+  height: auto;
+  display: block;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+svg.billiards-table.adjusted {
+  position: absolute;
+  inset: 0;
+  background: transparent;
+}
+
+svg.billiards-table.adjusted .trajectory-line {
+  stroke-dasharray: 0.015 0.01;
+}
+
+.edit-btn {
+  position: absolute;
+  bottom: 4%;
+  right: 5%;
+  font-size: 16px;
+  cursor: pointer;
+  z-index: 10;
+  opacity: 0.5;
+  background: none;
+  border: none;
+  padding: 0;
+  filter: grayscale(1);
+}
+
+.edit-btn:hover {
+  opacity: 0.9;
+  filter: none;
+}

--- a/dist/fit/compare.html
+++ b/dist/fit/compare.html
@@ -8,215 +8,123 @@
       href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.8em%22 font-size=%2290%22>═</text></svg>"
     />
     <link rel="stylesheet" href="../css/ball-colors.css" />
-    <style>
-      * {
-        box-sizing: border-box;
-        margin: 0;
-        padding: 0;
-      }
-      body {
-        font-family: system-ui, sans-serif;
-        background: #f0f0f0;
-        padding: 2px;
-      }
-      .page {
-        max-width: 800px;
-        margin: 0 auto;
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-      }
-      .controls-bar {
-        background: #fff;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        padding: 2px 4px;
-        font-size: 11px;
-      }
-      .controls-row {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-      }
-      .constant-group {
-        display: flex;
-        flex-direction: column;
-        gap: 1px;
-      }
-      .group-label {
-        font-weight: 600;
-        font-size: 10px;
-        text-align: center;
-        padding: 2px;
-      }
-      .constant-row {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        font-size: 10px;
-        color: #555;
-        width: 100%;
-      }
-      .constant-row input[type="range"] {
-        flex: 1;
-        height: 4px;
-        accent-color: #888;
-      }
-      .constant-row span.val {
-        display: inline-block;
-        width: 44px;
-        text-align: right;
-        font-family: monospace;
-        font-size: 10px;
-      }
-      .pair-wrapper {
-        position: relative;
-        width: 100%;
-      }
-      svg.billiards-table {
-        width: 100%;
-        height: auto;
-        display: block;
-        background: #fff;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-      }
-      svg.billiards-table.adjusted {
-        position: absolute;
-        inset: 0;
-        background: transparent;
-      }
-      svg.billiards-table.adjusted .trajectory-line {
-        stroke-dasharray: 0.015 0.01;
-      }
-      .edit-btn {
-        position: absolute;
-        bottom: 4%;
-        right: 5%;
-        font-size: 16px;
-        cursor: pointer;
-        z-index: 10;
-        opacity: 0.5;
-        background: none;
-        border: none;
-        padding: 0;
-        filter: grayscale(1);
-      }
-      .edit-btn:hover {
-        opacity: 0.9;
-        filter: none;
-      }
-    </style>
+    <link rel="stylesheet" href="compare.css" />
   </head>
   <body>
     <div class="page">
       <div class="controls-bar">
         <div class="controls-row">
-          <div class="constant-group">
-            <div class="group-label">Han</div>
-            <div class="constant-row">
-              <label for="mu">mu</label>
-              <input
-                id="mu"
-                type="range"
-                min="0.0001"
-                max="0.02"
-                step="0.0001"
-                value="0.0055"
-              />
-              <span class="val" id="mu-val">0.0055</span>
+          <details class="constant-group">
+            <summary class="group-label">Han</summary>
+            <div class="group-content">
+              <div class="constant-row">
+                <label for="mu">mu</label>
+                <input
+                  id="mu"
+                  type="range"
+                  min="0.0001"
+                  max="0.02"
+                  step="0.0001"
+                  value="0.0055"
+                />
+                <span class="val" id="mu-val">0.0055</span>
+              </div>
+              <div class="constant-row">
+                <label for="muS">muS</label>
+                <input
+                  id="muS"
+                  type="range"
+                  min="0.0001"
+                  max="0.5"
+                  step="0.0001"
+                  value="0.126"
+                />
+                <span class="val" id="muS-val">0.126</span>
+              </div>
             </div>
-            <div class="constant-row">
-              <label for="muS">muS</label>
-              <input
-                id="muS"
-                type="range"
-                min="0.0001"
-                max="0.5"
-                step="0.0001"
-                value="0.126"
-              />
-              <span class="val" id="muS-val">0.126</span>
+          </details>
+          <details class="constant-group">
+            <summary class="group-label">Mathavan</summary>
+            <div class="group-content">
+              <div class="constant-row">
+                <label for="μs">μs</label>
+                <input
+                  id="μs"
+                  type="range"
+                  min="0.0001"
+                  max="0.99"
+                  step="0.0001"
+                  value="0.2"
+                />
+                <span class="val" id="μs-val">0.20</span>
+              </div>
+              <div class="constant-row">
+                <label for="μw">μw</label>
+                <input
+                  id="μw"
+                  type="range"
+                  min="0.0001"
+                  max="0.99"
+                  step="0.0001"
+                  value="0.2"
+                />
+                <span class="val" id="μw-val">0.20</span>
+              </div>
+              <div class="constant-row">
+                <label for="ee">ee</label>
+                <input
+                  id="ee"
+                  type="range"
+                  min="0.0001"
+                  max="0.99"
+                  step="0.0001"
+                  value="0.85"
+                />
+                <span class="val" id="ee-val">0.85</span>
+              </div>
             </div>
-          </div>
-          <div class="constant-group">
-            <div class="group-label">Mathavan</div>
-            <div class="constant-row">
-              <label for="μs">μs</label>
-              <input
-                id="μs"
-                type="range"
-                min="0.0001"
-                max="0.99"
-                step="0.0001"
-                value="0.2"
-              />
-              <span class="val" id="μs-val">0.20</span>
+          </details>
+          <details class="constant-group">
+            <summary class="group-label">Stronge</summary>
+            <div class="group-content">
+              <div class="constant-row">
+                <label for="stronge_omega_ratio">ω ratio</label>
+                <input
+                  id="stronge_omega_ratio"
+                  type="range"
+                  min="0.0001"
+                  max="1.99"
+                  step="0.0001"
+                  value="1.76"
+                />
+                <span class="val" id="stronge_omega_ratio-val">1.76</span>
+              </div>
+              <div class="constant-row">
+                <label for="stronge_e_n">eₙ</label>
+                <input
+                  id="stronge_e_n"
+                  type="range"
+                  min="0.0001"
+                  max="0.99"
+                  step="0.0001"
+                  value="0.77"
+                />
+                <span class="val" id="stronge_e_n-val">0.77</span>
+              </div>
+              <div class="constant-row">
+                <label for="stronge_μ">μ</label>
+                <input
+                  id="stronge_μ"
+                  type="range"
+                  min="0.0001"
+                  max="0.99"
+                  step="0.0001"
+                  value="0.25"
+                />
+                <span class="val" id="stronge_μ-val">0.25</span>
+              </div>
             </div>
-            <div class="constant-row">
-              <label for="μw">μw</label>
-              <input
-                id="μw"
-                type="range"
-                min="0.0001"
-                max="0.99"
-                step="0.0001"
-                value="0.2"
-              />
-              <span class="val" id="μw-val">0.20</span>
-            </div>
-            <div class="constant-row">
-              <label for="ee">ee</label>
-              <input
-                id="ee"
-                type="range"
-                min="0.0001"
-                max="0.99"
-                step="0.0001"
-                value="0.85"
-              />
-              <span class="val" id="ee-val">0.85</span>
-            </div>
-          </div>
-          <div class="constant-group">
-            <div class="group-label">Stronge</div>
-            <div class="constant-row">
-              <label for="stronge_omega_ratio">ω ratio</label>
-              <input
-                id="stronge_omega_ratio"
-                type="range"
-                min="0.0001"
-                max="1.99"
-                step="0.0001"
-                value="1.76"
-              />
-              <span class="val" id="stronge_omega_ratio-val">1.76</span>
-            </div>
-            <div class="constant-row">
-              <label for="stronge_e_n">eₙ</label>
-              <input
-                id="stronge_e_n"
-                type="range"
-                min="0.0001"
-                max="0.99"
-                step="0.0001"
-                value="0.77"
-              />
-              <span class="val" id="stronge_e_n-val">0.77</span>
-            </div>
-            <div class="constant-row">
-              <label for="stronge_μ">μ</label>
-              <input
-                id="stronge_μ"
-                type="range"
-                min="0.0001"
-                max="0.99"
-                step="0.0001"
-                value="0.25"
-              />
-              <span class="val" id="stronge_μ-val">0.25</span>
-            </div>
-          </div>
+          </details>
         </div>
       </div>
 
@@ -339,10 +247,16 @@
         initDiagrams()
       }
 
-      // Wire slider value displays and refresh
+      // Set tick marks at initial values and wire slider value displays and refresh
       for (const slider of document.querySelectorAll(
         ".constant-row input[type=range]"
       )) {
+        const min = Number(slider.min) || 0
+        const max = Number(slider.max) || 100
+        const initialVal = Number(slider.getAttribute("value")) || 0
+        const percent = ((initialVal - min) / (max - min)) * 100
+        slider.style.setProperty("--tick-percent", `${percent}%`)
+
         const valEl = document.getElementById(slider.id + "-val")
         if (valEl) {
           slider.addEventListener("input", () => {

--- a/dist/lobby.html
+++ b/dist/lobby.html
@@ -19,10 +19,7 @@
       href="https://tailuge.github.io/billiards/dist/lobby.html"
     />
 
-    <meta
-      property="og:title"
-      content="Tailuge Billiards"
-    />
+    <meta property="og:title" content="Tailuge Billiards" />
     <meta
       property="og:description"
       content="Free multiplayer lobby for Billiards. Find matches and play realistic pool online."
@@ -42,10 +39,7 @@
     <meta property="og:video:type" content="text/html" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta
-      name="twitter:title"
-      content="Multiplayer Billiards - Free"
-    />
+    <meta name="twitter:title" content="Multiplayer Billiards - Free" />
     <meta
       name="twitter:description"
       content="Free multiplayer lobby for Billiards. Find matches and play realistic pool online."
@@ -96,7 +90,10 @@
         scrollbar-width: none;
         background: #f5f5f5;
       }
-      html::-webkit-scrollbar, body::-webkit-scrollbar { display: none; }
+      html::-webkit-scrollbar,
+      body::-webkit-scrollbar {
+        display: none;
+      }
       html[theme="dark"],
       html[theme="dark"] body {
         background: #1a1a1a;
@@ -112,14 +109,20 @@
 
     <script src="lobby.js" type="module"></script>
     <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('sw.js').then((registration) => {
-            console.log('ServiceWorker registration successful with scope: ', registration.scope);
-          }, (err) => {
-            console.log('ServiceWorker registration failed: ', err);
-          });
-        });
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("sw.js").then(
+            (registration) => {
+              console.log(
+                "ServiceWorker registration successful with scope: ",
+                registration.scope
+              )
+            },
+            (err) => {
+              console.log("ServiceWorker registration failed: ", err)
+            }
+          )
+        })
       }
     </script>
   </body>


### PR DESCRIPTION
Improved the UI/UX of the compare.html tool:
1. Converted Han, Mathavan, and Stronge parameter control groups to semantic `<details>` and `<summary>` sections, which are collapsed by default to save vertical space.
2. Moved comparison page styles to a dedicated `compare.css` stylesheet in the same folder.
3. Removed the narrow 800px limit on the page, replacing the vertical stack of table diagrams with a flexible, wrapping row layout so that wide viewports can display multiple tables side-by-side. Sized the tables to about 75% of their original width (~600px) and ensured they remain responsive to avoid cropping.
4. Redesigned range sliders with smaller, cleaner thumbs (10px circular handles) and added a subtle, dark vertical tickmark on each slider track indicating the default initial value, dynamically calculated on page load.

---
*PR created automatically by Jules for task [621717243720475683](https://jules.google.com/task/621717243720475683) started by @tailuge*