### PR TITLE
Transparent speedrun SVG table background

### DIFF
--- a/dist/speedrun/speedrun.css
+++ b/dist/speedrun/speedrun.css
@@ -148,6 +148,28 @@ header h1 {
   --ball-fill: var(--ball-stroke);
 }
 
+.billiards-table .ball-0 {
+  --ball-stroke: #000;
+  --ball-fill: #fff;
+}
+
+/* Make inset group components (spin offset & power indicators) visible on dark background */
+.billiards-table .inset-group circle,
+.billiards-table .inset-group rect,
+.billiards-table .inset-group line {
+  stroke: #cbd5e1;
+}
+
+/* Make status text under the table legible */
+.billiards-table .worker-status {
+  fill: #cbd5e1;
+}
+
+/* Ensure carom / pocketless tables have a solid white background inside their border */
+.billiards-table #outer-frame {
+  fill: #fff;
+}
+
 .play-rank-wrapper {
   display: flex;
   gap: 0.3rem;

--- a/dist/speedrun/speedrun.css
+++ b/dist/speedrun/speedrun.css
@@ -101,7 +101,7 @@ header h1 {
 .billiards-table {
   width: 100%;
   height: auto;
-  background: #fff;
+  background: transparent;
   border: 1px solid #000;
   border-radius: 20px;
   display: block;


### PR DESCRIPTION
Updated `.billiards-table` background to `transparent` in `dist/speedrun/speedrun.css` to allow the SVG table area to match the dark color of the speedrun card container seamlessly, eliminating the stark white background. Verified with tests and Playwright visual validation.

---
*PR created automatically by Jules for task [18047012926367218242](https://jules.google.com/task/18047012926367218242) started by @tailuge*