### PR TITLE
Simplify display pattern classification in solution search

### DIFF
--- a/dist/fit/solution.html
+++ b/dist/fit/solution.html
@@ -623,11 +623,7 @@
           if (thirdCushionIndex < 0) return patternStr
 
           const prefix = patternStr.slice(0, thirdCushionIndex + 1)
-          const balls = [...patternStr.slice(thirdCushionIndex + 1)].filter(
-            (c) => c === "◉"
-          )
-
-          return prefix + balls.map(() => ".*◉").join("")
+          return prefix + ".*◉"
         }
         function processResult(task, data) {
           const cutoff = getScoringCutoff(data.outcomes, 0)


### PR DESCRIPTION
This pull request simplifies the canonical display pattern classification in `dist/fit/solution.html`. It truncates the pattern string immediately after the third cushion hit and appends a single `.*◉` suffix. This consolidates patterns that differ only in terms of what happens after the third cushion, bringing related solutions together under a single clean classification.

---
*PR created automatically by Jules for task [10723953289970687822](https://jules.google.com/task/10723953289970687822) started by @tailuge*