### PR TITLE
Restore Timestamp-based Message Filtering on Reconnect

### DIFF
--- a/src/network/client/messagingmessagerelay.ts
+++ b/src/network/client/messagingmessagerelay.ts
@@ -11,6 +11,7 @@ export class MessagingMessageRelay implements MessageRelay {
     message: string
     prefix?: string
   }> = []
+  private lastProcessedTimestamp: number = -1
 
   constructor() {}
 
@@ -43,6 +44,13 @@ export class MessagingMessageRelay implements MessageRelay {
     // onBothJoined must be registered in the constructor (>= 1.37.0).
     const onMessage = (msg: TableMessage) => {
       if (msg.type !== "table:leave") {
+        const timestamp = msg.meta?.ts
+        if (typeof timestamp === "number") {
+          if (timestamp < this.lastProcessedTimestamp) {
+            return
+          }
+          this.lastProcessedTimestamp = timestamp
+        }
         const data = JSON.stringify(msg.data)
         for (const cb of this.pendingCallbacks) cb(data)
       }

--- a/test/network/client/messagingmessagerelay.spec.ts
+++ b/test/network/client/messagingmessagerelay.spec.ts
@@ -79,6 +79,53 @@ describe("MessagingMessageRelay", () => {
     expect(gameCallback).toHaveBeenCalledWith(JSON.stringify({ key: "value" }))
   })
 
+  it("should deduplicate messages based on meta.ts timestamp", async () => {
+    const relay = new MessagingMessageRelay()
+    await relay.connect(mockClient, "test-table")
+
+    const gameCallback = jest.fn()
+    relay.subscribe("test-chan", gameCallback)
+
+    const registeredHandler = mockClient.joinTable.mock.calls[0][2].onMessage
+
+    // First message with meta.ts = 100
+    registeredHandler({
+      type: "MyEvent",
+      senderId: "other-client",
+      data: { key: "one" },
+      meta: { ts: 100 },
+    })
+    expect(gameCallback).toHaveBeenCalledWith(JSON.stringify({ key: "one" }))
+
+    // Message with same timestamp (meta.ts = 100) -> allowed (ts < lastTs check)
+    registeredHandler({
+      type: "MyEvent",
+      senderId: "other-client",
+      data: { key: "duplicate" },
+      meta: { ts: 100 },
+    })
+    expect(gameCallback).toHaveBeenCalledWith(JSON.stringify({ key: "duplicate" }))
+
+    // Older message (meta.ts = 99) -> ignored/filtered
+    gameCallback.mockClear()
+    registeredHandler({
+      type: "MyEvent",
+      senderId: "other-client",
+      data: { key: "old" },
+      meta: { ts: 99 },
+    })
+    expect(gameCallback).not.toHaveBeenCalled()
+
+    // Newer message (meta.ts = 101) -> allowed
+    registeredHandler({
+      type: "MyEvent",
+      senderId: "other-client",
+      data: { key: "new" },
+      meta: { ts: 101 },
+    })
+    expect(gameCallback).toHaveBeenCalledWith(JSON.stringify({ key: "new" }))
+  })
+
   it("should not deliver messages with type 'table:leave' to subscribers", async () => {
     const relay = new MessagingMessageRelay()
     await relay.connect(mockClient, "test-table")


### PR DESCRIPTION
This PR introduces `lastProcessedTimestamp` tracking and filtering inside `MessagingMessageRelay` to restore the timestamp-based message deduplication/filtering logic which was broken during the migration to `@tailuge/messaging`. Upon reconnecting, replayed/buffered older messages from nchan are now properly ignored, preventing the game client from executing stale events. Added unit tests to verify the behavior.

---
*PR created automatically by Jules for task [1273302446551855235](https://jules.google.com/task/1273302446551855235) started by @tailuge*