### PR TITLE
Update camera button superscript for zoomed-out state

### DIFF
--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -305,7 +305,7 @@ export class Camera {
     if (btn) {
       btn.classList.remove("aim", "aimz", "topview")
       btn.classList.add(state)
-      btn.textContent = state === "topview" ? "🎥ᵀ" : "🎥"
+      btn.textContent = state === "aimz" ? "🎥ᶻ" : "🎥"
     }
   }
 

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -58,4 +58,37 @@ describe("Camera", () => {
     expect((camera as any).distance).to.equal(initialDistance)
     expect(camera.savedDistance).to.be.undefined
   })
+
+  describe("updateCameraButtonClass", () => {
+    let btn: HTMLButtonElement
+
+    beforeEach(() => {
+      btn = document.createElement("button")
+      btn.id = "camera"
+      document.body.appendChild(btn)
+    })
+
+    afterEach(() => {
+      btn.remove()
+    })
+
+    it("should set textContent to '🎥ᶻ' for aimz, and '🎥' for topview and aim states", () => {
+      const camera = new Camera(1)
+
+      // When state is topview
+      ;(camera as any).updateCameraButtonClass("topview")
+      expect(btn.classList.contains("topview")).to.be.true
+      expect(btn.textContent).to.equal("🎥")
+
+      // When state is aim
+      ;(camera as any).updateCameraButtonClass("aim")
+      expect(btn.classList.contains("aim")).to.be.true
+      expect(btn.textContent).to.equal("🎥")
+
+      // When state is zoomed out (aimz)
+      ;(camera as any).updateCameraButtonClass("aimz")
+      expect(btn.classList.contains("aimz")).to.be.true
+      expect(btn.textContent).to.equal("🎥ᶻ")
+    })
+  })
 })


### PR DESCRIPTION
Updates the camera view toggle button so that the superscript 'T' is removed from the 'topview' state, and instead, a superscript 'Z' ('🎥ᶻ') is shown when in the zoomed-out aim view state ('aimz'). Adds comprehensive unit tests to ensure correctness and prevent regressions.

---
*PR created automatically by Jules for task [5617627917524326919](https://jules.google.com/task/5617627917524326919) started by @tailuge*