### PR TITLE
Add chromeless mode on keypress toggle

### DIFF
--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -106,6 +106,16 @@ canvas {
   position: relative;
 }
 
+body.chromeless #panel {
+  height: 0;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .aimControlColumn {
   display: flex;
   flex-direction: column;

--- a/dist/help.html
+++ b/dist/help.html
@@ -302,6 +302,7 @@
         <div class="help-row">
           <kbd>🖱️ right click</kbd><span>Draw lines</span>
         </div>
+        <div class="help-row"><kbd>K</kbd><span>Chromeless mode</span></div>
         <div class="help-row"><kbd>H</kbd><span>Help</span></div>
       </div>
     </main>

--- a/src/controller/controllerbase.ts
+++ b/src/controller/controllerbase.ts
@@ -162,6 +162,9 @@ export abstract class ControllerBase extends Controller {
       case "KeyCUp":
         this.container.comment.openChat()
         return true
+      case "KeyKUp":
+        this.toggleChromeless()
+        return true
       case "Digit1":
         this.container.view.camera.adjustFov(-delta * 20)
         return true
@@ -194,5 +197,10 @@ export abstract class ControllerBase extends Controller {
     } else if (document.exitFullscreen) {
       document.exitFullscreen()
     }
+  }
+
+  private toggleChromeless() {
+    document.body.classList.toggle("chromeless")
+    window.dispatchEvent(new Event("resize"))
   }
 }


### PR DESCRIPTION
Adds a chromeless mode toggle bound to key 'K' (KeyKUp) which collapses the bottom UI panel (#panel) to height 0 and expands the 3D render canvas down to fill the viewport space.

---
*PR created automatically by Jules for task [3085118362046544007](https://jules.google.com/task/3085118362046544007) started by @tailuge*