### PR TITLE
Update twocue.md with cuesGroup hierarchical design

### DIFF
--- a/twocue.md
+++ b/twocue.md
@@ -1,4 +1,4 @@
-# Per-Player Cues: Two Pre-instantiated Cues with Visibility Toggling
+# Per-Player Cues: Two Pre-instantiated Cues with Visibility Toggling and Shared Transform Group
 
 This document describes the chosen design for showing a unique cue
 styling/geometry for each player in a 2-player match, together with the plan to
@@ -6,94 +6,98 @@ make the in-game cue geometry a visual duplicate of `dist/cue.html`.
 
 ---
 
-## 1. Chosen Approach: Two Pre-instantiated Cues with Visibility Toggling
+## 1. Chosen Approach: Two Pre-instantiated Cues with Group-Based Visibility Toggling
 
-Two distinct `Cue` instances (`cueP1` and `cueP2`) are fully created at startup
-and added to the Three.js scene. At runtime, we simply toggle their visibility
-(`.visible = true` / `.visible = false`).
+To support distinct styles for each player, two separate `Cue` instances (`cueP1` and `cueP2`) are fully pre-instantiated at startup and added to a shared parent transform node (`cuesGroup` / `cueRoot`). At runtime, we simply toggle their visibility (`.visible = true` / `.visible = false`).
 
-*   **Outstanding Runtime Performance:** Toggling `.visible` in Three.js is
-    extremely fast. When `.visible` is `false`, Three.js completely bypasses
-    frustum culling, CPU matrix world updates (`updateMatrixWorld`), and GPU
-    draw-call submission for that entire sub-tree.
-*   **No On-the-Fly Creation Overhead:** Since both cues are pre-instantiated
-    at startup, there is zero garbage collection pressure or runtime
-    instantiation lag when turns switch.
-*   **Maximum Flexibility:** Each player can have completely different 3D
-    models, textures, shaders, and geometry. Player 1 can use a traditional
-    wooden cue, while Player 2 uses a futuristic carbon-fiber model.
-*   **Code Simplicity:** Simple boolean toggling replaces
-    material-finding/traversal logic.
-*   **Slightly Higher Startup Memory:** Keeping two simple
-    geometries/material sets in memory (which is negligible for a low-poly cue
-    model).
+### Group hierarchy:
 
-## 2. Implementation Blueprint
+```text
+table
+└── cuesGroup                 ← the thing you always aim/transform
+    ├── cueP1                 ← fixed visual geometry
+    └── cueP2                 ← fixed visual geometry
+```
+
+### Key Advantages:
+*   **Zero Aiming Logic Redirection:** There is no need to redirect existing aiming logic from:
+    ```typescript
+    this.cue.rotation...
+    this.cue.position...
+    this.cue.tilt...
+    ```
+    to a dynamic `activeCue`. Instead, the existing conceptual cue object behaves directly as the shared transform parent (`cuesGroup` or `cueRoot`).
+*   **Separation of State and Visuals:** This design cleanly separates the visual identity from the gameplay state. The parent group handles the physical state (aiming, positioning, rotation, power, and animation transforms), while the child meshes handle appearance and identity.
+*   **Outstanding Runtime Performance:** Toggling `.visible` in Three.js is extremely fast. When `.visible` is `false`, Three.js completely bypasses frustum culling, CPU matrix world updates (`updateMatrixWorld`), and GPU draw-call submission for that entire sub-tree.
+*   **No On-the-Fly Creation Overhead:** Since both cues are pre-instantiated at startup, there is zero garbage collection pressure or runtime instantiation lag when turns switch.
+*   **Maximum Flexibility:** Each player can have completely different 3D models, textures, shaders, and geometry. Player 1 can use a traditional wooden cue, while Player 2 uses a futuristic carbon-fiber model.
+
+---
+
+## 2. Shared Transform Group (`cuesGroup` / `cueRoot`)
+
+To ensure flawless aiming and animation behavior, `cuesGroup` is the sole runtime transform node.
+
+### Essential Invariant:
+> The parent group represents the physical cue's current aim/position; the children represent only its appearance.
+
+### Important Consequences:
+1.  **Independent Local Transforms Prohibited:** The two cue meshes (`cueP1` and `cueP2`) must not have independent local transforms. Their local position, rotation, and scale must remain at their default/same identity coordinates:
+    ```typescript
+    cueP1.position.set(0, 0, 0)
+    cueP1.rotation.set(0, 0, 0)
+    cueP2.position.set(0, 0, 0)
+    cueP2.rotation.set(0, 0, 0)
+    ```
+2.  **All Transforms on Parent:** All physical positioning, rotation, tilting, and forward penetration stroke animation are applied exclusively to `cuesGroup`:
+    ```typescript
+    cuesGroup.rotation...
+    cuesGroup.position...
+    cuesGroup.translateOnAxis...
+    ```
+    Since both children are mounted under the same coordinate system, rotating/translating the parent produces identical aiming behavior without any duplicate code paths.
+
+---
+
+## 3. Implementation Blueprint
 
 ### Pointer Locations:
 
-1.  **`src/view/cue.ts`**: The main controller for the cue's representation,
-    shadow, helper line, and movement calculations.
-2.  **`src/model/table.ts`**: Currently holds and instantiates the single `cue`
-    reference (`this.cue = new Cue()`).
-3.  **`src/container/container.ts`**: Responsible for driving the active turn
-    via `this.inferActivePlayer(controller)`.
+1.  **`src/view/cue.ts`**: The main controller for the cue's representation, shadow, helper line, and movement calculations. This now represents the `cuesGroup` / `cueRoot`.
+2.  **`src/model/table.ts`**: Currently holds and instantiates the single `cue` reference (`this.cue = new Cue()`). It will now instantiate the `cuesGroup` containing `cueP1` and `cueP2`.
+3.  **`src/container/container.ts`**: Responsible for driving the active turn via `this.inferActivePlayer(controller)`.
 
 ### Steps:
 
-1.  Update `src/model/table.ts` to hold both cues, each built with its player's
-    cue params (see §3):
+1.  Update `src/model/table.ts` (or `Cue` controller) to hold both visual children inside a single parent group (`cuesGroup`):
 
     ```typescript
-    cueP1!: Cue
-    cueP2!: Cue
+    // In Cue or Table representation
+    cuesGroup = new THREE.Group()
+    cueP1 = createCue(..., paramsP1)
+    cueP2 = createCue(..., paramsP2)
+
+    cuesGroup.add(cueP1)
+    cuesGroup.add(cueP2)
     ```
 
-2.  Update `Table.addToScene()` in `src/model/table.ts` to mount both:
+2.  Update visibility toggling on turn or controller transitions inside `src/container/container.ts` (or matching controller):
 
     ```typescript
-    addToScene(scene) {
-      // Add balls, etc.
-      if (this.cueP1) scene.add(this.cueP1.mesh)
-      if (this.cueP2) scene.add(this.cueP2.mesh)
-    }
-    ```
-
-3.  Implement a wrapper property/method on `Table` to easily access the
-    "active" cue:
-
-    ```typescript
-    get activeCue(): Cue {
-      return this.currentTurnPlayerIndex === 0 ? this.cueP1 : this.cueP2
-    }
-    ```
-
-4.  Toggle visibility in `src/container/container.ts` on controller
-    transitions:
-
-    ```typescript
-    const active = this.inferActivePlayer(controller)
-    if (active === 1) {
-      this.table.cueP1.mesh.visible = true
-      this.table.cueP2.mesh.visible = false
-    } else if (active === 2) {
-      this.table.cueP1.mesh.visible = false
-      this.table.cueP2.mesh.visible = true
-    }
+    const activePlayer = this.inferActivePlayer(controller)
+    cueP1.visible = activePlayer === 1
+    cueP2.visible = activePlayer === 2
     ```
 
 ---
 
-## 3. Geometry Changes: `cuemesh.ts` as the Visual Dual of `cue.html`
+## 4. Geometry Changes: `cuemesh.ts` as the Visual Dual of `cue.html`
 
-Make `src/view/cuemesh.ts` render the same cue as `dist/cue.html` by default
-(cue.html's defaults now; player preferences later). This is the per-player
-parameterization that §2 instantiates once per player.
+Make `src/view/cuemesh.ts` render the same cue as `dist/cue.html` by default (cue.html's defaults now; player preferences later). This is the per-player parameterization that §3 instantiates once per player.
 
 ### Params surface and defaults
 
--   Add a `CueParams` type and `DEFAULT_CUE_PARAMS` mirroring cue.html's
-    `DEFAULT_STATE`:
+-   Add a `CueParams` type and `DEFAULT_CUE_PARAMS` mirroring cue.html's `DEFAULT_STATE`:
 
     | param          | default   |
     |----------------|-----------|
@@ -106,54 +110,35 @@ parameterization that §2 instantiates once per player.
     | `buttRatio`    | `0.4` |
     | `grain`        | `true` |
 
--   Values are used as supplied — no clamping or validation; missing fields
-    fall back to `DEFAULT_CUE_PARAMS`.
+-   Values are used as supplied — no clamping or validation; missing fields fall back to `DEFAULT_CUE_PARAMS`.
 
 ### Geometry port
 
 Port cue.html's `cueGeometry` construction into `CueMesh.cueGeometry`:
 
--   `buttLength = length * buttRatio`;
-    `shaftLength = length * (1 - buttRatio) - jointLength - ferruleLength`
--   4-point full splice (`createSpliceGeometries` + `addSpliceQuad`, N=24,
-    P=4) — upper prongs in shaft wood, lower body in butt wood, triangular-wave
-    seam
+-   `buttLength = length * buttRatio`; `shaftLength = length * (1 - buttRatio) - jointLength - ferruleLength`
+-   4-point full splice (`createSpliceGeometries` + `addSpliceQuad`, N=24, P=4) — upper prongs in shaft wood, lower body in butt wood, triangular-wave seam
 -   Butt bottom cap (`CircleGeometry`)
 -   Joint collar cylinder (`buttRadius * 0.9`, length `jointLength`)
--   Tapered shaft (`tipRadius` → `jointRadius`), ferrule, tip (keep
-    `tip.name = "cueTip"`)
+-   Tapered shaft (`tipRadius` → `jointRadius`), ferrule, tip (keep `tip.name = "cueTip"`)
 
-The returned `Group` shape is unchanged, so `createCue`'s rotation / position
-/ tilt logic and all existing `Cue` callers stay untouched.
+The returned `Group` shape is unchanged, so `createCue`'s rotation / position / tilt logic and all existing `Cue` callers stay untouched.
 
 ### Materials and wood grain
 
--   Per-part `MeshPhongMaterial` with cue.html's colours/shininess, plus the
-    `JOINT_STYLES` / `FERRULE_STYLES` specular maps (e.g. brass `#d9a62e`,
-    shininess 150, specular `0xfff2c8`).
--   Procedural seeded wood-grain canvas texture (shaft seed 7, butt seed 11;
-    64×512, `RepeatWrapping (4,1)`, `SRGBColorSpace`) applied to shaft and butt
-    when `grain` is true.
--   Materials are created per `createCue` call so each player's cue has
-    independent materials — no shared-state mutation.
+-   Per-part `MeshPhongMaterial` with cue.html's colours/shininess, plus the `JOINT_STYLES` / `FERRULE_STYLES` specular maps (e.g. brass `#d9a62e`, shininess 150, specular `0xfff2c8`).
+-   Procedural seeded wood-grain canvas texture (shaft seed 7, butt seed 11; 64×512, `RepeatWrapping (4,1)`, `SRGBColorSpace`) applied to shaft and butt when `grain` is true.
+-   Materials are created per `createCue` call so each player's cue has independent materials — no shared-state mutation.
 
 ### createCue signature
 
--   `createCue(tip, but, length, opts?: CueParams)` — defaults to
-    `DEFAULT_CUE_PARAMS`; backward compatible with existing callers.
+-   `createCue(tip, but, length, opts?: CueParams)` — defaults to `DEFAULT_CUE_PARAMS`; backward compatible with existing callers.
 
 ### Length
 
--   Total cue length does not change: it stays `Cue.length =
-    TableGeometry.tableX` (1.408 m on a default 10 ft table). Only the segment
-    split changes. With defaults the new butt→ferrule spans exactly `length`
-    (vs `0.997 * length` today) — about 4 mm longer on a 10 ft table,
-    imperceptible.
+-   Total cue length does not change: it stays `Cue.length = TableGeometry.tableX` (1.408 m on a default 10 ft table). Only the segment split changes. With defaults the new butt→ferrule spans exactly `length` (vs `0.997 * length` today) — about 4 mm longer on a 10 ft table, imperceptible.
 
 ### Out of scope (follow-ups)
 
--   Threading `Session.customParams` / `Session.opponentParams` (already
-    parsed from `custom.*` / `opponent.custom.*` URL params in
-    `Session.applyUrlParams`) into `CueParams` per player.
--   Validation: no new tests required; existing `yarn lint` / `yarn test`
-    suffice (cue.spec.ts already exercises `createCue` / `baseTilt`).
+-   Threading `Session.customParams` / `Session.opponentParams` (already parsed from `custom.*` / `opponent.custom.*` URL params in `Session.applyUrlParams`) into `CueParams` per player.
+-   Validation: no new tests required; existing `yarn lint` / `yarn test` suffice (cue.spec.ts already exercises `createCue` / `baseTilt`).


### PR DESCRIPTION
This change updates `twocue.md` to document the cleaner `cuesGroup` / `cueRoot` parent transform design where individual visual cues `cueP1` and `cueP2` are kept as identical children with local offsets set to zero. All aiming animations, rotations, positioning, and transitions happen directly on the parent group, allowing us to keep existing aiming logic on the single pointer reference unchanged while dynamically toggling visual visibility on children per active player.

---
*PR created automatically by Jules for task [16161474405888828170](https://jules.google.com/task/16161474405888828170) started by @tailuge*