### PR TITLE
Add Fake Shadows for 3D Emoji Wall

### DIFF
--- a/dist/cue.html
+++ b/dist/cue.html
@@ -30,8 +30,15 @@
       body {
         background: var(--bg);
         color: var(--text);
-        font-family: "Exo", -apple-system, BlinkMacSystemFont, "Segoe UI",
-          Roboto, Helvetica, Arial, sans-serif;
+        font-family:
+          "Exo",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
         font-weight: 200;
       }
       button,

--- a/dist/wall.html
+++ b/dist/wall.html
@@ -40,8 +40,15 @@
       body {
         background: var(--bg);
         color: var(--text);
-        font-family: "Exo", -apple-system, BlinkMacSystemFont, "Segoe UI",
-          Roboto, Helvetica, Arial, sans-serif;
+        font-family:
+          "Exo",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
         font-weight: 200;
         user-select: none;
       }
@@ -302,7 +309,9 @@
     <!-- Emoji picker panel -->
     <aside id="params">
       <div class="profile-row">
-        <button id="emoji-btn" class="emoji-btn" title="Choose emoji">😀</button>
+        <button id="emoji-btn" class="emoji-btn" title="Choose emoji">
+          😀
+        </button>
         <div class="profile-meta">
           <span id="profile-name" class="profile-name">Lukey</span>
           <span id="profile-elo" class="profile-elo">ELO 1805</span>
@@ -727,6 +736,20 @@
       )
       scene.add(instancedMesh)
 
+      // Dark grey shadow material (no transparency)
+      const shadowMaterial = new THREE.MeshBasicMaterial({
+        color: 0x1a1a1a,
+        side: THREE.DoubleSide,
+      })
+
+      // Shadow instanced mesh matching the same geometry and instance count (Single GPU efficiency)
+      const shadowMesh = new THREE.InstancedMesh(
+        planarTriGeom,
+        shadowMaterial,
+        TOTAL_INSTANCES
+      )
+      scene.add(shadowMesh)
+
       const dummy = new THREE.Object3D()
       const color = new THREE.Color()
       const instancesData = []
@@ -799,12 +822,7 @@
         plateCtx.fillRect(0, 0, plateCanvas.width, plateCanvas.height)
         plateCtx.strokeStyle = "#3a4350"
         plateCtx.lineWidth = 4
-        plateCtx.strokeRect(
-          2,
-          2,
-          plateCanvas.width - 4,
-          plateCanvas.height - 4
-        )
+        plateCtx.strokeRect(2, 2, plateCanvas.width - 4, plateCanvas.height - 4)
 
         plateCtx.textAlign = "center"
         plateCtx.textBaseline = "middle"
@@ -864,8 +882,7 @@
           const item = instancesData[i]
           const pixelIndex = i * 4
 
-          const alpha =
-            pixelData === null ? 0 : pixelData[pixelIndex + 3] / 255
+          const alpha = pixelData === null ? 0 : pixelData[pixelIndex + 3] / 255
 
           if (alpha > 0.1) {
             const r = pixelData[pixelIndex] / 255
@@ -969,6 +986,7 @@
         for (let i = 0; i < TOTAL_INSTANCES; i++) {
           const item = instancesData[i]
 
+          // Render main triangles
           dummy.position.set(item.posX, item.posY, item.z)
           dummy.rotation.set(item.rotX, item.rotY, item.rotZ)
           dummy.scale.set(item.scale, item.scale, item.scale)
@@ -978,11 +996,21 @@
 
           color.setRGB(item.r, item.g, item.b)
           instancedMesh.setColorAt(i, color)
+
+          // Render fake shadow flat against the wall
+          dummy.position.set(item.posX, item.posY, -0.395)
+          dummy.rotation.set(0, 0, item.rotZ)
+          dummy.scale.set(item.scale, item.scale, item.scale)
+          dummy.updateMatrix()
+
+          shadowMesh.setMatrixAt(i, dummy.matrix)
         }
 
         instancedMesh.instanceMatrix.needsUpdate = true
         if (instancedMesh.instanceColor)
           instancedMesh.instanceColor.needsUpdate = true
+
+        shadowMesh.instanceMatrix.needsUpdate = true
 
         controls.update()
         renderer.render(scene, camera)

--- a/dist/wall.html
+++ b/dist/wall.html
@@ -640,7 +640,7 @@
         0.1,
         1000
       )
-      camera.position.set(0, 0, 26)
+      camera.position.set(18.38, 0, 18.38)
 
       const renderer = new THREE.WebGLRenderer({ antialias: true })
       renderer.setSize(window.innerWidth, window.innerHeight)

--- a/dist/wall.html
+++ b/dist/wall.html
@@ -330,7 +330,7 @@
       </div>
       <div class="colour-row">
         <label for="bg-colour">Background</label>
-        <input type="color" id="bg-colour" value="#8b5a2b" />
+        <input type="color" id="bg-colour" value="#4a4e54" />
       </div>
       <div id="emoji-picker-mount" style="display: none"></div>
       <div class="done-row">
@@ -361,7 +361,7 @@
         showEmoji: true,
         showName: true,
         showElo: true,
-        bgColour: "#8b5a2b",
+        bgColour: "#4a4e54",
       }
 
       function readCustom() {
@@ -664,10 +664,10 @@
         metalness: 0.02,
       })
       const recessMat = new THREE.MeshStandardMaterial({
-        color: 0x8b5a2b,
+        color: 0x4a4e54,
         roughness: 0.85,
         metalness: 0.05,
-      }) // brown background panel
+      }) // grey background panel
       const frameMat = new THREE.MeshStandardMaterial({
         color: 0xcbd5e1,
         roughness: 0.5,


### PR DESCRIPTION
Implements fake shadows flat against the recess wall of 3D emoji triangles in wall.html.
Uses an InstancedMesh with the same geometry and count for single GPU draw-call efficiency.
The shadow material is a dark grey THREE.MeshBasicMaterial with no transparency, and shadows are positioned flat against the wall (rotX=0, rotY=0) at z=-0.395 to avoid z-fighting.

---
*PR created automatically by Jules for task [12677410340166839211](https://jules.google.com/task/12677410340166839211) started by @tailuge*