### PR TITLE
Camera Step Back on Key Press of Z in Aim View

### DIFF
--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -122,6 +122,16 @@ export abstract class ControllerBase extends Controller {
       case "KeyOUp":
         this.container.view.camera.toggleMode()
         return true
+      case "KeyZ":
+      case "KeyZUp":
+        const camera = this.container.view.camera
+        if (camera.mode === camera.aimView) {
+          camera.stepBackToFitAllBalls(
+            this.container.table.balls,
+            this.container.table.cue.aim
+          )
+        }
+        return true
       case "KeyDUp":
         //this.togglePanel()
         return true

--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -1,4 +1,4 @@
-import { PerspectiveCamera, MathUtils, Vector3 } from "three"
+import { PerspectiveCamera, MathUtils, Vector3, Frustum, Matrix4 } from "three"
 import { up, zero, unitAtAngle } from "../utils/three-utils"
 import { AimEvent } from "../events/aimevent"
 import { CameraTop } from "./cameratop"
@@ -34,6 +34,7 @@ export class Camera {
 
   private distance = Camera.defaultDistance
   private fovOffset = Camera.defaultFovOffset
+  savedDistance?: number
 
   elapsed: number
   private t = 0
@@ -132,7 +133,93 @@ export class Camera {
     this.distance = MathUtils.clamp(this.distance + delta, R * 2, R * 100)
   }
 
+  restoreSavedDistance() {
+    if (this.savedDistance !== undefined) {
+      this.distance = this.savedDistance
+      this.savedDistance = undefined
+    }
+  }
+
+  stepBackToFitAllBalls(balls: any[], aim: AimEvent) {
+    const frustum = new Frustum()
+    const projScreenMatrix = new Matrix4()
+
+    const h = this.height
+    const portrait = this.camera.aspect < 0.8
+    const tempFov = (portrait ? 60 : 40) + this.fovOffset
+    const fov = h < 10 * R ? tempFov - 100 * (10 * R - h) * (portrait ? 3 : 1) : tempFov
+
+    const originalPosition = this.camera.position.clone()
+    const originalRotation = this.camera.rotation.clone()
+    const originalMatrixWorld = this.camera.matrixWorld.clone()
+    const originalMatrixWorldInverse = this.camera.matrixWorldInverse.clone()
+    const originalProjectionMatrix = this.camera.projectionMatrix.clone()
+    const originalFov = this.camera.fov
+
+    this.camera.fov = fov
+    this.camera.updateProjectionMatrix()
+
+    let foundDistance = this.distance
+    const maxDistance = R * 120
+    const step = R
+
+    for (let testDistance = this.distance; testDistance <= maxDistance; testDistance += step) {
+      const targetPos = this.tempVec2
+        .copy(aim.pos)
+        .addScaledVector(unitAtAngle(aim.angle, this.tempVec), -testDistance)
+
+      this.camera.position.copy(targetPos)
+      this.camera.position.z = h
+      this.camera.up.copy(up)
+
+      const tempLookTarget = this.tempVec
+        .copy(aim.pos)
+        .addScaledVector(up, h / 2)
+
+      this.camera.lookAt(tempLookTarget)
+      this.camera.updateMatrixWorld(true)
+      this.camera.matrixWorldInverse.copy(this.camera.matrixWorld).invert()
+
+      projScreenMatrix.multiplyMatrices(this.camera.projectionMatrix, this.camera.matrixWorldInverse)
+      frustum.setFromProjectionMatrix(projScreenMatrix)
+
+      let allIn = true
+      for (const b of balls) {
+        if (!b.onTable()) continue
+        const mesh = b.ballmesh?.mesh
+        const inFrustum = mesh ? frustum.intersectsObject(mesh) : frustum.containsPoint(b.pos)
+        if (!inFrustum) {
+          allIn = false
+          break
+        }
+      }
+
+      if (allIn) {
+        foundDistance = testDistance
+        break
+      }
+    }
+
+    // Restore original camera state
+    this.camera.position.copy(originalPosition)
+    this.camera.rotation.copy(originalRotation)
+    this.camera.matrixWorld.copy(originalMatrixWorld)
+    this.camera.matrixWorldInverse.copy(originalMatrixWorldInverse)
+    this.camera.projectionMatrix.copy(originalProjectionMatrix)
+    this.camera.fov = originalFov
+
+    if (foundDistance !== this.distance) {
+      if (this.savedDistance === undefined) {
+        this.savedDistance = this.distance
+      }
+      this.distance = foundDistance
+    }
+  }
+
   suggestMode(mode) {
+    if (mode !== this.aimView) {
+      this.restoreSavedDistance()
+    }
     if (this.mainMode === this.aimView) {
       this.mode = mode
     }
@@ -145,6 +232,9 @@ export class Camera {
   }
 
   forceMode(mode) {
+    if (mode !== this.aimView) {
+      this.restoreSavedDistance()
+    }
     this.mode = mode
     this.mainMode = mode
   }
@@ -156,6 +246,7 @@ export class Camera {
   }
 
   toggleMode() {
+    this.restoreSavedDistance()
     if (this.mode === this.topView) {
       this.mode = this.aimView
     } else {

--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -140,14 +140,60 @@ export class Camera {
     }
   }
 
+  private computeStepBackFov(h: number): number {
+    const portrait = this.camera.aspect < 0.8
+    const tempFov = (portrait ? 60 : 40) + this.fovOffset
+    return h < 10 * R ? tempFov - 100 * (10 * R - h) * (portrait ? 3 : 1) : tempFov
+  }
+
+  private areAllBallsInFrustum(frustum: Frustum, balls: any[]): boolean {
+    for (const b of balls) {
+      if (!b.onTable()) continue
+      const mesh = b.ballmesh?.mesh
+      const inFrustum = mesh ? frustum.intersectsObject(mesh) : frustum.containsPoint(b.pos)
+      if (!inFrustum) {
+        return false
+      }
+    }
+    return true
+  }
+
+  private tryDistanceFit(
+    testDistance: number,
+    h: number,
+    aim: AimEvent,
+    frustum: Frustum,
+    projScreenMatrix: Matrix4,
+    balls: any[]
+  ): boolean {
+    const targetPos = this.tempVec2
+      .copy(aim.pos)
+      .addScaledVector(unitAtAngle(aim.angle, this.tempVec), -testDistance)
+
+    this.camera.position.copy(targetPos)
+    this.camera.position.z = h
+    this.camera.up.copy(up)
+
+    const tempLookTarget = this.tempVec
+      .copy(aim.pos)
+      .addScaledVector(up, h / 2)
+
+    this.camera.lookAt(tempLookTarget)
+    this.camera.updateMatrixWorld(true)
+    this.camera.matrixWorldInverse.copy(this.camera.matrixWorld).invert()
+
+    projScreenMatrix.multiplyMatrices(this.camera.projectionMatrix, this.camera.matrixWorldInverse)
+    frustum.setFromProjectionMatrix(projScreenMatrix)
+
+    return this.areAllBallsInFrustum(frustum, balls)
+  }
+
   stepBackToFitAllBalls(balls: any[], aim: AimEvent) {
     const frustum = new Frustum()
     const projScreenMatrix = new Matrix4()
 
     const h = this.height
-    const portrait = this.camera.aspect < 0.8
-    const tempFov = (portrait ? 60 : 40) + this.fovOffset
-    const fov = h < 10 * R ? tempFov - 100 * (10 * R - h) * (portrait ? 3 : 1) : tempFov
+    const fov = this.computeStepBackFov(h)
 
     const originalPosition = this.camera.position.clone()
     const originalRotation = this.camera.rotation.clone()
@@ -163,39 +209,9 @@ export class Camera {
     const maxDistance = R * 120
     const step = R
 
-    for (let testDistance = this.distance; testDistance <= maxDistance; testDistance += step) {
-      const targetPos = this.tempVec2
-        .copy(aim.pos)
-        .addScaledVector(unitAtAngle(aim.angle, this.tempVec), -testDistance)
-
-      this.camera.position.copy(targetPos)
-      this.camera.position.z = h
-      this.camera.up.copy(up)
-
-      const tempLookTarget = this.tempVec
-        .copy(aim.pos)
-        .addScaledVector(up, h / 2)
-
-      this.camera.lookAt(tempLookTarget)
-      this.camera.updateMatrixWorld(true)
-      this.camera.matrixWorldInverse.copy(this.camera.matrixWorld).invert()
-
-      projScreenMatrix.multiplyMatrices(this.camera.projectionMatrix, this.camera.matrixWorldInverse)
-      frustum.setFromProjectionMatrix(projScreenMatrix)
-
-      let allIn = true
-      for (const b of balls) {
-        if (!b.onTable()) continue
-        const mesh = b.ballmesh?.mesh
-        const inFrustum = mesh ? frustum.intersectsObject(mesh) : frustum.containsPoint(b.pos)
-        if (!inFrustum) {
-          allIn = false
-          break
-        }
-      }
-
-      if (allIn) {
-        foundDistance = testDistance
+    for (let d = this.distance; d <= maxDistance; d += step) {
+      if (this.tryDistanceFit(d, h, aim, frustum, projScreenMatrix, balls)) {
+        foundDistance = d
         break
       }
     }

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -24,4 +24,38 @@ describe("Camera", () => {
     const target = (camera as any).target
     expect(target.z).to.be.greaterThan(0)
   })
+
+  it("stepBackToFitAllBalls steps back and restores original distance on toggleMode", () => {
+    const camera = new Camera(1)
+    camera.forceMode(camera.aimView)
+
+    const { Vector3 } = require("three")
+    const balls = [
+      {
+        onTable: () => true,
+        pos: new Vector3(0, 0, 0)
+      },
+      {
+        onTable: () => true,
+        pos: new Vector3(1.0, 1.0, 0)
+      }
+    ]
+
+    const aim = new AimEvent()
+    aim.pos = new Vector3(0, 0, 0)
+    aim.angle = 0
+
+    const initialDistance = (camera as any).distance
+
+    camera.stepBackToFitAllBalls(balls, aim)
+
+    const steppedDistance = (camera as any).distance
+
+    expect(steppedDistance).to.be.greaterThan(initialDistance)
+    expect(camera.savedDistance).to.equal(initialDistance)
+
+    camera.toggleMode()
+    expect((camera as any).distance).to.equal(initialDistance)
+    expect(camera.savedDistance).to.be.undefined
+  })
 })


### PR DESCRIPTION
Implement a feature where pressing 'z' during aim view of the camera steps back the camera far enough to place all balls on the table within the view frustum. This adjustment reverts automatically to the original distance whenever the camera view is toggled or changed. Added unit test coverage for the new camera step-back and state restoration logic.

---
*PR created automatically by Jules for task [2385730041988835360](https://jules.google.com/task/2385730041988835360) started by @tailuge*