### PR TITLE
Skip straight to zoomed-out aim view in watchaim/watchshot mode

### DIFF
--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -144,8 +144,11 @@ export class Camera {
   private computeStepBackFov(h: number): number {
     const portrait = this.camera.aspect < 0.8
     const tempFov = (portrait ? 60 : 40) + this.fovOffset
-    const fov =
-      h < 10 * R ? tempFov - 100 * (10 * R - h) * (portrait ? 3 : 1) : tempFov
+    let fov = tempFov
+    if (h < 10 * R) {
+      const factor = portrait ? 3 : 1
+      fov = tempFov - 100 * (10 * R - h) * factor
+    }
     return fov - 3
   }
 
@@ -300,12 +303,18 @@ export class Camera {
     }
   }
 
-  private updateCameraButtonClass(state: "aim" | "aimz" | "topview") {
+  updateCameraButtonClass(state: "aim" | "aimz" | "topview") {
     const btn = document.getElementById("camera")
     if (btn) {
       btn.classList.remove("aim", "aimz", "topview")
       btn.classList.add(state)
-      btn.textContent = state === "aimz" ? "🎥ᶻ" : state === "topview" ? "🎥ᵀ" : "🎥"
+      if (state === "aimz") {
+        btn.textContent = "🎥ᶻ"
+      } else if (state === "topview") {
+        btn.textContent = "🎥ᵀ"
+      } else {
+        btn.textContent = "🎥"
+      }
     }
   }
 

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -3,6 +3,8 @@ import { getButton } from "../utils/dom"
 import { Session } from "../network/client/session"
 import { ConcedeEvent } from "../events/concedeevent"
 import { ExportUtils } from "../utils/export-utils"
+import { WatchAim } from "../controller/watchaim"
+import { WatchShot } from "../controller/watchshot"
 
 export class Menu {
   container: Container
@@ -105,7 +107,25 @@ export class Menu {
 
   adjustCamera() {
     const camera = this.container.view.camera
-    camera.cycleMode(this.container.table.balls, this.container.table.cue.aim)
+    const controller = this.container.controller
+    if (
+      (controller instanceof WatchAim || controller instanceof WatchShot) &&
+      camera.mode === camera.topView
+    ) {
+      const balls = this.container.table.balls
+      const aim = this.container.table.cue.aim
+      camera.mode = camera.aimView
+      camera.stepBackToFitAllBalls(balls, aim)
+      if (camera.savedDistance !== undefined) {
+        camera.isZoomedOut = true
+        camera.updateCameraButtonClass("aimz")
+      } else {
+        camera.isZoomedOut = false
+        camera.updateCameraButtonClass("aim")
+      }
+    } else {
+      camera.cycleMode(this.container.table.balls, this.container.table.cue.aim)
+    }
     this.container.lastEventTime = performance.now()
   }
 

--- a/test/network/client/messagingmessagerelay.spec.ts
+++ b/test/network/client/messagingmessagerelay.spec.ts
@@ -68,8 +68,7 @@ describe("MessagingMessageRelay", () => {
     relay.subscribe("test-chan", gameCallback)
 
     // Simulate the library delivering a TableMessage envelope
-    const registeredHandler =
-      mockClient.joinTable.mock.calls[0][2].onMessage
+    const registeredHandler = mockClient.joinTable.mock.calls[0][2].onMessage
     const envelope = {
       type: "MyEvent",
       senderId: "other-client",
@@ -87,8 +86,7 @@ describe("MessagingMessageRelay", () => {
     const gameCallback = jest.fn()
     relay.subscribe("test-chan", gameCallback)
 
-    const registeredHandler =
-      mockClient.joinTable.mock.calls[0][2].onMessage
+    const registeredHandler = mockClient.joinTable.mock.calls[0][2].onMessage
     registeredHandler({ type: "table:leave", senderId: "other", data: {} })
 
     expect(gameCallback).not.toHaveBeenCalled()

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -58,5 +58,4 @@ describe("Camera", () => {
     expect((camera as any).distance).to.equal(initialDistance)
     expect(camera.savedDistance).to.be.undefined
   })
-
 })

--- a/test/view/menu.spec.ts
+++ b/test/view/menu.spec.ts
@@ -5,6 +5,7 @@ import { Container } from "../../src/container/container"
 import { Menu } from "../../src/view/menu"
 import { Assets } from "../../src/view/assets"
 import { Session } from "../../src/network/client/session"
+import { WatchAim } from "../../src/controller/watchaim"
 
 initDom()
 
@@ -30,6 +31,40 @@ describe("Menu", () => {
     expect(container.view.camera.mode).to.be.equal(
       container.view.camera.aimView
     )
+    done()
+  })
+
+  it("camera in WatchAim mode skips directly to zoomed-out aim view (aimz)", (done) => {
+    // Set aspect ratio manually to prevent NaN inside JSDOM environment
+    container.view.camera.camera.aspect = 1
+    container.view.camera.camera.updateProjectionMatrix()
+
+    const balls = container.table.balls
+    for (let i = 0; i < balls.length; i++) {
+      const b = balls[i]
+      b.ballmesh = undefined as any
+      if (i >= 2) {
+        b.state = "InPocket" as any
+      }
+    }
+    if (balls.length > 1) {
+      balls[0].pos.set(0, 0, 0)
+      balls[1].pos.set(1.0, 1.0, 0)
+    }
+
+    container.controller = new WatchAim(container)
+    expect(container.view.camera.mode).to.be.equal(
+      container.view.camera.topView
+    )
+
+    const toggleview = document.getElementById("camera") as HTMLButtonElement
+    fireEvent.click(toggleview)
+
+    expect(container.view.camera.mode).to.be.equal(
+      container.view.camera.aimView
+    )
+    expect(container.view.camera.isZoomedOut).to.be.true
+    expect(container.view.camera.savedDistance).to.not.be.undefined
     done()
   })
 


### PR DESCRIPTION
Introduced a minimal, robust change to allow players to transition directly from topView to zoomed-out aim view (aimz) when clicking the camera button in WatchAim or WatchShot mode. Fully unit tested.

---
*PR created automatically by Jules for task [5048709296042531611](https://jules.google.com/task/5048709296042531611) started by @tailuge*