### PR TITLE
Simplify carom innings and score average calculation

### DIFF
--- a/src/network/client/matchresult.ts
+++ b/src/network/client/matchresult.ts
@@ -218,8 +218,6 @@ export class MatchResultHelper {
 
     let whiteInnings = 0
     let yellowInnings = 0
-    let whitePoints = 0
-    let yellowPoints = 0
 
     let previousCueBallIndex: number | null = null
 
@@ -234,21 +232,11 @@ export class MatchResultHelper {
         }
         previousCueBallIndex = currentCueBallIndex
       }
-
-      if (entry.isPartOfBreak) {
-        if (currentCueBallIndex === 0) {
-          whitePoints++
-        } else {
-          yellowPoints++
-        }
-      }
     }
 
     return {
       whiteInnings,
       yellowInnings,
-      whitePoints,
-      yellowPoints,
     }
   }
 
@@ -259,18 +247,10 @@ export class MatchResultHelper {
     if (rulename === "threecushion" || rulename === "sagu") {
       const stats = this.calculateInningsStats(container)
       if (container.isSinglePlayer) {
-        const whiteAvg =
-          stats.whiteInnings > 0
-            ? (stats.whitePoints / stats.whiteInnings).toFixed(2)
-            : "0.00"
-        const yellowAvg =
-          stats.yellowInnings > 0
-            ? (stats.yellowPoints / stats.yellowInnings).toFixed(2)
-            : "0.00"
-        return (
-          `White: ${stats.whitePoints} (Avg: ${whiteAvg} over ${stats.whiteInnings} inn)\n` +
-          `Yellow: ${stats.yellowPoints} (Avg: ${yellowAvg} over ${stats.yellowInnings} inn)`
-        )
+        const score = Session.getInstance().myScore()
+        const totalInnings = stats.whiteInnings + stats.yellowInnings
+        const avg = totalInnings > 0 ? (score / totalInnings).toFixed(2) : "0.00"
+        return `Score: ${score} (Avg: ${avg} over ${totalInnings} inn)`
       } else {
         const { p1, p2 } = Session.getInstance().orderedScoresForHud()
         const names = Session.getInstance().orderedNamesForHud()

--- a/test/rules/matchresult.spec.ts
+++ b/test/rules/matchresult.spec.ts
@@ -248,6 +248,7 @@ describe("MatchResult Construction", () => {
 
       // Simulate recorded shots in single player mode
       container.isSinglePlayer = true
+      Session.getInstance().setMyScore(2)
 
       // Inning 1 (White)
       container.recorder.entries.push({
@@ -294,8 +295,7 @@ describe("MatchResult Construction", () => {
         container,
         "threecushion"
       )
-      expect(subtext).to.contain("White: 2 (Avg: 1.00 over 2")
-      expect(subtext).to.contain("Yellow: 0 (Avg: 0.00 over 1")
+      expect(subtext).to.equal("Score: 2 (Avg: 0.67 over 3 inn)")
     })
 
     it("should calculate correct innings and averages in multiplayer mode", () => {


### PR DESCRIPTION
Simplified and cleaned up the calculation of carom innings and score average. For single player mode, the stats for both cue balls are combined and reported together for the single player. Scores are retrieved directly from the Session rather than being parsed from recorder entries.

---
*PR created automatically by Jules for task [5296294799965639797](https://jules.google.com/task/5296294799965639797) started by @tailuge*