### PR TITLE
Fix Snooker Final Ball Potted Score Synchronization

### DIFF
--- a/src/controller/watchshot.ts
+++ b/src/controller/watchshot.ts
@@ -7,11 +7,15 @@ import { RerackEvent } from "../events/rerackevent"
 import { Session } from "../network/client/session"
 import { BeginEvent } from "../events/beginevent"
 import { HitEvent } from "../events/hitevent"
+import { ScoreEvent } from "../events/scoreevent"
 
 export class WatchShot extends ControllerBase {
   override get name(): string {
     return "WatchShot"
   }
+
+  private scoreEventReceived = false
+
   constructor(container, _hitEvent?: HitEvent) {
     super(container)
     this.container.table.outcome = []
@@ -22,6 +26,11 @@ export class WatchShot extends ControllerBase {
     this.container.table.cue.aimInputs.setDisabled(true)
   }
 
+  override handleScore(event: ScoreEvent) {
+    this.scoreEventReceived = true
+    return super.handleScore(event)
+  }
+
   override handleStationary(_) {
     if (Session.isBotMode()) {
       this.container.sendEvent(new BeginEvent())
@@ -29,6 +38,14 @@ export class WatchShot extends ControllerBase {
 
     const outcome = this.container.table.outcome
     if (this.container.rules.isEndOfGame(outcome) && !Session.isBotMode()) {
+      if (this.container.rules.rulename === "snooker" && !this.scoreEventReceived) {
+        const points = this.container.rules.getAmountScored(outcome)
+        if (points > 0) {
+          Session.getInstance().addOpponentScore(points)
+          const { p1, p2 } = Session.getInstance().orderedScoresForHud()
+          this.container.updateScoreHud(p1, p2, 0)
+        }
+      }
       return this.container.rules.handleGameEnd(false)
     }
     return this

--- a/test/controller/watchshot.spec.ts
+++ b/test/controller/watchshot.spec.ts
@@ -8,6 +8,8 @@ import { Vector3 } from "three"
 import { Assets } from "../../src/view/assets"
 import { initDom } from "../view/dom"
 import { Session } from "../../src/network/client/session"
+import { Outcome } from "../../src/model/outcome"
+import { ScoreEvent } from "../../src/events/scoreevent"
 
 initDom()
 
@@ -64,5 +66,82 @@ describe("WatchShot Controller", () => {
     expect(ball.pos.x).to.equal(0)
     expect(ball.pos.y).to.equal(0)
     expect(ball.state).to.equal(State.Stationary)
+  })
+
+  describe("Snooker final ball potted and score tracking in WatchShot", () => {
+    let snookerContainer: Container
+
+    beforeEach(() => {
+      Ball.id = 0
+      Session.init("test-client-snooker", "TestPlayer", "test-table", false)
+      const session = Session.getInstance()
+      session.playerIndex = 1 // playerIndex 1 means opponent is Player 1 (p1), we are Player 2 (p2)
+      session.opponentName = "OpponentPlayer"
+      session.setOpponentClientId("test-opponent")
+
+      snookerContainer = new Container({
+        element: undefined,
+        log: (_) => {},
+        assets: Assets.localAssets("snooker"),
+        ruletype: "snooker",
+      })
+      snookerContainer.isSinglePlayer = false
+    })
+
+    it("should update opponent's score when the final black is potted if ScoreEvent has not been received", () => {
+      const session = Session.getInstance()
+      session.initializeScores()
+      session.setMyScore(50)
+      session.setOpponentScore(100)
+
+      const watchShot = new WatchShot(snookerContainer)
+
+      // Set the outcome of the shot to be a pot of the black ball (id = 6)
+      // black is worth 7 points in snooker (id + 1)
+      const blackBall = snookerContainer.table.balls.find((b) => b.id === 6)!
+      blackBall.state = State.InPocket
+      snookerContainer.table.outcome = [Outcome.pot(blackBall, 1.0, 0)]
+
+      // Clear all other balls so isEndOfGame returns true
+      snookerContainer.table.balls.forEach((b) => {
+        if (b.id !== 0) {
+          b.state = State.InPocket
+        }
+      })
+
+      watchShot.handleStationary(null as any)
+
+      // The opponent's score should have been increased by 7 points (100 -> 107)
+      expect(session.opponentScore()).to.equal(107)
+    })
+
+    it("should NOT double-count the final potted ball if ScoreEvent was already received", () => {
+      const session = Session.getInstance()
+      session.initializeScores()
+      session.setMyScore(50)
+      session.setOpponentScore(107) // Already updated to include the black ball's 7 points
+
+      const watchShot = new WatchShot(snookerContainer)
+
+      // Simulate receiving ScoreEvent first (which sets scoreEventReceived to true)
+      const scoreEvent = new ScoreEvent(107, 50, 0, 1)
+      watchShot.handleScore(scoreEvent)
+
+      const blackBall = snookerContainer.table.balls.find((b) => b.id === 6)!
+      blackBall.state = State.InPocket
+      snookerContainer.table.outcome = [Outcome.pot(blackBall, 1.0, 0)]
+
+      // Clear all other balls so isEndOfGame returns true
+      snookerContainer.table.balls.forEach((b) => {
+        if (b.id !== 0) {
+          b.state = State.InPocket
+        }
+      })
+
+      watchShot.handleStationary(null as any)
+
+      // The opponent's score should remain 107, not increased to 114
+      expect(session.opponentScore()).to.equal(107)
+    })
   })
 })


### PR DESCRIPTION
This PR fixes a bug where the final potted ball score in snooker is not correctly synchronized on the opponent's side prior to win calculation and match result upload. In WatchShot, we now check if the final shot has been potted under the snooker rule. If the network ScoreEvent hasn't been received yet, we calculate the potted ball's points locally and add them to the opponent's score before transitioning to the End state, preventing incorrect uploads.

---
*PR created automatically by Jules for task [7086881100616764395](https://jules.google.com/task/7086881100616764395) started by @tailuge*