### PR TITLE
Add lobby-independent bothJoined Promise and callback to Container and BrowserContainer

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -42,6 +42,9 @@ export class BrowserContainer {
   playername: string
   replay: string | null
   messageRelay: MessageRelay | null = null
+  public readonly bothJoined: Promise<void>
+  public onBothJoined?: () => void
+  private resolveBothJoined!: () => void
   breakState: {
     init: any
     shots: any[]
@@ -70,6 +73,9 @@ export class BrowserContainer {
   localMesh: boolean = false
   readonly botDelay: number = 500
   constructor(canvas3d, params) {
+    this.bothJoined = new Promise<void>((resolve) => {
+      this.resolveBothJoined = resolve
+    })
     this.now = Date.now()
     this.playername =
       params.get("userName") ??
@@ -241,6 +247,11 @@ export class BrowserContainer {
       this.initMultiplayer(scoreReporter)
     }
 
+    this.container.bothJoined.then(() => {
+      this.resolveBothJoined()
+      this.onBothJoined?.()
+    })
+
     this.container.broadcast = (e) => {
       this.broadcast(e)
     }
@@ -257,6 +268,10 @@ export class BrowserContainer {
       this.container.eventQueue.push(new BeginEvent())
     } else {
       this.initGameLoop()
+    }
+
+    if (this.container.isSinglePlayer || this.botMode || !!this.replay) {
+      this.container.triggerBothJoined()
     }
 
     // trigger animation loops
@@ -325,6 +340,15 @@ export class BrowserContainer {
     }
 
     const session = Session.getInstance()
+    if (
+      !this.botMode &&
+      !this.spectator &&
+      session.playername &&
+      session.opponentName
+    ) {
+      this.container.triggerBothJoined()
+    }
+
     if (
       !session.vsNotificationShown &&
       !this.botMode &&

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -65,6 +65,10 @@ export class Container {
   id: string
   isSinglePlayer: boolean = true
   rules: Rules
+  public readonly bothJoined: Promise<void>
+  public onBothJoined?: () => void
+  private resolveBothJoined!: () => void
+  private hasTriggeredBothJoined = false
   menu: Menu
   comment: Comment
   hud: Hud
@@ -99,6 +103,9 @@ export class Container {
   log: (text: string) => void
 
   constructor(config: ContainerConfig) {
+    this.bothJoined = new Promise<void>((resolve) => {
+      this.resolveBothJoined = resolve
+    })
     const {
       element,
       log,
@@ -275,6 +282,13 @@ export class Container {
     if (changed) {
       this.sendEvent(new ScoreEvent(p1, p2, b, activePlayer))
     }
+  }
+
+  triggerBothJoined() {
+    if (this.hasTriggeredBothJoined) return
+    this.hasTriggeredBothJoined = true
+    this.resolveBothJoined()
+    this.onBothJoined?.()
   }
 
   notify(data: NotificationData | string, duration?: number) {

--- a/src/controller/spectate.ts
+++ b/src/controller/spectate.ts
@@ -74,6 +74,10 @@ export class Spectate extends ControllerBase {
         session.vsNotificationShown = true
       }
     }
+
+    if (session.spectatedP1Name && session.spectatedP2Name) {
+      this.container.triggerBothJoined()
+    }
   }
 
   override handleAim(event: AimEvent) {

--- a/test/network/bothjoined.spec.ts
+++ b/test/network/bothjoined.spec.ts
@@ -1,0 +1,179 @@
+import { expect } from "chai"
+import { Container } from "../../src/container/container"
+import { BrowserContainer } from "../../src/container/browsercontainer"
+import { Session } from "../../src/network/client/session"
+import { Assets } from "../../src/view/assets"
+import { initDom } from "../view/dom"
+import { Spectate } from "../../src/controller/spectate"
+import { BeginEvent } from "../../src/events/beginevent"
+import { WatchEvent } from "../../src/events/watchevent"
+import { EventUtil } from "../../src/events/eventutil"
+
+initDom()
+
+describe("bothJoined Promise and Callback", () => {
+  beforeEach(() => {
+    Session.reset()
+  })
+
+  it("should resolve Container.bothJoined when triggerBothJoined is called", async () => {
+    const container = new Container({
+      element: undefined,
+      log: () => {},
+      assets: Assets.localAssets(),
+      ruletype: "nineball",
+    })
+
+    let callbackCalled = false
+    container.onBothJoined = () => {
+      callbackCalled = true
+    }
+
+    container.triggerBothJoined()
+
+    await container.bothJoined
+    expect(callbackCalled).to.be.true
+  })
+
+  it("should link BrowserContainer.bothJoined to Container.bothJoined", async () => {
+    const params = new URLSearchParams("ruletype=nineball")
+    const browserContainer = new BrowserContainer(undefined, params)
+
+    const container = new Container({
+      element: undefined,
+      log: () => {},
+      assets: Assets.localAssets(),
+      ruletype: "nineball",
+    })
+
+    browserContainer.container = container
+
+    // Setup the link manually as is done in onAssetsReady
+    container.bothJoined.then(() => {
+      const bc = browserContainer as any
+      bc.resolveBothJoined()
+      browserContainer.onBothJoined?.()
+    })
+
+    let callbackCalled = false
+    browserContainer.onBothJoined = () => {
+      callbackCalled = true
+    }
+
+    container.triggerBothJoined()
+
+    await browserContainer.bothJoined
+    expect(callbackCalled).to.be.true
+  })
+
+  it("should resolve immediately in single-player or bot mode inside BrowserContainer", async () => {
+    const params = new URLSearchParams("ruletype=nineball")
+    const browserContainer = new BrowserContainer(undefined, params)
+
+    const container = new Container({
+      element: undefined,
+      log: () => {},
+      assets: Assets.localAssets(),
+      ruletype: "nineball",
+      isSinglePlayer: true,
+    })
+    browserContainer.container = container
+
+    // link them
+    container.bothJoined.then(() => {
+      const bc = browserContainer as any
+      bc.resolveBothJoined()
+      browserContainer.onBothJoined?.()
+    })
+
+    // Simulate the onAssetsReady check
+    if (container.isSinglePlayer || browserContainer.botMode) {
+      container.triggerBothJoined()
+    }
+
+    await browserContainer.bothJoined
+  })
+
+  it("should trigger bothJoined in spectator mode once both names are sniffed", async () => {
+    Session.init("spectator-client", "Spectator", "test-table", true)
+
+    const container = new Container({
+      element: undefined,
+      log: () => {},
+      assets: Assets.localAssets(),
+      ruletype: "nineball",
+    })
+    container.isSinglePlayer = false
+
+    let triggered = false
+    container.onBothJoined = () => {
+      triggered = true
+    }
+
+    let capturedCallback: (message: string) => void = () => {}
+    const messageRelay = {
+      subscribe: (channel: string, callback: (message: string) => void) => {
+        capturedCallback = callback
+      },
+      publish: () => {},
+    }
+
+    const spectate = new Spectate(container, messageRelay, "test-table")
+    expect(spectate).to.not.be.null
+
+    // Simulate BEGIN event from P1
+    const beginEvent = new BeginEvent()
+    beginEvent.clientId = "p1-id"
+    beginEvent.playername = "Peter"
+    capturedCallback(EventUtil.serialise(beginEvent))
+
+    expect(triggered).to.be.false // Only P1 sniffed
+
+    // Simulate WATCHAIM event from P2
+    const watchEvent = new WatchEvent({})
+    watchEvent.clientId = "p2-id"
+    watchEvent.playername = "Yvette"
+    capturedCallback(EventUtil.serialise(watchEvent))
+
+    await container.bothJoined
+    expect(triggered).to.be.true // Both sniffed and promise resolved!
+  })
+
+  it("should trigger bothJoined in multiplayer netEvent when opponent joins", async () => {
+    // Setup URL search params with userName to override default "Anon"
+    const params = new URLSearchParams("ruletype=nineball&websocketserver=ws://localhost&userName=Peter&userId=p1-client")
+    const browserContainer = new BrowserContainer(undefined, params)
+
+    const container = new Container({
+      element: undefined,
+      log: () => {},
+      assets: Assets.localAssets(),
+      ruletype: "nineball",
+      isSinglePlayer: false,
+    })
+    browserContainer.container = container
+
+    // Link them
+    container.bothJoined.then(() => {
+      const bc = browserContainer as any
+      bc.resolveBothJoined()
+      browserContainer.onBothJoined?.()
+    })
+
+    let triggered = false
+    browserContainer.onBothJoined = () => {
+      triggered = true
+    }
+
+    // Simulate opponent sending a WATCHAIM netEvent
+    const watchEvent = new WatchEvent({})
+    watchEvent.clientId = "p2-client"
+    watchEvent.playername = "Yvette"
+    const serialised = EventUtil.serialise(watchEvent)
+
+    browserContainer.netEvent(serialised)
+
+    await browserContainer.bothJoined
+    expect(triggered).to.be.true
+  })
+})


### PR DESCRIPTION
This pull request introduces `bothJoined: Promise<void>` and `onBothJoined?: () => void` to both `Container` and `BrowserContainer` classes. This provides a clean, lobby-independent mechanism for consumers to await or register a callback for when both players have joined a table. Spectator joins are ignored, and single-player, bot, and replay modes resolve immediately. Spectator clients resolve once the names of both active players have been sniffed. Full unit tests were added and all existings tests pass cleanly.

---
*PR created automatically by Jules for task [3864339625027972176](https://jules.google.com/task/3864339625027972176) started by @tailuge*