### PR TITLE
Implement handicap system for Sagu and Three-Cushion

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -208,6 +208,30 @@ export class Container {
     const orderedScores = session.orderedScoresForHud()
     this.hudScores = orderedScores
     const orderedNames = session.orderedNamesForHud()
+
+    // Format handicap append next to player names
+    const isHandicapRule = this.rules.rulename === "sagu" || this.rules.rulename === "threecushion"
+    const handicaps = session.getHandicaps()
+    const hasHandicaps = isHandicapRule && Object.keys(handicaps).length > 0
+
+    let p1Target = ThreeCushionConfig.raceTo
+    let p2Target = ThreeCushionConfig.raceTo
+
+    if (hasHandicaps) {
+      const p1ClientId = session.playerIndex === 0 ? session.clientId : (session.opponentClientId ?? "opponent")
+      const p2ClientId = session.playerIndex === 0 ? (session.opponentClientId ?? "opponent") : session.clientId
+
+      p1Target = session.getRaceTargetForPlayer(p1ClientId)
+      p2Target = session.getRaceTargetForPlayer(p2ClientId)
+
+      if (orderedNames.p1Name) {
+        orderedNames.p1Name = `${orderedNames.p1Name}(${p1Target})`
+      }
+      if (orderedNames.p2Name) {
+        orderedNames.p2Name = `${orderedNames.p2Name}(${p2Target})`
+      }
+    }
+
     if (this.rules.rulename === "eightball" && session.p1type !== 0) {
       const typeLabel = session.p1type === 1 ? "solids" : "stripes"
       const mySlot = session.playerIndex === 0 ? "p1Name" : "p2Name"
@@ -217,8 +241,8 @@ export class Container {
     }
     const hideScore = this.rules.hideScoreHud?.() ?? false
     const isSagu = this.rules.rulename === "sagu"
-    const p1Star = isSagu && orderedScores.p1 === ThreeCushionConfig.raceTo - 1
-    const p2Star = isSagu && orderedScores.p2 === ThreeCushionConfig.raceTo - 1
+    const p1Star = isSagu && orderedScores.p1 === p1Target - 1
+    const p2Star = isSagu && orderedScores.p2 === p2Target - 1
 
     this.hud.updateScores(
       orderedScores.p1,

--- a/src/controller/rules/sagu.ts
+++ b/src/controller/rules/sagu.ts
@@ -31,7 +31,8 @@ export class Sagu extends ThreeCushion {
   isSuccessfulShot(outcomes: Outcome[]): boolean {
     const session = Session.getInstance()
     const myCurrentScore = session.myScore()
-    if (myCurrentScore === ThreeCushionConfig.raceTo - 1) {
+    const myTarget = session.getRaceTargetForPlayer(session.clientId)
+    if (myCurrentScore === myTarget - 1) {
       return !this.foulReason(outcomes) && this.isSaguThreeCushionShot(outcomes)
     }
     return !this.foulReason(outcomes) && this.hitsBothReds(outcomes)

--- a/src/controller/rules/threecushion.ts
+++ b/src/controller/rules/threecushion.ts
@@ -125,9 +125,16 @@ export class ThreeCushion implements Rules {
   }
 
   isEndOfGame(_: Outcome[]): boolean {
-    const { p1: s1, p2: s2 } = Session.getInstance().orderedScoresForHud()
+    const session = Session.getInstance()
+    const p1ClientId = session.playerIndex === 0 ? session.clientId : (session.opponentClientId ?? "opponent")
+    const p2ClientId = session.playerIndex === 0 ? (session.opponentClientId ?? "opponent") : session.clientId
 
-    return s1 >= ThreeCushionConfig.raceTo || s2 >= ThreeCushionConfig.raceTo
+    const p1Target = session.getRaceTargetForPlayer(p1ClientId)
+    const p2Target = session.getRaceTargetForPlayer(p2ClientId)
+
+    const { p1: s1, p2: s2 } = session.orderedScoresForHud()
+
+    return s1 >= p1Target || s2 >= p2Target
   }
 
   handleGameEnd(isWinner: boolean, endSubtext?: string): Controller {

--- a/src/network/client/session.ts
+++ b/src/network/client/session.ts
@@ -217,4 +217,39 @@ export class Session {
     }
     this.currentBreak = breakScore
   }
+
+  /**
+   * Retrieves a map of user ID to handicap value from the URL query parameters.
+   */
+  getHandicaps(): Record<string, number> {
+    if (typeof globalThis.location === "undefined" || !globalThis.location.search) {
+      return {}
+    }
+    const params = new URLSearchParams(globalThis.location.search)
+    const handicaps: Record<string, number> = {}
+    for (const [k, v] of params) {
+      if (k.startsWith('handicap_')) {
+        const userId = k.replace('handicap_', '')
+        handicaps[userId] = Number.parseInt(v) || 5
+      }
+    }
+    return handicaps
+  }
+
+  /**
+   * Resolves the race target for a specific player by their client ID.
+   * - If no player has a handicap specified, returns the default ThreeCushionConfig.raceTo (7).
+   * - If at least one player has a handicap specified, any player (or bot) without an explicit handicap defaults to 5.
+   */
+  getRaceTargetForPlayer(clientId: string): number {
+    const handicaps = this.getHandicaps()
+    const hasAnyHandicap = Object.keys(handicaps).length > 0
+
+    if (!hasAnyHandicap) {
+      return 7 // ThreeCushionConfig.raceTo is 7
+    }
+
+    // If a handicap exists in URL for this client, use it; otherwise, default to 5 (handles opponent or bot)
+    return handicaps[clientId] ?? 5
+  }
 }

--- a/test/rules/sagu.spec.ts
+++ b/test/rules/sagu.spec.ts
@@ -256,4 +256,76 @@ describe("Sagu", () => {
     ])
     done()
   })
+
+  describe("Sagu Handicap specific behaviors", () => {
+    let getHandicapsSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      getHandicapsSpy = jest.spyOn(Session.prototype, "getHandicaps")
+    })
+
+    afterEach(() => {
+      getHandicapsSpy.mockRestore()
+    })
+
+    it("respects player specific target when evaluating final cushion shot condition", (done) => {
+      getHandicapsSpy.mockReturnValue({
+        "test-client": 4
+      })
+
+      const session = Session.getInstance()
+      session.opponentClientId = "opponent"
+
+      // We are at myTarget - 1 = 3 points
+      session.setMyScore(3)
+
+      container.controller = new PlayShot(container)
+      container.isSinglePlayer = false
+
+      container.table.cueball.setStationary()
+      container.eventQueue.push(new StationaryEvent())
+
+      const balls = container.table.balls
+      // Hitting both reds directly without 3 cushions should NOT qualify as successful shot at target - 1
+      container.table.outcome.push(
+        Outcome.collision(balls[0], balls[2], 1),
+        Outcome.collision(balls[0], balls[3], 1)
+      )
+
+      container.processEvents()
+      expect(container.controller).to.be.an.instanceof(WatchAim)
+      expect(session.myScore()).to.equal(3)
+      done()
+    })
+
+    it("evaluates dynamic star position on HUD score updates", (done) => {
+      getHandicapsSpy.mockReturnValue({
+        "test-client": 4,
+        "opponent": 15
+      })
+
+      const session = Session.getInstance()
+      session.opponentName = "Bot"
+      session.opponentClientId = "opponent"
+
+      // Player 1 at target - 1 = 3, Player 2 at target - 1 = 14
+      session.setMyScore(3)
+      session.setOpponentScore(14)
+
+      const updateScoresSpy = jest.spyOn(container.hud, "updateScores")
+      container.updateScoreHud(3, 14, 0)
+
+      expect(updateScoresSpy.mock.calls[updateScoresSpy.mock.calls.length - 1]).to.deep.equal([
+        3,
+        14,
+        "TestPlayer(4)",
+        "Bot(15)",
+        0,
+        false,
+        true, // p1Star
+        true  // p2Star
+      ])
+      done()
+    })
+  })
 })

--- a/test/rules/threecushion.spec.ts
+++ b/test/rules/threecushion.spec.ts
@@ -187,6 +187,77 @@ describe("ThreeCushion", () => {
     done()
   })
 
+  describe("Handicap system", () => {
+    let getHandicapsSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      getHandicapsSpy = jest.spyOn(Session.prototype, "getHandicaps")
+    })
+
+    afterEach(() => {
+      getHandicapsSpy.mockRestore()
+    })
+
+    it("resolves player specific targets using getRaceTargetForPlayer", () => {
+      getHandicapsSpy.mockReturnValue({
+        "test-client": 18,
+        "bot": 5
+      })
+
+      const session = Session.getInstance()
+      expect(session.getRaceTargetForPlayer("test-client")).to.equal(18)
+      expect(session.getRaceTargetForPlayer("bot")).to.equal(5)
+      expect(session.getRaceTargetForPlayer("non-existent")).to.equal(5)
+    })
+
+    it("defaults to 7 if no handicaps are defined in the URL", () => {
+      getHandicapsSpy.mockReturnValue({})
+
+      const session = Session.getInstance()
+      expect(session.getRaceTargetForPlayer("test-client")).to.equal(7)
+    })
+
+    it("respects dynamic player and opponent targets in isEndOfGame", () => {
+      getHandicapsSpy.mockReturnValue({
+        "test-client": 12,
+        "opponent": 8
+      })
+
+      const session = Session.getInstance()
+      session.opponentClientId = "opponent"
+      const rules = RuleFactory.create(rule, container)
+
+      // Both players under targets
+      session.updateScoresFromNetwork(11, 7, 0)
+      expect(rules.isEndOfGame([])).to.be.false
+
+      // Player 2 reaches target
+      session.updateScoresFromNetwork(11, 8, 0)
+      expect(rules.isEndOfGame([])).to.be.true
+
+      // Player 1 reaches target
+      session.updateScoresFromNetwork(12, 7, 0)
+      expect(rules.isEndOfGame([])).to.be.true
+    })
+
+    it("appends handicap value next to player names in HUD when handicaps are defined", () => {
+      getHandicapsSpy.mockReturnValue({
+        "test-client": 12,
+        "opponent": 8
+      })
+
+      const session = Session.getInstance()
+      session.opponentName = "Bot"
+      session.opponentClientId = "opponent"
+
+      const updateScoresSpy = jest.spyOn(container.hud, "updateScores")
+      container.updateScoreHud(3, 4, 0)
+
+      expect(updateScoresSpy.mock.calls[updateScoresSpy.mock.calls.length - 1][2]).to.equal("TestPlayer(12)")
+      expect(updateScoresSpy.mock.calls[updateScoresSpy.mock.calls.length - 1][3]).to.equal("Bot(8)")
+    })
+  })
+
   describe("getAmountScored", () => {
     it("returns 0 when no three-cushion point", () => {
       const balls = container.table.balls


### PR DESCRIPTION
This PR implements the billiard handicap system specified in `handicap.md` for both Three-Cushion (`threecushion`) and Sagu (`sagu`) rule systems.

Key modifications:
1. **URL-based Handicap Parsing (`src/network/client/session.ts`)**: Introduces `getHandicaps()` and `getRaceTargetForPlayer(clientId)` to dynamically resolve target race values from URL parameters like `handicap_Luke=10`. Resolves a default target of 7, or 5 if any handicap is specified but a player doesn't have an explicit one.
2. **Three-Cushion Support (`src/controller/rules/threecushion.ts`)**: Overrides `isEndOfGame` to dynamically check the winning condition against each player's resolved target score.
3. **Sagu Support (`src/controller/rules/sagu.ts`)**: Updates `isSuccessfulShot` to verify if the final cushion-shot criteria should be active based on `target - 1` rather than a static fallback.
4. **Scoreboard HUD (`src/container/container.ts`)**: Appends targets in parenthesized format beside player names (e.g. `Luke(10)`) when handicaps exist and adjusts the Sagu final-point indicator (⭐) threshold dynamically.
5. **Testing & Validation (`test/rules/sagu.spec.ts` & `test/rules/threecushion.spec.ts`)**: Validates victory thresholds, HUD string formatting, and final Sagu cushion shot conditions under custom handicaps using Jest spies on the `Session` class to work around JSDOM constraints. All 600 tests pass successfully.

---
*PR created automatically by Jules for task [12722871999832454100](https://jules.google.com/task/12722871999832454100) started by @tailuge*