### PR TITLE
Shorten challenge message

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -97,3 +97,19 @@ export function randomEmoji(): string {
   }
   return "🎱"
 }
+
+export const ruleTypeMap: Record<
+  string,
+  { emoji: string; title: string }
+> = {
+  nineball: { emoji: "⑨", title: "nineball" },
+  eightball: { emoji: "🎱", title: "eightball" },
+  snooker: { emoji: "🔴", title: "snooker" },
+  threecushion: { emoji: "③", title: "threecushion" },
+  sagu: { emoji: "④", title: "sagu" },
+}
+
+export function getRuleEmoji(ruleType: string): string {
+  const base = ruleType.split("-")[0]
+  return ruleTypeMap[base]?.emoji ?? ruleType
+}

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -293,7 +293,7 @@ export class LobbyIndicator {
     this.challengePill.hidden = !challenged
     if (challenged) {
       const textNode = this.challengePill.childNodes[0]
-      const msg = `Challenge of ${this.challenger!.ruleType} from ${this.challenger!.userName} `
+      const msg = `${this.challenger!.ruleType} ${this.challenger!.userName} `
       if (textNode?.nodeType === Node.TEXT_NODE) {
         textNode.textContent = msg
       } else {

--- a/src/view/lobbyindicator.ts
+++ b/src/view/lobbyindicator.ts
@@ -10,6 +10,7 @@ import { id } from "../utils/dom"
 import { LOBBY_URL } from "../network/client/constants"
 import { VERSION } from "../utils/version"
 import { NetworkLogger } from "../utils/network-logger"
+import { getRuleEmoji } from "../utils/utils"
 
 export class LobbyIndicator {
   private readonly element: HTMLElement | null
@@ -293,7 +294,7 @@ export class LobbyIndicator {
     this.challengePill.hidden = !challenged
     if (challenged) {
       const textNode = this.challengePill.childNodes[0]
-      const msg = `${this.challenger!.ruleType} ${this.challenger!.userName} `
+      const msg = `${getRuleEmoji(this.challenger!.ruleType)} ${this.challenger!.userName} `
       if (textNode?.nodeType === Node.TEXT_NODE) {
         textNode.textContent = msg
       } else {

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -64,7 +64,7 @@ describe("LobbyIndicator", () => {
     const countElement = element?.querySelector(".lobby-count")
     expect(countElement?.classList.contains("is-hidden")).toBe(false)
     expect(document.getElementById("challengePill")?.textContent).toContain(
-      "nineball Bob"
+      "⑨ Bob"
     )
     expect(element?.getAttribute("aria-label")).toContain("CHALLENGE FROM Bob")
 

--- a/test/view/lobbyindicator.spec.ts
+++ b/test/view/lobbyindicator.spec.ts
@@ -64,7 +64,7 @@ describe("LobbyIndicator", () => {
     const countElement = element?.querySelector(".lobby-count")
     expect(countElement?.classList.contains("is-hidden")).toBe(false)
     expect(document.getElementById("challengePill")?.textContent).toContain(
-      "Challenge of nineball from Bob"
+      "nineball Bob"
     )
     expect(element?.getAttribute("aria-label")).toContain("CHALLENGE FROM Bob")
 


### PR DESCRIPTION
Shortens the multiplayer lobby challenge message on the challenge pill to just ruleType and userName while keeping accept/decline buttons intact.

---
*PR created automatically by Jules for task [4821621581561610042](https://jules.google.com/task/4821621581561610042) started by @tailuge*