### PR TITLE
Export and Lobby UI Improvements

### DIFF
--- a/dist/diagrams/export.html
+++ b/dist/diagrams/export.html
@@ -110,9 +110,21 @@
         padding: 0.5rem;
       }
 
+      .panel-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 0.5rem;
+      }
+
       #panels h2 {
         font-size: 1rem;
-        margin: 0 0 0.5rem;
+        margin: 0;
+      }
+
+      .btn-sm {
+        padding: 2px 6px;
+        font-size: 0.75rem;
       }
 
       #panels pre {
@@ -146,11 +158,17 @@
 
     <div id="panels">
       <div>
-        <h2>Simulation SVG</h2>
+        <div class="panel-header">
+          <h2>Simulation SVG</h2>
+          <button class="btn btn-sm" onclick="selectAll('simulation-json')">Select All</button>
+        </div>
         <pre id="simulation-json"></pre>
       </div>
       <div>
-        <h2>Computed SVG</h2>
+        <div class="panel-header">
+          <h2>Computed SVG</h2>
+          <button class="btn btn-sm" onclick="selectAll('computed-svg')">Select All</button>
+        </div>
         <pre id="computed-svg"></pre>
       </div>
     </div>
@@ -160,6 +178,16 @@
       window.toggleEditMode = function () {
         isEditMode = !isEditMode
         return isEditMode
+      }
+
+      window.selectAll = function (elementId) {
+        const el = document.getElementById(elementId)
+        if (!el) return
+        const range = document.createRange()
+        range.selectNodeContents(el)
+        const sel = window.getSelection()
+        sel.removeAllRanges()
+        sel.addRange(range)
       }
 
       import {

--- a/dist/exam/exam.css
+++ b/dist/exam/exam.css
@@ -274,10 +274,26 @@ body > h2 {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.85rem;
+  margin-left: 0.25rem;
 }
 
 .reset-btn:hover {
   background-color: #dc2626;
+}
+
+.lobby-btn {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  background-color: #2563eb;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.lobby-btn:hover {
+  background-color: #1d4ed8;
 }
 
 /* Iframe overlay */

--- a/dist/exam/snooker.html
+++ b/dist/exam/snooker.html
@@ -30,7 +30,10 @@
       >
       <span id="completionPct" class="assessment-item">—</span>
       <span id="scorePct" class="assessment-item">—</span>
-      <button id="resetExam" class="reset-btn">Reset</button>
+      <div>
+        <a href="https://billiards.tailuge.workers.dev/lobby" class="lobby-btn">Lobby</a>
+        <button id="resetExam" class="reset-btn">Reset</button>
+      </div>
     </div>
 
     <section class="summary">

--- a/dist/exam/threecushion.html
+++ b/dist/exam/threecushion.html
@@ -27,7 +27,10 @@
       >
       <span id="completionPct" class="assessment-item">—</span>
       <span id="scorePct" class="assessment-item">—</span>
-      <button id="resetExam" class="reset-btn">Reset</button>
+      <div>
+        <a href="https://billiards.tailuge.workers.dev/lobby" class="lobby-btn">Lobby</a>
+        <button id="resetExam" class="reset-btn">Reset</button>
+      </div>
     </div>
 
     <section class="summary">

--- a/dist/speedrun/speedrun.css
+++ b/dist/speedrun/speedrun.css
@@ -22,7 +22,8 @@ body {
 header {
   position: relative;
   text-align: center;
-  margin-bottom: 0.5rem;
+  max-width: 1200px;
+  margin: 0 auto 0.5rem;
 }
 
 header h1 {


### PR DESCRIPTION
Added small 'Select All' buttons to the SVG raw text panels in export.html, aligned the speedrun lobby button to match the max-width page layout constraint, and added a blue Lobby button next to the Reset button in the snooker/three-cushion exam assessment line headers.

---
*PR created automatically by Jules for task [6236141028813846828](https://jules.google.com/task/6236141028813846828) started by @tailuge*