### PR TITLE
Style Chat Input and Handle Mobile Keyboard & Close Behaviors

### DIFF
--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -51,10 +51,12 @@
      spin column (152px, left) and the button column (70px, right) so it can
      never cover either, at any window width. */
   position: absolute;
-  /* dialogs default to width: fit-content from the UA stylesheet, which stops
-     left/right offsets from stretching the box — force width back to auto so
-     the input fills the whole corridor. */
-  width: auto;
+  /* dialogs default to width: fit-content from the UA stylesheet. We keep
+     it as fit-content but set a min-width and max-width so that the input is
+     constrained to the size of its content instead of stretching unnecessarily,
+     avoiding a large empty grey area. */
+  width: fit-content;
+  min-width: 320px;
   top: auto;
   bottom: 4px; /* positioned up 3px from 1px */
   left: max(160px, calc(50% - 406px)); /* 152px spin column + 8px gap, centered up to 812px */

--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -62,29 +62,11 @@
   gap: 4px;
   box-shadow: 2px 2px 0 rgb(0 0 0 / 50%); /* non blur drop shadow 2px */
   box-sizing: border-box;
-}
 
-@media (max-width: 640px) {
-  #inputTextDiv {
-    /* Stretched between the spin column (152px, left) and the button column (70px, right)
-       so it can never cover either on small screens. */
-    left: 160px; /* 152px spin column + 8px gap */
-    right: 80px; /* button column */
-    width: auto;
-    margin: 0;
-  }
-}
-
-@media (min-width: 641px) {
-  #inputTextDiv {
-    /* Center perfectly relative to the viewport/screen on larger displays without setting both left/right
-       to prevent the native browser <dialog> stretching/layout overlay bugs (keeping left/right transparent). */
-    left: 50%;
-    transform: translateX(-50%);
-    width: fit-content;
-    min-width: 320px;
-    max-width: 812px;
-  }
+  /* Constraints and centering relative to the screen to prevent native <dialog> stretching */
+  left: max(160px, calc(50% - 406px));
+  right: max(80px, calc(50% - 406px));
+  margin: 0;
 }
 
 #inputTextDiv[open] {

--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -56,9 +56,10 @@
      the input fills the whole corridor. */
   width: auto;
   top: auto;
-  bottom: 1px;
-  left: 160px; /* 152px spin column + 8px gap */
-  right: 80px; /* button column */
+  bottom: 4px; /* positioned up 3px from 1px */
+  left: max(160px, calc(50% - 406px)); /* 152px spin column + 8px gap, centered up to 812px */
+  right: max(80px, calc(50% - 406px)); /* button column, centered up to 812px */
+  max-width: 812px;
   z-index: 1000;
   display: none;
   align-items: center;
@@ -68,8 +69,8 @@
   border-radius: 999px;
   padding: 2px 3px;
   gap: 4px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 40%);
-  margin: 0;
+  box-shadow: 2px 2px 0 rgb(0 0 0 / 50%); /* non blur drop shadow 2px */
+  margin: 0 auto;
 }
 
 #inputTextDiv[open] {

--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -47,21 +47,10 @@
 
 #inputTextDiv {
   /* Just above the 70px control panel (#panel): the dialog lives inside
-     #viewP1 which sits directly on top of the panel. Stretched between the
-     spin column (152px, left) and the button column (70px, right) so it can
-     never cover either, at any window width. */
+     #viewP1 which sits directly on top of the panel. */
   position: absolute;
-  /* dialogs default to width: fit-content from the UA stylesheet. We keep
-     it as fit-content but set a min-width and max-width so that the input is
-     constrained to the size of its content instead of stretching unnecessarily,
-     avoiding a large empty grey area. */
-  width: fit-content;
-  min-width: 320px;
   top: auto;
   bottom: 4px; /* positioned up 3px from 1px */
-  left: max(160px, calc(50% - 406px)); /* 152px spin column + 8px gap, centered up to 812px */
-  right: max(80px, calc(50% - 406px)); /* button column, centered up to 812px */
-  max-width: 812px;
   z-index: 1000;
   display: none;
   align-items: center;
@@ -72,7 +61,30 @@
   padding: 2px 3px;
   gap: 4px;
   box-shadow: 2px 2px 0 rgb(0 0 0 / 50%); /* non blur drop shadow 2px */
-  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+@media (max-width: 640px) {
+  #inputTextDiv {
+    /* Stretched between the spin column (152px, left) and the button column (70px, right)
+       so it can never cover either on small screens. */
+    left: 160px; /* 152px spin column + 8px gap */
+    right: 80px; /* button column */
+    width: auto;
+    margin: 0;
+  }
+}
+
+@media (min-width: 641px) {
+  #inputTextDiv {
+    /* Center perfectly relative to the viewport/screen on larger displays without setting both left/right
+       to prevent the native browser <dialog> stretching/layout overlay bugs (keeping left/right transparent). */
+    left: 50%;
+    transform: translateX(-50%);
+    width: fit-content;
+    min-width: 320px;
+    max-width: 812px;
+  }
 }
 
 #inputTextDiv[open] {

--- a/src/view/comment.ts
+++ b/src/view/comment.ts
@@ -35,6 +35,8 @@ export class Comment {
     ) as HTMLDialogElement
     const inputText = document.getElementById("inputText") as HTMLInputElement
 
+    const isMobile = "ontouchstart" in globalThis
+
     const sendText = () => {
       const text = inputText.value.trim()
       if (text) {
@@ -42,8 +44,21 @@ export class Comment {
         this.container.sendChat(text)
         inputText.value = ""
       }
-      // Keep the input open so further messages can be typed; close via ✖ or Esc.
-      inputText.focus()
+      if (isMobile) {
+        this.closeChat()
+      } else {
+        // Keep the input open so further messages can be typed; close via ✖ or Esc.
+        inputText.focus()
+      }
+    }
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", () => {
+        this.adjustInputPosition()
+      })
+      window.visualViewport.addEventListener("scroll", () => {
+        this.adjustInputPosition()
+      })
     }
 
     const emojiButtons = this.menu.querySelectorAll(".comment-emoji")
@@ -114,6 +129,19 @@ export class Comment {
     })
   }
 
+  adjustInputPosition() {
+    const inputTextDiv = document.getElementById("inputTextDiv")
+    const viewP1 = document.getElementById("viewP1")
+    if (!inputTextDiv || !viewP1 || !window.visualViewport) {
+      return
+    }
+    const rect = viewP1.getBoundingClientRect()
+    const visualViewportBottom = window.visualViewport.offsetTop + window.visualViewport.height
+    const distance = rect.bottom - visualViewportBottom
+    const lift = Math.max(0, distance)
+    inputTextDiv.style.bottom = `${4 + lift}px`
+  }
+
   openChat() {
     const inputTextDiv = document.getElementById(
       "inputTextDiv"
@@ -123,6 +151,7 @@ export class Comment {
     inputTextDiv.show()
     inputText.value = ""
     inputText.focus()
+    this.adjustInputPosition()
   }
 
   closeChat() {
@@ -130,6 +159,7 @@ export class Comment {
       "inputTextDiv"
     ) as HTMLDialogElement
     inputTextDiv.close()
+    inputTextDiv.style.bottom = ""
     // Non-modal dialogs don't return focus automatically — hand it back to the
     // game canvas so keyboard controls (arrows, F for fullscreen, etc.) resume.
     ;(this.container.view.element as HTMLElement | null)?.focus()


### PR DESCRIPTION
This change updates the `#inputTextDiv` chat input styling in `dist/css/chat.css` to center the element with `max-width: 812px` (matching the power indicator), set `bottom: 4px` (positioning it up 3px), add a 2px non-blurred drop shadow, and use dynamic constraints `left: max(160px, calc(50% - 406px))` and `right: max(80px, calc(50% - 406px))` to perfectly center on large screens while preventing overlaps on smaller viewports. Additionally, on mobile/touch devices, pressing enter or clicking send automatically closes the input box, and the input box dynamically shifts up based on the Visual Viewport API when the onscreen virtual keyboard is active to keep it fully visible.

---
*PR created automatically by Jules for task [16726577586229109086](https://jules.google.com/task/16726577586229109086) started by @tailuge*