### PR TITLE
Responsive Zoomed Diagram in viewraw.html

### DIFF
--- a/dist/fit/viewraw.html
+++ b/dist/fit/viewraw.html
@@ -49,12 +49,21 @@
         justify-content: center;
         align-items: center;
         flex-direction: column;
+        box-sizing: border-box;
+        padding: 16px;
       }
       .overlay.open {
         display: flex;
       }
+      .overlay .diagram {
+        width: 100%;
+        max-width: 800px;
+        box-sizing: border-box;
+      }
       .overlay svg {
         display: block;
+        width: 100%;
+        height: auto;
       }
       .overlay .close {
         color: #aaa;


### PR DESCRIPTION
This PR updates `dist/fit/viewraw.html` to improve visual layout and responsiveness of the zoomed diagram overlay, particularly on smaller screens/mobile. It constraints the diagram width to 100% with a max width of 800px, and enables responsive scaling of the inner SVG.

---
*PR created automatically by Jules for task [10515701815240846595](https://jules.google.com/task/10515701815240846595) started by @tailuge*