### PR TITLE
Fix Sagu Depth Exceeded Physics Repro

### DIFF
--- a/src/model/physics/physics.ts
+++ b/src/model/physics/physics.ts
@@ -33,8 +33,8 @@ export function rollingFull(w: Vector3, v: Vector3, t: number) {
     delta.v.set(-v.x / t, -v.y / t, 0)
     const spindownFactor = zmag > 24 ? 12 : 1
     delta.w.set(
-      -w.x,
-      -w.y,
+      -w.x / t,
+      -w.y / t,
       -(5 / 2) * (Mz / (m * R * R)) * spindownFactor * zsign
     )
     return delta

--- a/test/bug/sagu_depth_exceeded_repro.spec.ts
+++ b/test/bug/sagu_depth_exceeded_repro.spec.ts
@@ -32,7 +32,7 @@ const aimJson = {
 }
 
 describe("Sagu Depth Exceeded Repro", () => {
-  it("throws exception 'Depth exceeded resolving collisions' during replay of the crashing shot", () => {
+  it("completes replay of the shot successfully without throwing depth exceeded exception", () => {
     Ball.id = 0
 
     // Apply rule and table size configuration (Sagu, tableSize = 5)
@@ -56,6 +56,7 @@ describe("Sagu Depth Exceeded Repro", () => {
       }
     }
 
-    expect(runReplay).to.throw("Depth exceeded resolving collisions")
+    expect(runReplay).not.to.throw()
+    expect(table.allStationary()).to.be.true
   })
 })


### PR DESCRIPTION
This PR resolves the 'Sagu Depth Exceeded Repro' test failure by correcting the horizontal angular deceleration in the rolling physics integration. Previously, when the horizontal spin fell below the threshold eps, the spin-down components were not divided by the time delta t, preventing them from being completely zeroed out and causing unphysical drift/infinite collision depth loops. We also update the reproduction test assertion to verify successful replay completion.

---
*PR created automatically by Jules for task [13267749200992528127](https://jules.google.com/task/13267749200992528127) started by @tailuge*