### PR TITLE
Style Speedrun Tables with Dark Background and Subtle Radial Gradients

### DIFF
--- a/dist/diagrams/pooltable.js
+++ b/dist/diagrams/pooltable.js
@@ -8,6 +8,18 @@
 
 
 const POOL_TABLE_SVG_CONTENT = `
+    <defs>
+      <radialGradient id="pool-blue-gradient" cx="50%" cy="35%" r="65%" fx="50%" fy="25%">
+        <stop offset="0%" stop-color="#3b95d8" />
+        <stop offset="50%" stop-color="#2b7bb9" />
+        <stop offset="100%" stop-color="#1d5886" />
+      </radialGradient>
+      <radialGradient id="snooker-green-gradient" cx="50%" cy="35%" r="65%" fx="50%" fy="25%">
+        <stop offset="0%" stop-color="#11833d" />
+        <stop offset="50%" stop-color="#0a5c2b" />
+        <stop offset="100%" stop-color="#063d1c" />
+      </radialGradient>
+    </defs>
     <style>
       path, line, polyline { fill: none; stroke: #000; stroke-width: 0.003; stroke-linecap: round; stroke-linejoin: round; }
       .pool-cloth { fill: none; stroke: none; }

--- a/dist/speedrun/speedrun.css
+++ b/dist/speedrun/speedrun.css
@@ -101,16 +101,13 @@ header h1 {
 .billiards-table {
   width: 100%;
   height: auto;
-  background: #fff;
-  border: 1px solid #000;
-  border-radius: 20px;
+  background: transparent;
   display: block;
-  box-shadow: inset 0 0 1px 1px #1e293b87;
 }
 
 /* Pool Table Coloring */
 .billiards-table .pool-cloth {
-  fill: #2b7bb9;
+  fill: url(#pool-blue-gradient);
 }
 
 .billiards-table .pool-surround {
@@ -135,7 +132,7 @@ header h1 {
 
 /* Snooker Table Coloring */
 .billiards-table.snooker .pool-cloth {
-  fill: #0a5c2b;
+  fill: url(#snooker-green-gradient);
 }
 
 .billiards-table.snooker .pool-cushion {


### PR DESCRIPTION
This change styles the SVG tables on the speedrun page by making the surrounding container background transparent (removing the white background/borders so it matches the card design) and adds subtle radial overhead lighting gradients to the blue pool table and green snooker table cloths.

---
*PR created automatically by Jules for task [8089754078790352821](https://jules.google.com/task/8089754078790352821) started by @tailuge*