### PR TITLE
Style SVG cue ball with white fill and black outline

### DIFF
--- a/dist/css/ball-colors.css
+++ b/dist/css/ball-colors.css
@@ -21,6 +21,11 @@
 }
 
 /* Default / Pool Colors */
+.ball-0 {
+  --ball-fill: #fff !important;
+  --ball-stroke: #000;
+}
+
 .ball-1 {
   --ball-stroke: #ffd900;
 }


### PR DESCRIPTION
Ensure the white cue ball in all SVG diagrams is filled with white and keeps its black outline. This fix overrides solid ball fill variables on dark-themed speedrun page and snooker exam pages.

---
*PR created automatically by Jules for task [2535254353612842494](https://jules.google.com/task/2535254353612842494) started by @tailuge*