### PR TITLE
Equal-Density Trajectory Simplification with Proximity Protections

### DIFF
--- a/dist/fit/simplify.js
+++ b/dist/fit/simplify.js
@@ -1,132 +1,12 @@
-import { interpolateTrack } from './rmse.js'
+const R = 0.03275
 
 /**
- * Node representation for the doubly-linked list of trajectory points.
+ * Checks if a point (x, y) is within 3*R of any of the four cushions of the three-cushion billiard table.
  */
-class ListNode {
-  constructor(index, sample) {
-    this.index = index // Original index in the sorted samples array
-    this.t = sample.t
-    this.x = sample.x
-    this.y = sample.y
-    this.ball = sample.ball
-    this.prev = null
-    this.next = null
-    this.cost = Infinity // Cost of deleting this node
-    this.heapIndex = -1 // Index in the binary min-heap
-  }
-}
-
-/**
- * An updatable binary min-heap for managing candidate points for deletion.
- */
-class MinHeap {
-  constructor() {
-    this.data = []
-  }
-
-  size() {
-    return this.data.length
-  }
-
-  push(node) {
-    node.heapIndex = this.data.length
-    this.data.push(node)
-    this.up(this.data.length - 1)
-  }
-
-  pop() {
-    if (this.data.length === 0) return null
-    const min = this.data[0]
-    const last = this.data.pop()
-    if (this.data.length > 0) {
-      this.data[0] = last
-      last.heapIndex = 0
-      this.down(0)
-    }
-    min.heapIndex = -1
-    return min
-  }
-
-  update(node) {
-    const idx = node.heapIndex
-    if (idx !== -1) {
-      this.up(idx)
-      this.down(idx)
-    }
-  }
-
-  remove(node) {
-    const idx = node.heapIndex
-    if (idx !== -1) {
-      const last = this.data.pop()
-      if (idx < this.data.length) {
-        this.data[idx] = last
-        last.heapIndex = idx
-        this.up(idx)
-        this.down(idx)
-      }
-      node.heapIndex = -1
-    }
-  }
-
-  up(i) {
-    while (i > 0) {
-      const p = (i - 1) >> 1
-      if (this.data[i].cost >= this.data[p].cost) break
-      this.swap(i, p)
-      i = p
-    }
-  }
-
-  down(i) {
-    const len = this.data.length
-    while ((i << 1) + 1 < len) {
-      let left = (i << 1) + 1
-      let right = left + 1
-      let best = i
-      if (this.data[left].cost < this.data[best].cost) best = left
-      if (right < len && this.data[right].cost < this.data[best].cost) best = right
-      if (best === i) break
-      this.swap(i, best);
-      i = best
-    }
-  }
-
-  swap(i, j) {
-    const tmp = this.data[i]
-    this.data[i] = this.data[j]
-    this.data[j] = tmp
-    this.data[i].heapIndex = i
-    this.data[j].heapIndex = j
-  }
-}
-
-/**
- * Computes the minimum perpendicular distance from point P(px, py) to the line segment connecting A(ax, ay) and B(bx, by).
- */
-function distanceToLineSegment(px, py, ax, ay, bx, by) {
-  const dx = bx - ax
-  const dy = by - ay
-  const lenSq = dx * dx + dy * dy
-  if (lenSq === 0) {
-    return Math.hypot(px - ax, py - ay)
-  }
-  let t = ((px - ax) * dx + (py - ay) * dy) / lenSq
-  t = Math.max(0, Math.min(1, t))
-  const projX = ax + t * dx
-  const projY = ay + t * dy
-  return Math.hypot(px - projX, py - projY)
-}
-
-/**
- * Checks if a point (x, y) is within 2R of any of the four cushions of the three-cushion billiard table.
- */
-function isWithin2ROfCushion(x, y) {
-  const R = 0.03275
+export function isWithin3ROfCushion(x, y) {
   const tableX = R * 45.18
   const tableY = R * 22.09
-  const limit = 2 * R
+  const limit = 3 * R
 
   const distToCushionX = tableX - Math.abs(x)
   const distToCushionY = tableY - Math.abs(y)
@@ -135,116 +15,75 @@ function isWithin2ROfCushion(x, y) {
 }
 
 /**
- * Computes the deletion cost of a node by evaluating the maximum perpendicular distance
- * of all intermediate points over the interval between its predecessor and successor if the node is removed.
- *
- * @param {ListNode} node - The candidate node.
- * @param {Array} originalSamples - The full array of original samples for this ball.
- * @returns {number} The maximum Euclidean distance error.
+ * Linearly interpolates a ball's position at a specific timestamp.
  */
-function computeDeletionCost(node, originalSamples) {
-  if (!node.prev || !node.next) {
-    return Infinity
+export function getBallPosAtTime(samples, t) {
+  if (!samples || samples.length === 0) return null
+  if (t <= samples[0].t) {
+    return { x: samples[0].x, y: samples[0].y }
   }
-  if (isWithin2ROfCushion(node.x, node.y)) {
-    return Infinity
+  if (t >= samples[samples.length - 1].t) {
+    return { x: samples[samples.length - 1].x, y: samples[samples.length - 1].y }
   }
-  const p = node.prev
-  const s = node.next
 
-  let maxError = 0
-  for (let k = p.index + 1; k < s.index; k++) {
-    const orig = originalSamples[k]
-    const err = distanceToLineSegment(orig.x, orig.y, p.x, p.y, s.x, s.y)
-    if (err > maxError) {
-      maxError = err
+  let low = 0
+  let high = samples.length - 1
+  while (low <= high) {
+    const mid = (low + high) >> 1
+    if (samples[mid].t === t) {
+      return { x: samples[mid].x, y: samples[mid].y }
+    } else if (samples[mid].t < t) {
+      low = mid + 1
+    } else {
+      high = mid - 1
     }
   }
-  return maxError
+
+  const p1 = samples[high]
+  const p2 = samples[low]
+  if (!p1 || !p2) return null
+  const dt = p2.t - p1.t
+  if (dt === 0) return { x: p1.x, y: p1.y }
+  const alpha = (t - p1.t) / dt
+  return {
+    x: p1.x + alpha * (p2.x - p1.x),
+    y: p1.y + alpha * (p2.y - p1.y)
+  }
 }
 
 /**
- * Simplifies a single ball's trajectory using the decimation algorithm.
- *
- * @param {Array} samples - Array of trajectory samples of form {ball, t, x, y}.
- * @param {number} tolerance - Tolerance threshold in meters.
- * @returns {Array} The simplified array of samples.
+ * Checks if a ball is within 3*R proximity of any other ball at that time.
  */
-function simplifyBallTrajectory(samples, tolerance) {
-  if (samples.length <= 2) {
-    return samples
-  }
+export function isNearOtherBall(currentBallId, p, t, ballGroups) {
+  const limit = 3 * R
 
-  const n = samples.length
-  const nodes = new Array(n)
-  for (let i = 0; i < n; i++) {
-    nodes[i] = new ListNode(i, samples[i])
-  }
+  for (const [otherBallIdStr, otherSamples] of Object.entries(ballGroups)) {
+    const otherBallId = parseInt(otherBallIdStr, 10)
+    if (otherBallId === currentBallId) continue
 
-  for (let i = 0; i < n; i++) {
-    if (i > 0) nodes[i].prev = nodes[i - 1]
-    if (i < n - 1) nodes[i].next = nodes[i + 1]
-  }
+    const otherPos = getBallPosAtTime(otherSamples, t)
+    if (!otherPos) continue
 
-  const heap = new MinHeap()
-
-  for (let i = 1; i < n - 1; i++) {
-    nodes[i].cost = computeDeletionCost(nodes[i], samples)
-    heap.push(nodes[i])
-  }
-
-  while (heap.size() > 0) {
-    const minNode = heap.pop()
-    if (minNode.cost > tolerance) {
-      break
-    }
-
-    // Permanently remove minNode from the linked list
-    const p = minNode.prev
-    const s = minNode.next
-    p.next = s
-    s.prev = p
-
-    // Recompute cost for predecessor if it is an interior node
-    if (p.prev !== null) {
-      p.cost = computeDeletionCost(p, samples)
-      heap.update(p)
-    }
-
-    // Recompute cost for successor if it is an interior node
-    if (s.next !== null) {
-      s.cost = computeDeletionCost(s, samples)
-      heap.update(s)
+    const dist = Math.hypot(p.x - otherPos.x, p.y - otherPos.y)
+    if (dist <= limit) {
+      return true
     }
   }
-
-  // Reconstruct simplified array of samples
-  const result = []
-  let curr = nodes[0]
-  while (curr !== null) {
-    result.push({
-      ball: curr.ball,
-      t: curr.t,
-      x: curr.x,
-      y: curr.y
-    })
-    curr = curr.next
-  }
-
-  return result
+  return false
 }
 
 /**
- * Simplifies the multi-ball trajectory data, grouping by ball.
+ * Simplifies the multi-ball trajectory data to have equal density along the path,
+ * except that it preserves points within 3*R of cushions and other balls.
  *
  * @param {Array} truth - Original flat trajectory array of [{ball, t, x, y}, ...].
- * @param {number} toleranceInMm - Configurable tolerance threshold in millimeters.
+ * @param {number} minDistanceInMm - Configurable minimum distance between points in millimeters.
  * @returns {Array} The simplified flat trajectory array.
  */
-export function simplifyTruth(truth, toleranceInMm) {
+export function simplifyTruth(truth, minDistanceInMm) {
   if (!truth || truth.length === 0) return []
 
-  const toleranceInMeters = toleranceInMm / 1000
+  const minDistanceInMeters = minDistanceInMm / 1000
 
   // Group by ball ID
   const groups = {}
@@ -253,14 +92,50 @@ export function simplifyTruth(truth, toleranceInMm) {
     groups[s.ball].push(s)
   }
 
+  // Sort groups by t
+  for (const ballStr of Object.keys(groups)) {
+    groups[ballStr].sort((a, b) => a.t - b.t)
+  }
+
   const simplifiedGroups = []
   for (const [ballStr, samples] of Object.entries(groups)) {
-    // Sort by timestamp to be absolutely safe
-    samples.sort((a, b) => a.t - b.t)
-    const simplified = simplifyBallTrajectory(samples, toleranceInMeters)
+    const ballId = parseInt(ballStr, 10)
+    if (samples.length <= 2) {
+      simplifiedGroups.push(samples)
+      continue
+    }
+
+    const simplified = []
+    // Always keep the first point
+    simplified.push(samples[0])
+    let lastKept = samples[0]
+
+    for (let i = 1; i < samples.length - 1; i++) {
+      const p = samples[i]
+      if (isWithin3ROfCushion(p.x, p.y)) {
+        simplified.push(p)
+        lastKept = p
+        continue
+      }
+      if (isNearOtherBall(ballId, p, p.t, groups)) {
+        simplified.push(p)
+        lastKept = p
+        continue
+      }
+
+      // Check distance from lastKept to p
+      const dist = Math.hypot(p.x - lastKept.x, p.y - lastKept.y)
+      if (dist >= minDistanceInMeters) {
+        simplified.push(p)
+        lastKept = p
+      }
+    }
+
+    // Always keep the last point
+    simplified.push(samples[samples.length - 1])
     simplifiedGroups.push(simplified)
   }
 
-  // Concatenate simplified trajectories, maintaining ball groupings order
+  // Concatenate simplified trajectories, preserving ball grouping order
   return simplifiedGroups.flat()
 }

--- a/dist/fit/viewer.html
+++ b/dist/fit/viewer.html
@@ -59,14 +59,17 @@
           <button id="saveBtn" disabled>Save JSON</button>
           <button id="simplifyBtn" disabled>Simplify</button>
           <label class="tol-label"
-            >Tol(mm):<input
-              type="number"
+            >MinDist(mm):<input
+              type="range"
               id="simplifyTol"
-              value="0.25"
+              value="100"
               min="0"
-              step="0.05"
+              max="1000"
+              step="5"
               class="tol-input"
-          /></label>
+              style="width: 80px"
+            /><span id="simplifyTolVal">100</span></label
+          >
           <button onclick="document.getElementById('file').click()">
             Load
           </button>
@@ -360,19 +363,24 @@
         onRunSim()
       }
 
-      const urlFile = new URLSearchParams(window.location.search).get("file")
-      const defaultFile = urlFile ?? "simple_shot_545600_stronge.json"
-      // Full paths (starting with /) are fetched as-is for file:// protocol usage
-      const fetchUrl = defaultFile.startsWith("/")
-        ? defaultFile
-        : "./" + defaultFile
-      fetch(fetchUrl)
-        .then((r) => r.json())
-        .then((data) => {
-          loadedFile = defaultFile
-          loadData(data)
-        })
-        .catch(() => {})
+      const urlParams = new URLSearchParams(window.location.search)
+      const urlFile = urlParams.get("file")
+      const urlIndex = urlParams.get("index") ?? urlParams.get("shot")
+
+      if (urlIndex === null) {
+        const defaultFile = urlFile ?? "simple_shot_545600_stronge.json"
+        // Full paths (starting with /) are fetched as-is for file:// protocol usage
+        const fetchUrl = defaultFile.startsWith("/")
+          ? defaultFile
+          : "./" + defaultFile
+        fetch(fetchUrl)
+          .then((r) => r.json())
+          .then((data) => {
+            loadedFile = defaultFile
+            loadData(data)
+          })
+          .catch(() => {})
+      }
 
       async function onRunSim() {
         const btn = document.getElementById("simBtn")
@@ -413,12 +421,20 @@
       document.getElementById("simBtn").onclick = onRunSim
       document.getElementById("trackAll").onchange = updateDrawing
 
+      const simplifyTolInput = document.getElementById("simplifyTol")
+      const simplifyTolValSpan = document.getElementById("simplifyTolVal")
+      if (simplifyTolInput && simplifyTolValSpan) {
+        simplifyTolInput.addEventListener("input", () => {
+          simplifyTolValSpan.textContent = simplifyTolInput.value
+        })
+      }
+
       document.getElementById("simplifyBtn").onclick = () => {
         if (!loadedData || !loadedData.truth) return
-        const tolVal = parseFloat(document.getElementById("simplifyTol").value)
+        const tolVal = parseFloat(simplifyTolInput.value)
         if (isNaN(tolVal) || tolVal < 0) {
           document.getElementById("status").textContent =
-            "Invalid tolerance value"
+            "Invalid minimum distance value"
           return
         }
 
@@ -427,9 +443,10 @@
         loadedData.truth = simplifiedTruth
 
         const newCount = simplifiedTruth.length
+        const removed = originalCount - newCount
         const pct = ((newCount / originalCount) * 100).toFixed(1)
         document.getElementById("status").textContent =
-          `Simplified: ${originalCount} -> ${newCount} samples (${pct}%) at ${tolVal}mm`
+          `Simplified: ${originalCount} -> ${newCount} samples (${removed} points removed, ${pct}%) at ${tolVal}mm`
 
         updateDrawing()
       }
@@ -690,6 +707,20 @@
             opt.textContent = `Shot ${shot.id ?? index}`
             select.appendChild(opt)
           })
+
+          if (urlIndex !== null) {
+            const idx = parseInt(urlIndex, 10)
+            if (!isNaN(idx) && data[idx]) {
+              select.value = idx
+              const shot = data[idx]
+              loadedFile = `trajectories.json [Shot ${shot.id ?? idx}]`
+              const converted = convertTrajectoryShot(shot)
+              loadData(converted)
+
+              const examplesSelect = document.getElementById("examples")
+              if (examplesSelect) examplesSelect.value = ""
+            }
+          }
         })
         .catch((err) => {
           console.warn("Failed to load trajectories.json", err)

--- a/dist/fit/viewraw.html
+++ b/dist/fit/viewraw.html
@@ -163,7 +163,7 @@
       const shots = await resp.json()
 
       const grid = document.getElementById("grid")
-      for (const shot of shots) {
+      shots.forEach((shot, index) => {
         const wrap = document.createElement("div")
         wrap.className = "shot"
 
@@ -175,10 +175,10 @@
         label.textContent = `shot ${shot.id}`
         wrap.appendChild(label)
 
-        wrap.addEventListener("click", () => openOverlay(shot))
+        wrap.addEventListener("click", () => openOverlay(shot, index))
 
         grid.appendChild(wrap)
-      }
+      })
 
       /* overlay */
       const overlay = document.createElement("div")
@@ -243,7 +243,7 @@
         window.open(url, "_blank")
       }
 
-      function openOverlay(shot) {
+      function openOverlay(shot, index) {
         const moverId = findMover(shot)
         const remapped = remapShot(shot, moverId)
         const big = renderShot(remapped, BIG_W, BIG_H)
@@ -251,16 +251,29 @@
         wrap.className = "diagram"
         wrap.style.position = "relative"
         wrap.appendChild(big)
+
         const playBtn = document.createElement("button")
         playBtn.style.position = "absolute"
-        playBtn.style.bottom = "0"
-        playBtn.style.right = "0"
+        playBtn.style.bottom = "4px"
+        playBtn.style.right = "4px"
         playBtn.textContent = "▶"
         playBtn.addEventListener("click", (e) => {
           e.stopPropagation()
           launchThree(remapped)
         })
         wrap.appendChild(playBtn)
+
+        const viewBtn = document.createElement("button")
+        viewBtn.style.position = "absolute"
+        viewBtn.style.bottom = "4px"
+        viewBtn.style.right = "36px"
+        viewBtn.textContent = "🔍"
+        viewBtn.addEventListener("click", (e) => {
+          e.stopPropagation()
+          window.open(`./viewer.html?index=${index}`, "_blank")
+        })
+        wrap.appendChild(viewBtn)
+
         /* remove old diagram if any */
         const old = overlay.querySelector(".diagram")
         if (old) old.remove()

--- a/dist/lobby.html
+++ b/dist/lobby.html
@@ -19,10 +19,7 @@
       href="https://tailuge.github.io/billiards/dist/lobby.html"
     />
 
-    <meta
-      property="og:title"
-      content="Tailuge Billiards"
-    />
+    <meta property="og:title" content="Tailuge Billiards" />
     <meta
       property="og:description"
       content="Free multiplayer lobby for Billiards. Find matches and play realistic pool online."
@@ -42,10 +39,7 @@
     <meta property="og:video:type" content="text/html" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta
-      name="twitter:title"
-      content="Multiplayer Billiards - Free"
-    />
+    <meta name="twitter:title" content="Multiplayer Billiards - Free" />
     <meta
       name="twitter:description"
       content="Free multiplayer lobby for Billiards. Find matches and play realistic pool online."
@@ -85,7 +79,10 @@
     />
     <link rel="icon" type="image/png" href="assets/threecushion.png" />
     <link rel="manifest" href="manifest.json" />
-    <meta name="ocs-site-verification" content="7e2c8724a132bd19fa2cac60ae730ba5" />
+    <meta
+      name="ocs-site-verification"
+      content="7e2c8724a132bd19fa2cac60ae730ba5"
+    />
     <meta name="theme-color" content="#1a1a1a" />
     <style>
       html,
@@ -97,7 +94,10 @@
         scrollbar-width: none;
         background: #f5f5f5;
       }
-      html::-webkit-scrollbar, body::-webkit-scrollbar { display: none; }
+      html::-webkit-scrollbar,
+      body::-webkit-scrollbar {
+        display: none;
+      }
       html[theme="dark"],
       html[theme="dark"] body {
         background: #1a1a1a;
@@ -113,10 +113,10 @@
 
     <script src="lobby.js" type="module"></script>
     <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('sw.js');
-        });
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("sw.js")
+        })
       }
     </script>
   </body>

--- a/test/simplify.spec.ts
+++ b/test/simplify.spec.ts
@@ -2,8 +2,8 @@ import { simplifyTruth } from "../dist/fit/simplify"
 
 describe("simplifyTruth", () => {
   it("should handle empty or undefined input gracefully", () => {
-    expect(simplifyTruth([], 0.25)).toEqual([])
-    expect(simplifyTruth(undefined as any, 0.25)).toEqual([])
+    expect(simplifyTruth([], 250)).toEqual([])
+    expect(simplifyTruth(undefined as any, 250)).toEqual([])
   })
 
   it("should return the original points if the trajectory has 2 or fewer samples", () => {
@@ -11,74 +11,57 @@ describe("simplifyTruth", () => {
       { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
       { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
     ]
-    expect(simplifyTruth(samples, 0.25)).toEqual(samples)
+    expect(simplifyTruth(samples, 250)).toEqual(samples)
   })
 
-  it("should simplify interior linear points perfectly with low tolerance", () => {
-    // 3 points perfectly aligned: we should be able to remove the middle one
+  it("should simplify interior linear points when distance to last kept is less than min distance", () => {
     const samples = [
       { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
-      { ball: 0, t: 0.5, x: 0.5, y: 0.5 },
+      { ball: 0, t: 0.5, x: 0.1, y: 0.1 }, // very close to first point
       { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
     ]
-    // Reconstruct with 1st and 3rd. Interpolating at t=0.5 gives x=0.5, y=0.5.
-    // Euclidean distance error is 0. This is less than tolerance 0.25mm.
-    // So the middle point should be removed!
-    const simplified = simplifyTruth(samples, 0.25)
+    // minDistance is 250mm = 0.25m.
+    // Distance from (0,0) to (0.1, 0.1) is sqrt(0.02) = 0.141m. This is < 0.25m, so it should be skipped.
+    const simplified = simplifyTruth(samples, 250)
     expect(simplified).toEqual([
       { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
       { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
     ])
   })
 
-  it("should NOT remove interior points if the error exceeds tolerance", () => {
-    // 3 points where the middle point is offset (not aligned)
+  it("should NOT remove interior points if distance is at least minDistance", () => {
     const samples = [
       { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
-      { ball: 0, t: 0.5, x: 1.0, y: 0.0 }, // completely off line
+      { ball: 0, t: 0.5, x: 0.5, y: 0.5 }, // distance from (0,0) is 0.707m > 0.25m
       { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
     ]
-    // Reconstruct with 1st and 3rd. Interpolating at t=0.5 gives x=0.5, y=0.5.
-    // Euclidean distance error is sqrt((0.5)^2 + (0.5)^2) = 0.707 meters = 707 mm.
-    // This is far greater than tolerance 0.25mm.
-    // So the middle point must be retained!
-    const simplified = simplifyTruth(samples, 0.25)
+    const simplified = simplifyTruth(samples, 250)
     expect(simplified).toEqual(samples)
   })
 
-  it("should simplify multiple balls independently", () => {
-    const samples = [
-      // Ball 0 linear
-      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
-      { ball: 0, t: 0.5, x: 0.5, y: 0.5 },
-      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
-      // Ball 1 with non-linear middle point (not simplified)
-      { ball: 1, t: 0.0, x: 0.0, y: 0.0 },
-      { ball: 1, t: 0.5, x: 1.0, y: 0.0 },
-      { ball: 1, t: 1.0, x: 1.0, y: 1.0 },
-    ]
-
-    const simplified = simplifyTruth(samples, 0.25)
-    expect(simplified).toEqual([
-      { ball: 0, t: 0.0, x: 0.0, y: 0.0 },
-      { ball: 0, t: 1.0, x: 1.0, y: 1.0 },
-      { ball: 1, t: 0.0, x: 0.0, y: 0.0 },
-      { ball: 1, t: 0.5, x: 1.0, y: 0.0 },
-      { ball: 1, t: 1.0, x: 1.0, y: 1.0 },
-    ])
-  })
-
-  it("should never remove points within 2r of cushion", () => {
+  it("should never remove points within 3r of cushion", () => {
     // Left cushion is at -1.479645.
-    // Point at x = -1.45, y = 0.0 is within 2R (0.0655) of left cushion.
-    // Points are collinear: A(-1.47, 0.0) -> B(-1.45, 0.0) -> C(-1.40, 0.0).
+    // Point at x = -1.45, y = 0.0 is within 3R of left cushion.
     const samples = [
       { ball: 0, t: 0.0, x: -1.47, y: 0.0 },
       { ball: 0, t: 0.5, x: -1.45, y: 0.0 },
       { ball: 0, t: 1.0, x: -1.4, y: 0.0 },
     ]
-    const simplified = simplifyTruth(samples, 0.25)
-    // Point B must not be removed despite being perfectly collinear, because it's within 2R of cushion.
+    const simplified = simplifyTruth(samples, 1000) // even with 1000mm minDistance, it should keep the cushion point
+    expect(simplified).toEqual(samples)
+  })
+
+  it("should never remove points within 3r of other balls", () => {
+    // Ball 0 and Ball 1 are in close proximity at t = 0.5.
+    const samples = [
+      { ball: 0, t: 0.0, x: -1.0, y: 0.0 },
+      { ball: 0, t: 0.5, x: -0.01, y: 0.0 }, // near other ball (0.01, 0)
+      { ball: 0, t: 1.0, x: 1.0, y: 0.0 },
+      { ball: 1, t: 0.0, x: 0.0, y: 1.0 },
+      { ball: 1, t: 0.5, x: 0.01, y: 0.0 }, // near other ball (-0.01, 0)
+      { ball: 1, t: 1.0, x: 0.0, y: -1.0 },
+    ]
+    const simplified = simplifyTruth(samples, 1000)
     expect(simplified).toEqual(samples)
   })
 })


### PR DESCRIPTION
Replaces the decimation simplify algorithm in dist/fit/simplify.js with an equal-density path-filtering algorithm. It maintains a configurable minimum distance between points along the trajectory, while preserving critical points: the first and last points, points within 3*R of cushions, and points within 3*R proximity of other balls at that time (using linear interpolation). It also adds a slider UI to viewer.html to easily configure the minimum distance, shows the count of removed points, and supports launching viewer.html directly from viewraw.html with a given trajectory shot index.

---
*PR created automatically by Jules for task [5261055538588096263](https://jules.google.com/task/5261055538588096263) started by @tailuge*