### PR TITLE
Track and log opponent disconnect and reconnect events

### DIFF
--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -35,6 +35,7 @@ export class LobbyIndicator {
   private users: PresenceMessage[] = []
   private readonly onChatMessage: ((msg: string) => void) | undefined
   private readonly onShowOverlay: ((url: string) => void) | undefined
+  private readonly offlineHandler: () => void
 
   constructor(
     botMode: boolean,
@@ -44,6 +45,9 @@ export class LobbyIndicator {
     messagingUrl?: string,
     onShowOverlay?: (url: string) => void
   ) {
+    this.offlineHandler = () => {
+      this.onChatMessage?.("<br>🚫")
+    }
     this.rules = rules
     this.replayMode = replayMode
     this.onChatMessage = onChatMessage
@@ -170,8 +174,15 @@ export class LobbyIndicator {
       presence.tableId = this.currentTableId
     }
 
-    this.lobby = await this.messagingClient.joinLobby(presence)
+    this.lobby = await this.messagingClient.joinLobby(presence, {
+      onReconnect: () => {
+        NetworkLogger.logLobby("lobby reconnect")
+        NetworkLogger.logGame("lobby reconnect")
+        this.onChatMessage?.("<br>📶")
+      },
+    })
     NetworkLogger.logLobby("joined")
+    globalThis.addEventListener?.("offline", this.offlineHandler)
 
     this.lobby.onUsersChange((users) => {
       NetworkLogger.logLobby(`users: ${users.length}`)
@@ -359,6 +370,7 @@ export class LobbyIndicator {
 
   async stop(): Promise<void> {
     try {
+      globalThis.removeEventListener?.("offline", this.offlineHandler)
       if (this.lobby) {
         await this.lobby.leave()
       }

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -31,6 +31,7 @@ export class LobbyIndicator {
   private readonly replayMode: boolean
   private readonly isSpectator: boolean
   private opponentOnline: boolean | null = null
+  private opponentSeen = false
   private users: PresenceMessage[] = []
   private readonly onChatMessage: ((msg: string) => void) | undefined
   private readonly onShowOverlay: ((url: string) => void) | undefined
@@ -185,8 +186,29 @@ export class LobbyIndicator {
             u.userId === opponentId &&
             u.tableId === (this.currentTableId || session.tableId)
         )
+        const isTwoPlayer =
+          opponentId !== "bot" &&
+          !session.botMode &&
+          !session.practiceMode &&
+          !this.replayMode
+
         if (wasOnline !== false && this.opponentOnline === false) {
           NetworkLogger.logLobby(`opponent offline: ${opponentId}`)
+        }
+
+        if (isTwoPlayer) {
+          if (wasOnline === true && this.opponentOnline === false) {
+            NetworkLogger.logGame(`opponent disconnect: ${opponentId}`)
+            this.onChatMessage?.("<br>🔌")
+          } else if (wasOnline === false && this.opponentOnline === true) {
+            if (this.opponentSeen) {
+              NetworkLogger.logGame(`opponent reconnect: ${opponentId}`)
+              this.onChatMessage?.("<br>⚡")
+            }
+          }
+          if (this.opponentOnline) {
+            this.opponentSeen = true
+          }
         }
       } else {
         this.opponentOnline = null

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -265,4 +265,57 @@ describe("LobbyIndicator", () => {
     onUsersChangeCallback([{ userId: "test-client", userName: "TestPlayer" }])
     expect(countElement.hasAttribute("title")).toBe(false)
   })
+
+  it("logs disconnect and sends unplug emoji when opponent disconnects, and reconnect when they reconnect", async () => {
+    Session.init("p1", "Player 1", "table-1", false)
+    Session.getInstance().setOpponentClientId("p2")
+
+    const mockRules = { rulename: "nineball" } as any
+    const mockOnChatMessage = jest.fn()
+    const indicator = new LobbyIndicator(
+      false,
+      false,
+      mockRules,
+      mockOnChatMessage
+    )
+
+    await indicator.init()
+
+    const mockLobby = (indicator as any).lobby
+    const onUsersChangeCallback = mockLobby.onUsersChange.mock.calls[0][0]
+
+    // 1. Initial status: opponent not on table yet (opponentOnline is false)
+    onUsersChangeCallback([{ userId: "p1", tableId: "table-1" }])
+    expect(mockOnChatMessage).not.toHaveBeenCalled()
+
+    // 2. Opponent joins table (opponentOnline becomes true)
+    onUsersChangeCallback([
+      { userId: "p1", tableId: "table-1" },
+      { userId: "p2", tableId: "table-1" },
+    ])
+    // Still shouldn't have disconnect or reconnect message on initial join
+    expect(mockOnChatMessage).not.toHaveBeenCalled()
+
+    // Clear any mock log state for the game logs
+    const { NetworkLogger } = require("../../src/utils/network-logger")
+    const getGameLogLabels = () =>
+      NetworkLogger.getGameLogs().map((log: any) => log.label)
+
+    // 3. Opponent disconnects (opponentOnline goes from true to false)
+    onUsersChangeCallback([{ userId: "p1", tableId: "table-1" }])
+    expect(mockOnChatMessage).toHaveBeenCalledWith("<br>🔌")
+    expect(getGameLogLabels()).toContain("opponent disconnect: p2")
+
+    mockOnChatMessage.mockClear()
+
+    // 4. Opponent reconnects (opponentOnline goes from false to true)
+    onUsersChangeCallback([
+      { userId: "p1", tableId: "table-1" },
+      { userId: "p2", tableId: "table-1" },
+    ])
+    expect(mockOnChatMessage).toHaveBeenCalledWith("<br>⚡")
+    expect(getGameLogLabels()).toContain("opponent reconnect: p2")
+
+    await indicator.stop()
+  })
 })

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -318,4 +318,45 @@ describe("LobbyIndicator", () => {
 
     await indicator.stop()
   })
+
+  it("logs local player offline and reconnect events with unique emojis", async () => {
+    Session.init("p1", "Player 1", "table-1", false)
+
+    const mockRules = { rulename: "nineball" } as any
+    const mockOnChatMessage = jest.fn()
+    const indicator = new LobbyIndicator(
+      false,
+      false,
+      mockRules,
+      mockOnChatMessage
+    )
+
+    await indicator.init()
+
+    // 1. Simulate local player going offline
+    const offlineEvent = new window.Event("offline")
+    globalThis.dispatchEvent(offlineEvent)
+    expect(mockOnChatMessage).toHaveBeenCalledWith("<br>🚫")
+
+    mockOnChatMessage.mockClear()
+
+    // 2. Simulate websocket/lobby reconnecting
+    const mockLobby = (indicator as any).lobby
+    const joinLobbyCall = (indicator as any).messagingClient.joinLobby
+    const joinLobbyOptions = joinLobbyCall.mock.calls[0][1]
+
+    expect(joinLobbyOptions).toBeDefined()
+    expect(joinLobbyOptions.onReconnect).toBeDefined()
+
+    // Trigger onReconnect callback
+    joinLobbyOptions.onReconnect()
+    expect(mockOnChatMessage).toHaveBeenCalledWith("<br>📶")
+
+    const { NetworkLogger } = require("../../src/utils/network-logger")
+    const getGameLogLabels = () =>
+      NetworkLogger.getGameLogs().map((log: any) => log.label)
+    expect(getGameLogLabels()).toContain("lobby reconnect")
+
+    await indicator.stop()
+  })
 })


### PR DESCRIPTION
Tracks 2-player opponent disconnect and reconnect events, logs them to the network history panel, and displays corresponding single emoji local chat notifications.

---
*PR created automatically by Jules for task [5504725444066963066](https://jules.google.com/task/5504725444066963066) started by @tailuge*