### PR TITLE
Handle opponent rejoin table callback with network log and emoji

### DIFF
--- a/src/container/browsercontainer.ts
+++ b/src/container/browsercontainer.ts
@@ -275,13 +275,20 @@ export class BrowserContainer {
     await li.init()
     const mc = li.getMessagingClient()
     if (!mc) return
-    await relay.connect(mc, this.tableId, () => {
-      this.container.chat.showMessage("<br>🔌")
-      this.container.notifyLocal({
-        type: "Info",
-        title: "Opponent left the game",
-      })
-    })
+    await relay.connect(
+      mc,
+      this.tableId,
+      () => {
+        this.container.chat.showMessage("<br>🔌")
+        this.container.notifyLocal({
+          type: "Info",
+          title: "Opponent left the game",
+        })
+      },
+      () => {
+        this.container.chat.showMessage("<br>⚡")
+      }
+    )
   }
 
   private connectRelayIfNeeded(): void {

--- a/src/network/client/messagingmessagerelay.ts
+++ b/src/network/client/messagingmessagerelay.ts
@@ -34,7 +34,8 @@ export class MessagingMessageRelay implements MessageRelay {
   async connect(
     messagingClient: MessagingClient,
     tableId: string,
-    onOpponentLeft?: () => void
+    onOpponentLeft?: () => void,
+    onOpponentRejoined?: () => void
   ): Promise<void> {
     if (this.table) return
     const session = Session.getInstance()
@@ -72,6 +73,10 @@ export class MessagingMessageRelay implements MessageRelay {
       this.table.onOpponentLeft(() => {
         NetworkLogger.logGame(`opponent left: table ${tableId}`)
         onOpponentLeft?.()
+      })
+      this.table.onOpponentRejoined(() => {
+        NetworkLogger.logGame(`opponent rejoined: table ${tableId}`)
+        onOpponentRejoined?.()
       })
 
       // Flush any publishes that were queued while connect was in-flight.

--- a/test/network/client/messagingmessagerelay.spec.ts
+++ b/test/network/client/messagingmessagerelay.spec.ts
@@ -5,11 +5,13 @@ import { Session } from "../../../src/network/client/session"
 // Mock the Table class methods we care about
 const mockTable: {
   onOpponentLeft: jest.Mock
+  onOpponentRejoined: jest.Mock
   onMessage: jest.Mock
   publish: jest.Mock
   bothJoined?: Promise<void>
 } = {
   onOpponentLeft: jest.fn(),
+  onOpponentRejoined: jest.fn(),
   onMessage: jest.fn(),
   publish: jest.fn().mockResolvedValue(undefined),
 }
@@ -30,6 +32,7 @@ describe("MessagingMessageRelay", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockTable.onOpponentLeft.mockClear()
+    mockTable.onOpponentRejoined.mockClear()
     mockTable.onMessage.mockClear()
     mockTable.publish.mockClear()
     Session.init("test-client", "TestPlayer", "test-table", false)


### PR DESCRIPTION
This change adds support for the new rejoin table callback (onOpponentRejoined) in tailuge/messaging. When an opponent rejoins, the event is logged via NetworkLogger.logGame and a lightning bolt (⚡) emoji is shown in the chat window. Existing Jest tests have also been updated to mock the new onOpponentRejoined method on Table, and the entire test suite has been verified to pass successfully.

---
*PR created automatically by Jules for task [9684896351528912545](https://jules.google.com/task/9684896351528912545) started by @tailuge*