### PR TITLE
Scale cue hit animation forward stroke based on power ratio

### DIFF
--- a/src/view/cue.ts
+++ b/src/view/cue.ts
@@ -187,7 +187,12 @@ export class Cue {
       this.hitAnimationWeight *= 0.97
     }
 
-    const curveVal = this.hitAnimationCurve(this.t)
+    let curveVal = this.hitAnimationCurve(this.t)
+    if (curveVal < 0) {
+      const powerRatio = this.aim.power / maxPower
+      const factor = 0.5 + 0.5 * powerRatio
+      curveVal *= factor
+    }
     const hitOffset = this.hitAnimationWeight * curveVal * 2 * R
     const strokeX = (1 - this.hitAnimationWeight) * swing - hitOffset
     const strokeZ = (0.15 + Math.min(this.t / 5, 0.25)) * hitOffset


### PR DESCRIPTION
This change scales the cue's forward hit animation when curveVal < 0 in applyHitAnimation of src/view/cue.ts. The scaling factor is calculated linearly as 0.5 + 0.5 * (power / maxPower), so that the forward stroke has 100% of the max position at max power down to 50% at 0 power. All existing tests pass successfully.

---
*PR created automatically by Jules for task [6012320915857766524](https://jules.google.com/task/6012320915857766524) started by @tailuge*