### PR TITLE
Add percentage integer overlay on power slider

### DIFF
--- a/dist/css/powerinput.css
+++ b/dist/css/powerinput.css
@@ -17,6 +17,18 @@
   align-self: center;
 }
 
+.powerPercent {
+  position: absolute;
+  left: 5%;
+  font-family: var(--font-family-primary), sans-serif;
+  font-size: 14px;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+  pointer-events: none;
+  z-index: 3;
+}
+
 /* Flat Power Triangle (Sits behind the cue) */
 .power-track {
   position: absolute;

--- a/dist/index.html
+++ b/dist/index.html
@@ -228,6 +228,7 @@
           id="cuePower"
           aria-label="power slider"
         />
+        <span id="powerPercent" class="powerPercent">65%</span>
       </div>
       <div class="outerMenu">
         <button

--- a/src/view/dom/aiminputs.ts
+++ b/src/view/dom/aiminputs.ts
@@ -16,6 +16,7 @@ export class AimInputs {
   readonly cueTipElement
   readonly powerSliderContainerElement
   readonly cuePowerElement
+  readonly cuePowerPercentElement: HTMLElement | null
   readonly tiltSliderContainerElement
   readonly openElevationElement
   readonly cueTiltElement: AngleInput
@@ -42,6 +43,7 @@ export class AimInputs {
     this.cueTipElement = id("cueTip")
     this.powerSliderContainerElement = id("powerSliderContainer")
     this.cuePowerElement = id("cuePower")
+    this.cuePowerPercentElement = id("powerPercent")
     this.tiltSliderContainerElement = id("tiltSliderContainer")
     this.openElevationElement = id("openElevation") as HTMLButtonElement
     this.cueTiltElement = id("cueTilt") as AngleInput
@@ -264,6 +266,9 @@ export class AimInputs {
     if (this.cuePowerElement) {
       const percent = Number(this.cuePowerElement.value) * 100
       this.cuePowerElement.style.setProperty("--p", percent + "%")
+      if (this.cuePowerPercentElement) {
+        this.cuePowerPercentElement.innerText = Math.round(percent) + "%"
+      }
     }
   }
 
@@ -395,6 +400,9 @@ export class AimInputs {
     const percent = val * 100
     this.cuePowerElement.value = val.toString()
     this.cuePowerElement.style.setProperty("--p", percent + "%")
+    if (this.cuePowerPercentElement) {
+      this.cuePowerPercentElement.innerText = Math.round(percent) + "%"
+    }
   }
 
   mousewheel = (e) => {

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -36,6 +36,7 @@ describe("AimInput", () => {
     aiminputs.cuePowerElement.value = "1"
     fireEvent.input(aiminputs.cuePowerElement, { target: { value: "1" } })
     expect(container.table.cue.aim.power).to.be.greaterThan(0)
+    expect(aiminputs.cuePowerPercentElement?.innerText).to.equal("100%")
     done()
   })
 


### PR DESCRIPTION
This change adds an integer percentage display overlaid on the left part of the power slider (at the 5% position) to save space. The text is kept simple and managed directly by the existing slider update logic. It has been visually and programmatically verified, and all unit tests pass.

---
*PR created automatically by Jules for task [15952883007878184922](https://jules.google.com/task/15952883007878184922) started by @tailuge*