### PR TITLE
Implement Sagu Foul Subtraction & Match Point Star Display

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -16,6 +16,7 @@ import { Recorder } from "../events/recorder"
 import { LinkFormatter } from "../view/link-formatter"
 import { Rules } from "../controller/rules/rules"
 import { RuleFactory } from "../controller/rules/rulefactory"
+import { ThreeCushionConfig } from "../utils/threecushionconfig"
 import { Menu } from "../view/menu"
 import { Comment } from "../view/comment"
 import { Hud } from "../view/hud"
@@ -215,13 +216,19 @@ export class Container {
       }
     }
     const hideScore = this.rules.hideScoreHud?.() ?? false
+    const isSagu = this.rules.rulename === "sagu"
+    const p1Star = isSagu && orderedScores.p1 === ThreeCushionConfig.raceTo - 1
+    const p2Star = isSagu && orderedScores.p2 === ThreeCushionConfig.raceTo - 1
+
     this.hud.updateScores(
       orderedScores.p1,
       orderedScores.p2,
       orderedNames.p1Name,
       orderedNames.p2Name,
       hideScore ? 0 : b,
-      hideScore
+      hideScore,
+      p1Star,
+      p2Star
     )
     this.setHudActivePlayer(active ?? this.inferActivePlayer())
   }

--- a/src/controller/rules/sagu.ts
+++ b/src/controller/rules/sagu.ts
@@ -132,6 +132,9 @@ export class Sagu extends ThreeCushion {
 
     const reason = this.foulReason(outcomes)
     if (reason) {
+      const session = Session.getInstance()
+      session.setMyScore(Math.max(0, session.myScore() - 1))
+
       this.container.notify({
         type: "Foul",
         title: "FOUL",

--- a/src/network/bot/boteventhandler.ts
+++ b/src/network/bot/boteventhandler.ts
@@ -335,6 +335,10 @@ export class BotEventHandler {
       session.addMyScore(this.snookerFoulPoints(outcome))
     }
 
+    if (this.container.rules.rulename === "sagu") {
+      session.setOpponentScore(Math.max(0, session.opponentScore() - 1))
+    }
+
     const { p1: s1, p2: s2 } = session.orderedScoresForHud()
     this.container.sendScoreUpdate(s1, s2, 0, this.myActivePlayer())
 

--- a/src/view/hud.ts
+++ b/src/view/hud.ts
@@ -41,7 +41,9 @@ export class Hud {
     p1Name?: string,
     p2Name?: string,
     b: number = 0,
-    hideScore: boolean = false
+    hideScore: boolean = false,
+    p1Star: boolean = false,
+    p2Star: boolean = false
   ) {
     this.setText(this.p1Element, "")
     this.setText(this.p2Element, "")
@@ -53,15 +55,18 @@ export class Hud {
       return
     }
 
+    const p1Str = p1Star ? `${p1}⭐` : `${p1}`
+    const p2Str = p2Star ? `⭐${p2}` : `${p2}`
+
     if (p1Name && p2Name) {
-      this.setText(this.p1Element, `${p1Name} ${p1}`)
-      this.setText(this.p2Element, `${p2} ${p2Name}`)
+      this.setText(this.p1Element, `${p1Name} ${p1Str}`)
+      this.setText(this.p2Element, `${p2Str} ${p2Name}`)
     } else if (p1Name) {
-      this.setText(this.p1Element, `${p1Name} ${p1}`)
+      this.setText(this.p1Element, `${p1Name} ${p1Str}`)
     } else if (p2Name) {
-      this.setText(this.p2Element, `${p2} ${p2Name}`)
+      this.setText(this.p2Element, `${p2Str} ${p2Name}`)
     } else {
-      this.setText(this.p1Element, `${p1}`)
+      this.setText(this.p1Element, `${p1Str}`)
     }
 
     if (b > 0) {

--- a/test/rules/sagu.spec.ts
+++ b/test/rules/sagu.spec.ts
@@ -197,4 +197,63 @@ describe("Sagu", () => {
     expect(Session.getInstance().myScore()).to.equal(ThreeCushionConfig.raceTo)
     done()
   })
+
+  it("Sagu foul subtracts 1 from the player's score but does not go below 0", (done) => {
+    // 1. Initial score = 2
+    Session.getInstance().setMyScore(2)
+    container.controller = new PlayShot(container)
+    container.isSinglePlayer = false
+    container.table.cueball.setStationary()
+    container.eventQueue.push(new StationaryEvent())
+
+    const balls = container.table.balls
+    // Foul: hit opponent's cueball
+    container.table.outcome.push(
+      Outcome.collision(balls[0], balls[1], 1)
+    )
+
+    container.processEvents()
+    expect(Session.getInstance().myScore()).to.equal(1)
+
+    // 2. Initial score = 0
+    Session.getInstance().setMyScore(0)
+    container.controller = new PlayShot(container)
+    container.isSinglePlayer = false
+    container.table.cueball.setStationary()
+    container.eventQueue.push(new StationaryEvent())
+
+    container.table.outcome.push(
+      Outcome.collision(balls[0], balls[1], 1)
+    )
+
+    container.processEvents()
+    expect(Session.getInstance().myScore()).to.equal(0)
+    done()
+  })
+
+  it("Sagu HUD displays a ⭐ beside the score if a player is at raceTo - 1", (done) => {
+    const session = Session.getInstance()
+    session.opponentName = "Bot"
+
+    // Set my score to 3, opponent score to raceTo - 1 (6)
+    session.setMyScore(3)
+    session.setOpponentScore(ThreeCushionConfig.raceTo - 1)
+
+    const updateScoresSpy = jest.spyOn(container.hud, "updateScores")
+
+    container.updateScoreHud(session.myScore(), session.opponentScore(), 0)
+
+    expect(updateScoresSpy.mock.calls).to.have.lengthOf(1)
+    expect(updateScoresSpy.mock.calls[0]).to.deep.equal([
+      3,
+      ThreeCushionConfig.raceTo - 1,
+      "TestPlayer",
+      "Bot",
+      0,
+      false,
+      false,
+      true // p2Star should be true
+    ])
+    done()
+  })
 })


### PR DESCRIPTION
Implemented score subtraction on Sagu fouls (down to a minimum of 0) for both human and bot players. Added a star (⭐) display next to the score in the HUD when a player reaches the `raceTo - 1` point in Sagu. Comprehensive unit tests and visual verification with Playwright were completed successfully.

---
*PR created automatically by Jules for task [5327982485398959521](https://jules.google.com/task/5327982485398959521) started by @tailuge*