### PR TITLE
Align Lobby Button inside Main Page Width on Speedrun Page

### DIFF
--- a/dist/speedrun/speedrun.css
+++ b/dist/speedrun/speedrun.css
@@ -22,7 +22,8 @@ body {
 header {
   position: relative;
   text-align: center;
-  margin-bottom: 0.5rem;
+  margin: 0 auto 0.5rem;
+  max-width: 1200px;
 }
 
 header h1 {
@@ -107,7 +108,7 @@ header h1 {
 
 /* Pool Table Coloring */
 .billiards-table .pool-cloth {
-  fill: url(#pool-blue-gradient);
+  fill: url("#pool-blue-gradient");
 }
 
 .billiards-table .pool-surround {
@@ -118,6 +119,7 @@ header h1 {
 .billiards-table .pool-cushion {
   fill: #24699e;
   stroke: #16466b;
+  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 50%));
 }
 
 .billiards-table .pool-pocket {
@@ -132,7 +134,7 @@ header h1 {
 
 /* Snooker Table Coloring */
 .billiards-table.snooker .pool-cloth {
-  fill: url(#snooker-green-gradient);
+  fill: url("#snooker-green-gradient");
 }
 
 .billiards-table.snooker .pool-cushion {
@@ -156,7 +158,7 @@ header h1 {
 .play-btn {
   display: block;
   padding: 0.35rem 0.75rem;
-  background: linear-gradient(135deg, #6366f1, #2563eb, #1d4ed8);
+  background: #3967bc;
   color: white;
   border: none;
   border-radius: 6px;


### PR DESCRIPTION
Applied the requested custom CSS styling to the speedrun page and aligned the Lobby button with the card grid's max-width (1200px) for a consistent layout. Validated using playwright screenshots and ensured stylelint and prettier tests pass perfectly.

---
*PR created automatically by Jules for task [8484805569042885094](https://jules.google.com/task/8484805569042885094) started by @tailuge*