### PR TITLE
Center and style chat input area

### DIFF
--- a/dist/css/chat.css
+++ b/dist/css/chat.css
@@ -51,14 +51,13 @@
      spin column (152px, left) and the button column (70px, right) so it can
      never cover either, at any window width. */
   position: absolute;
+
   /* dialogs default to width: fit-content from the UA stylesheet, which stops
      left/right offsets from stretching the box — force width back to auto so
      the input fills the whole corridor. */
   width: auto;
-  top: auto;
-  bottom: 1px;
-  left: 160px; /* 152px spin column + 8px gap */
-  right: 80px; /* button column */
+  max-width: 812px;
+  inset: auto max(80px, calc(50% - 406px)) 4px max(160px, calc(50% - 406px));
   z-index: 1000;
   display: none;
   align-items: center;
@@ -68,7 +67,7 @@
   border-radius: 999px;
   padding: 2px 3px;
   gap: 4px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 40%);
+  box-shadow: 0 2px 0 rgb(0 0 0 / 40%);
   margin: 0;
 }
 
@@ -87,6 +86,7 @@
   background: transparent;
   border: none;
   outline: none;
+
   /* .view3d sets cursor: none, which would hide the text caret over the input */
   cursor: text;
 }

--- a/src/view/view.ts
+++ b/src/view/view.ts
@@ -110,8 +110,14 @@ export class View {
   }
 
   render() {
-    const isGracePeriod = this.camera.aimGraceStartT !== undefined && (this.camera.t - this.camera.aimGraceStartT < 5)
-    if (!isGracePeriod && this.isInMotionNotVisible() && !this.camera.isZoomedOut) {
+    const isGracePeriod =
+      this.camera.aimGraceStartT !== undefined &&
+      this.camera.t - this.camera.aimGraceStartT < 5
+    if (
+      !isGracePeriod &&
+      this.isInMotionNotVisible() &&
+      !this.camera.isZoomedOut
+    ) {
       this.camera.suggestMode(this.camera.topView)
     }
     this.renderCamera(this.camera)

--- a/test/view/camera.spec.ts
+++ b/test/view/camera.spec.ts
@@ -71,7 +71,7 @@ describe("Camera", () => {
       {
         onTable: () => true,
         pos: new Vector3(0, 0, 0),
-      }
+      },
     ]
 
     it("sets aimGraceStartT to current t in toggleMode", () => {


### PR DESCRIPTION
Centering and styling of the chat input area to have a max width matching the power indicator, raised by 3px, and styled with a 2px non-blurred drop shadow. Left and right safety margins are maintained to avoid overlap with menu/spin buttons on small viewports.

---
*PR created automatically by Jules for task [14804145154540639620](https://jules.google.com/task/14804145154540639620) started by @tailuge*