### PR TITLE
Fix 2-player end-of-game stats display for loser in Sagu and Three-Cushion

### DIFF
--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -54,6 +54,18 @@ export abstract class ControllerBase extends Controller {
         session.playerIndex === 0 ? event.p1type : flipP1type(event.p1type)
     }
     this.container.updateScoreHud(event.p1, event.p2, event.b, event.active)
+
+    const rulename = this.container.rules.rulename
+    if (
+      (rulename === "threecushion" || rulename === "sagu") &&
+      this.container.rules.isEndOfGame([]) &&
+      this.name !== "End"
+    ) {
+      const myTarget = session.getRaceTargetForPlayer(session.clientId)
+      const amIWinner = session.myScore() >= myTarget
+      return this.container.rules.handleGameEnd(amIWinner)
+    }
+
     return this
   }
 


### PR DESCRIPTION
In 2-player multiplayer games for threecushion and sagu rules, the watcher/loser client would previously process a StationaryEvent and evaluate isEndOfGame with outdated scores before processing the network ScoreEvent. This would leave them stuck in WatchShot/WatchAim, preventing them from transitioning to the End state and seeing the game-over stats overlay. This change intercepts ScoreEvent inside ControllerBase.handleScore, checks if the updated scores trigger isEndOfGame, and correctly transitions them to End via handleGameEnd.

---
*PR created automatically by Jules for task [13447622292052686912](https://jules.google.com/task/13447622292052686912) started by @tailuge*