### PR TITLE
Fix Export PNG Filename

### DIFF
--- a/dist/diagrams/export.html
+++ b/dist/diagrams/export.html
@@ -452,7 +452,10 @@
             canvas.toBlob((blob) => {
               if (!blob) return
               const pngUrl = URL.createObjectURL(blob)
-              window.open(pngUrl, "_blank")
+              const a = document.createElement("a")
+              a.href = pngUrl
+              a.download = "diagram.png"
+              a.click()
               setTimeout(() => URL.revokeObjectURL(pngUrl), 1000)
             }, "image/png")
           }


### PR DESCRIPTION
Update the PNG button on export.html to download the generated diagram as diagram.png instead of opening a random-named blob URL in a new tab.

---
*PR created automatically by Jules for task [7079455395172405432](https://jules.google.com/task/7079455395172405432) started by @tailuge*