### PR TITLE
Camera Transition Grace Period

### DIFF
--- a/src/view/camera.ts
+++ b/src/view/camera.ts
@@ -39,7 +39,8 @@ export class Camera {
   savedHeight?: number
 
   elapsed: number
-  private t = 0
+  t = 0
+  aimGraceStartT?: number
 
   update(elapsed, aim: AimEvent) {
     this.elapsed = elapsed
@@ -320,6 +321,7 @@ export class Camera {
   }
 
   cycleModeToAimz(balls: any[], aim: AimEvent) {
+    const wasTopView = this.mode === this.topView
     this.mode = this.aimView
     this.mainMode = this.aimView
     this.stepBackToFitAllBalls(balls, aim)
@@ -329,6 +331,9 @@ export class Camera {
     } else {
       this.isZoomedOut = true
       this.updateCameraButtonClass("aimz")
+    }
+    if (wasTopView) {
+      this.aimGraceStartT = this.t
     }
   }
 
@@ -356,6 +361,7 @@ export class Camera {
       this.mainMode = this.aimView
       this.isZoomedOut = false
       this.updateCameraButtonClass("aim")
+      this.aimGraceStartT = this.t
     }
   }
 
@@ -379,6 +385,7 @@ export class Camera {
     if (this.mode === this.topView) {
       this.mode = this.aimView
       this.updateCameraButtonClass("aim")
+      this.aimGraceStartT = this.t
     } else {
       this.mode = this.topView
       this.updateCameraButtonClass("topview")

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -110,7 +110,8 @@ export class View {
   }
 
   render() {
-    if (this.isInMotionNotVisible() && !this.camera.isZoomedOut) {
+    const isGracePeriod = this.camera.aimGraceStartT !== undefined && (this.camera.t - this.camera.aimGraceStartT < 5)
+    if (!isGracePeriod && this.isInMotionNotVisible() && !this.camera.isZoomedOut) {
       this.camera.suggestMode(this.camera.topView)
     }
     this.renderCamera(this.camera)

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -64,4 +64,47 @@ describe("Camera", () => {
     expect(camera.savedDistance).to.be.undefined
     expect(camera.savedHeight).to.be.undefined
   })
+
+  describe("Camera transition grace period", () => {
+    const { Vector3 } = require("three")
+    const balls = [
+      {
+        onTable: () => true,
+        pos: new Vector3(0, 0, 0),
+      }
+    ]
+
+    it("sets aimGraceStartT to current t in toggleMode", () => {
+      const camera = new Camera(1)
+      camera.forceMode(camera.topView)
+      camera.update(3.5, new AimEvent()) // set t to 3.5
+      expect(camera.aimGraceStartT).to.be.undefined
+
+      camera.toggleMode()
+      expect(camera.mode).to.equal(camera.aimView)
+      expect(camera.aimGraceStartT).to.be.closeTo(3.5, 0.001)
+    })
+
+    it("sets aimGraceStartT to current t in cycleMode", () => {
+      const camera = new Camera(1)
+      camera.forceMode(camera.topView)
+      camera.update(4.2, new AimEvent()) // set t to 4.2
+      expect(camera.aimGraceStartT).to.be.undefined
+
+      camera.cycleMode(balls, new AimEvent())
+      expect(camera.mode).to.equal(camera.aimView)
+      expect(camera.aimGraceStartT).to.be.closeTo(4.2, 0.001)
+    })
+
+    it("sets aimGraceStartT to current t in cycleModeToAimz", () => {
+      const camera = new Camera(1)
+      camera.forceMode(camera.topView)
+      camera.update(1.8, new AimEvent()) // set t to 1.8
+      expect(camera.aimGraceStartT).to.be.undefined
+
+      camera.cycleModeToAimz(balls, new AimEvent())
+      expect(camera.mode).to.equal(camera.aimView)
+      expect(camera.aimGraceStartT).to.be.closeTo(1.8, 0.001)
+    })
+  })
 })

--- a/test/view/view.spec.ts
+++ b/test/view/view.spec.ts
@@ -46,4 +46,32 @@ describe("View", () => {
     expect(view.isInMotionNotVisible()).to.be.false
     done()
   })
+
+  it("does not suggest topView when isInMotionNotVisible is true but within grace period", (done) => {
+    table.hasPockets = false
+    const view = new View(canvas3d, table, Assets.localAssets())
+
+    // Set camera to aimView and configure grace period
+    view.camera.forceMode(view.camera.aimView)
+    view.camera.aimGraceStartT = 1.0
+    view.camera.t = 3.0 // elapsed time is 2 seconds, which is less than 5 seconds (grace period active)
+
+    // Override isInMotionNotVisible to return true
+    view.isInMotionNotVisible = () => true
+
+    // Spy suggestMode
+    let suggestModeCalled = false
+    view.camera.suggestMode = (_mode) => {
+      suggestModeCalled = true
+    }
+
+    view.render()
+    expect(suggestModeCalled).to.be.false
+
+    // Advance t past grace period (e.g. 6.1 seconds since grace start)
+    view.camera.t = 7.1
+    view.render()
+    expect(suggestModeCalled).to.be.true
+    done()
+  })
 })


### PR DESCRIPTION
Implements a 5-second grace period where the rule that checks if a ball is off screen is not applied, triggered when switching from top view to aim view on camera button click. It uses the existing cumulative time t of the camera instead of timers.

---
*PR created automatically by Jules for task [12113642757977741283](https://jules.google.com/task/12113642757977741283) started by @tailuge*