### PR TITLE
Resolve multiplayer startup race condition for slow connections

### DIFF
--- a/src/network/client/messagingmessagerelay.ts
+++ b/src/network/client/messagingmessagerelay.ts
@@ -45,6 +45,18 @@ export class MessagingMessageRelay implements MessageRelay {
         for (const cb of this.pendingCallbacks) cb(data)
       }
     })
+    if (!session.spectator && typeof this.table.onBothJoined === "function") {
+      this.table.onBothJoined(() => {
+        this.table
+          ?.publish("joined", { id: session.clientId })
+          .catch((error) => {
+            console.error(
+              "Failed to republish joined message on bothJoined",
+              error
+            )
+          })
+      })
+    }
   }
 
   subscribe(

--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -305,7 +305,8 @@ export class Camera {
     if (btn) {
       btn.classList.remove("aim", "aimz", "topview")
       btn.classList.add(state)
-      btn.textContent = state === "aimz" ? "🎥ᶻ" : state === "topview" ? "🎥ᵀ" : "🎥"
+      btn.textContent =
+        state === "aimz" ? "🎥ᶻ" : state === "topview" ? "🎥ᵀ" : "🎥"
     }
   }
 

--- a/test/network/client/messagingmessagerelay.spec.ts
+++ b/test/network/client/messagingmessagerelay.spec.ts
@@ -7,11 +7,13 @@ const mockTable: {
   onOpponentLeft: jest.Mock
   onMessage: jest.Mock
   publish: jest.Mock
+  onBothJoined?: jest.Mock
   bothJoined?: Promise<void>
 } = {
   onOpponentLeft: jest.fn(),
   onMessage: jest.fn(),
   publish: jest.fn().mockResolvedValue(undefined),
+  onBothJoined: jest.fn(),
 }
 
 // Mock MessagingClient so joinTable returns our mock table
@@ -32,6 +34,7 @@ describe("MessagingMessageRelay", () => {
     mockTable.onOpponentLeft.mockClear()
     mockTable.onMessage.mockClear()
     mockTable.publish.mockClear()
+    mockTable.onBothJoined?.mockClear()
     Session.init("test-client", "TestPlayer", "test-table", false)
     mockClient = new (MessagingClient as any)({ baseUrl: "https://test" })
   })
@@ -132,6 +135,25 @@ describe("MessagingMessageRelay", () => {
     await relay.connect(mockClient, "test-table")
 
     expect(mockClient.joinTable).toHaveBeenCalledTimes(1)
+  })
+
+  it("should register onBothJoined callback and republish joined on bothJoined", async () => {
+    const relay = new MessagingMessageRelay()
+    await relay.connect(mockClient, "test-table")
+
+    expect(mockTable.onBothJoined).toHaveBeenCalledWith(expect.any(Function))
+
+    // Trigger the callback
+    const callback = mockTable.onBothJoined?.mock.calls[0][0]
+    callback()
+
+    // Allow any microtasks to flush
+    await Promise.resolve()
+
+    // It should publish 'joined' with the correct clientId
+    expect(mockTable.publish).toHaveBeenCalledWith("joined", {
+      id: "test-client",
+    })
   })
 
   describe("awaitBothJoined", () => {

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -58,5 +58,4 @@ describe("Camera", () => {
     expect((camera as any).distance).to.equal(initialDistance)
     expect(camera.savedDistance).to.be.undefined
   })
-
 })


### PR DESCRIPTION
This change resolves a race condition when a player with a slower connection joins second. Previously, the second player to join would miss the first player's initial 'joined' message, preventing their bothJoined promise from ever resolving. As a result, the second player experienced a timeout hang of 8 seconds while the first player immediately proceeded to broadcast a BeginEvent that got dropped/lost. 

We address this by using the library's native `onBothJoined` callback to republish a 'joined' message from whichever player resolves bothJoined first. This guarantees both players successfully resolve `bothJoined` and start the game loop reliably without delay.

---
*PR created automatically by Jules for task [896032675354233881](https://jules.google.com/task/896032675354233881) started by @tailuge*