### PR TITLE
Show foul dialog on Sagu fouls

### DIFF
--- a/src/controller/rules/sagu.ts
+++ b/src/controller/rules/sagu.ts
@@ -130,6 +130,15 @@ export class Sagu extends ThreeCushion {
 
     this.startTurn()
 
+    const reason = this.foulReason(outcomes)
+    if (reason) {
+      this.container.notify({
+        type: "Foul",
+        title: "FOUL",
+        subtext: reason,
+      })
+    }
+
     if (this.container.isSinglePlayer) {
       this.cueball = this.otherPlayersCueBall()
       const cue = this.container.table.cue

--- a/test/rules/sagu.spec.ts
+++ b/test/rules/sagu.spec.ts
@@ -82,7 +82,8 @@ describe("Sagu", () => {
     done()
   })
 
-  it("Sagu miss (hitting only one red ball) switches players", (done) => {
+  it("Sagu miss (hitting only one red ball) switches players and does not trigger foul notification", (done) => {
+    const notifySpy = jest.spyOn(container, "notify")
     container.controller = new PlayShot(container)
     container.isSinglePlayer = false
     container.table.cueball.setStationary()
@@ -94,10 +95,12 @@ describe("Sagu", () => {
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(WatchAim)
     expect(Session.getInstance().myScore()).to.equal(0)
+    expect(notifySpy.mock.calls).to.have.lengthOf(0)
     done()
   })
 
-  it("Sagu sub-cue foul (hitting opponent's cueball) is a foul and switches players", (done) => {
+  it("Sagu sub-cue foul (hitting opponent's cueball) triggers a foul notification and switches players", (done) => {
+    const notifySpy = jest.spyOn(container, "notify")
     container.controller = new PlayShot(container)
     container.isSinglePlayer = false
     container.table.cueball.setStationary()
@@ -115,10 +118,17 @@ describe("Sagu", () => {
     expect(container.controller).to.be.an.instanceof(WatchAim)
     // No score increment because of the foul
     expect(Session.getInstance().myScore()).to.equal(0)
+    expect(notifySpy.mock.calls).to.have.lengthOf(1)
+    expect(notifySpy.mock.calls[0][0]).to.deep.equal({
+      type: "Foul",
+      title: "FOUL",
+      subtext: "Foul: Contacted the opponent's cue ball!",
+    })
     done()
   })
 
-  it("Sagu no-hit foul switches players", (done) => {
+  it("Sagu no-hit foul triggers a foul notification and switches players", (done) => {
+    const notifySpy = jest.spyOn(container, "notify")
     container.controller = new PlayShot(container)
     container.isSinglePlayer = false
     container.table.cueball.setStationary()
@@ -130,6 +140,12 @@ describe("Sagu", () => {
     container.processEvents()
     expect(container.controller).to.be.an.instanceof(WatchAim)
     expect(Session.getInstance().myScore()).to.equal(0)
+    expect(notifySpy.mock.calls).to.have.lengthOf(1)
+    expect(notifySpy.mock.calls[0][0]).to.deep.equal({
+      type: "Foul",
+      title: "FOUL",
+      subtext: "Foul: No ball hit",
+    })
     done()
   })
 


### PR DESCRIPTION
This change implements standard foul dialog notifications for Sagu (Korean Four-Ball) Billiards. When a sub-cue foul (striking the opponent's cue ball) or a no-hit foul occurs, Sagu now triggers a standard foul notification dialog via the container's notification service with correct details and duration. The change is verified with newly added and updated unit tests in the Sagu rules test suite.

---
*PR created automatically by Jules for task [7551451351295486907](https://jules.google.com/task/7551451351295486907) started by @tailuge*