### PR TITLE
Add fast-forward button to replay mode

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -280,6 +280,16 @@
             </button>
             <button
               class="menuButton half-height"
+              title="fast forward"
+              id="ffwd"
+              type="button"
+              aria-label="Fast forward"
+              hidden
+            >
+              ⏩
+            </button>
+            <button
+              class="menuButton half-height"
               title="share"
               id="share"
               type="button"

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -71,6 +71,7 @@ export class Container {
   notification: Notification
   lobbyIndicator: LobbyIndicator
   replayMode: boolean = false
+  fastForwardActive: boolean = false
   examMode: boolean = false
   relay: MessageRelay | null = null
   scoreReporter: ScoreReporter | null = null
@@ -336,7 +337,11 @@ export class Container {
   lastEventTime = performance.now()
 
   animate(timestamp): void {
-    this.advance((timestamp - this.last) / 1000)
+    let elapsed = (timestamp - this.last) / 1000
+    if (this.fastForwardActive) {
+      elapsed *= 2
+    }
+    this.advance(elapsed)
     this.last = timestamp
     this.processEvents()
     const needsRender =
@@ -384,6 +389,12 @@ export class Container {
           (this.wasReplay && controller instanceof End)) &&
           this.rules.rulename === "threecushion"
       )
+      this.menu?.setFfwdVisible(
+        controller instanceof Replay
+      )
+      if (!(controller instanceof Replay)) {
+        this.fastForwardActive = false
+      }
       const isTwoPlayer =
         !this.isSinglePlayer &&
         !this.replayMode &&

--- a/src/view/menu.ts
+++ b/src/view/menu.ts
@@ -13,6 +13,7 @@ export class Menu {
   concede: HTMLButtonElement
   help: HTMLButtonElement
   analysis: HTMLButtonElement
+  ffwd: HTMLButtonElement
   menuDropdown: HTMLDetailsElement | null
 
   disabled = true
@@ -26,6 +27,7 @@ export class Menu {
     this.concede = this.getElement("concede")
     this.help = this.getElement("help")
     this.analysis = this.getElement("analysis")
+    this.ffwd = this.getElement("ffwd")
     this.menuDropdown = document.getElementById(
       "menuDropdown"
     ) as HTMLDetailsElement | null
@@ -34,12 +36,36 @@ export class Menu {
       this.analysis.onclick = () => this.handleExport(true)
     }
 
+    if (this.ffwd) {
+      this.ffwd.onmousedown = (e) => {
+        e.preventDefault()
+        this.container.fastForwardActive = true
+      }
+      this.ffwd.ontouchstart = (e) => {
+        e.preventDefault()
+        this.container.fastForwardActive = true
+      }
+      this.ffwd.onmouseup = () => {
+        this.container.fastForwardActive = false
+      }
+      this.ffwd.onmouseleave = () => {
+        this.container.fastForwardActive = false
+      }
+      this.ffwd.ontouchend = () => {
+        this.container.fastForwardActive = false
+      }
+      this.ffwd.ontouchcancel = () => {
+        this.container.fastForwardActive = false
+      }
+    }
+
     if (this.diagram) {
       this.diagram.onclick = () => this.handleExport(false)
     }
 
     this.setShareVisible(false)
     this.setDiagramVisible(false)
+    this.setFfwdVisible(false)
     if (this.camera) {
       this.camera.onclick = (_) => {
         this.adjustCamera()
@@ -158,6 +184,13 @@ export class Menu {
     if (this.analysis) {
       this.analysis.hidden = !visible
       this.analysis.disabled = !visible
+    }
+  }
+
+  setFfwdVisible(visible: boolean) {
+    if (this.ffwd) {
+      this.ffwd.hidden = !visible
+      this.ffwd.disabled = !visible
     }
   }
 

--- a/test/view/menu.spec.ts
+++ b/test/view/menu.spec.ts
@@ -80,6 +80,37 @@ describe("Menu", () => {
     done()
   })
 
+  it("fast-forward button visibility and active state control", (done) => {
+    const menu = new Menu(container)
+    const ffwd = document.getElementById("ffwd") as HTMLButtonElement
+
+    // 1. Verify initially hidden
+    expect(ffwd.hidden).to.be.true
+
+    // 2. Verify setFfwdVisible(true) makes it visible
+    menu.setFfwdVisible(true)
+    expect(ffwd.hidden).to.be.false
+
+    // 3. Verify mousedown sets container.fastForwardActive to true
+    expect(container.fastForwardActive).to.be.false
+    fireEvent.mouseDown(ffwd)
+    expect(container.fastForwardActive).to.be.true
+
+    // 4. Verify mouseup sets container.fastForwardActive to false
+    fireEvent.mouseUp(ffwd)
+    expect(container.fastForwardActive).to.be.false
+
+    // 5. Verify touchstart sets container.fastForwardActive to true
+    fireEvent.touchStart(ffwd)
+    expect(container.fastForwardActive).to.be.true
+
+    // 6. Verify touchend sets container.fastForwardActive to false
+    fireEvent.touchEnd(ffwd)
+    expect(container.fastForwardActive).to.be.false
+
+    done()
+  })
+
   it("camera", (done) => {
     const toggleview = document.getElementById("camera") as HTMLButtonElement
     expect(container.view.camera.mode).to.be.equal(


### PR DESCRIPTION
This feature adds a fast-forward button (⏩) to the sub menu during replay mode. While the button is held down, it doubles the elapsed frame time sent to the simulation loop, allowing snappier playback.

---
*PR created automatically by Jules for task [10528050109197816460](https://jules.google.com/task/10528050109197816460) started by @tailuge*