### PR TITLE
Fix table gradient rendering issue when filtering speedrun cards by run

### DIFF
--- a/dist/speedrun/speedrun.css
+++ b/dist/speedrun/speedrun.css
@@ -464,7 +464,16 @@ header h1 {
 
 /* ?run=id filtering — hide all cards except the matching one */
 html[data-run] .card-grid > .speedrun-card:not(.active-run) {
-  display: none;
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
 }
 
 /* Icon buttons on card SVGs */


### PR DESCRIPTION
Fixed the table background rendering issue on speedrun card previews when filtered via the query parameter `?run=id`. The root cause was using `display: none` to hide non-matching cards, which caused browsers to ignore the SVG gradients (`#pool-blue-gradient` / `#snooker-green-gradient`) defined within those hidden cards, breaking the fill of the visible card. This has been fixed by replacing `display: none` with a hidden-but-present styling pattern (`position: absolute; width: 0; height: 0; overflow: hidden; opacity: 0; ...`).

---
*PR created automatically by Jules for task [12773702280353012917](https://jules.google.com/task/12773702280353012917) started by @tailuge*