### PR TITLE
Enable double tap to place ball or hit on mobile devices

### DIFF
--- a/src/view/dom/aiminputs.ts
+++ b/src/view/dom/aiminputs.ts
@@ -88,9 +88,7 @@ export class AimInputs {
     this.cueHitElement?.addEventListener("click", this.hit)
     this.cuePowerElement?.addEventListener("input", this.powerChanged)
     this.cueTiltElement?.addEventListener("input", this.tiltChanged)
-    if (!("ontouchstart" in globalThis)) {
-      id("viewP1")?.addEventListener("dblclick", this.hit)
-    }
+    id("viewP1")?.addEventListener("dblclick", this.hit)
     document.addEventListener("wheel", this.mousewheel, { passive: false })
   }
 

--- a/test/view/aiminput.spec.ts
+++ b/test/view/aiminput.spec.ts
@@ -97,6 +97,33 @@ describe("AimInput", () => {
     done()
   })
 
+  it("double click viewP1 triggers hit regardless of touch support", (done) => {
+    aiminputs.setDisabled(false)
+    aiminputs.tiltSliderContainerElement.hidden = false
+    aiminputs.container.inputQueue = []
+    fireEvent.dblClick(document.getElementById("viewP1") as HTMLElement)
+    expect(aiminputs.tiltSliderContainerElement.hidden).to.be.true
+    expect(aiminputs.container.inputQueue).to.be.not.empty
+
+    // Verify when ontouchstart is defined on globalThis
+    const originalOntouchstart = (globalThis as any).ontouchstart
+    ;(globalThis as any).ontouchstart = () => {}
+    try {
+      const touchInputs = new AimInputs(container)
+      touchInputs.setDisabled(false)
+      touchInputs.container.inputQueue = []
+      fireEvent.dblClick(document.getElementById("viewP1") as HTMLElement)
+      expect(touchInputs.container.inputQueue).to.be.not.empty
+    } finally {
+      if (originalOntouchstart === undefined) {
+        delete (globalThis as any).ontouchstart
+      } else {
+        ;(globalThis as any).ontouchstart = originalOntouchstart
+      }
+    }
+    done()
+  })
+
   it("mouse wheel updates power", (done) => {
     aiminputs.setDisabled(false)
     const initialPower = Number(aiminputs.cuePowerElement.value)


### PR DESCRIPTION
Fixes an issue where double-tapping the table canvas (#viewP1) on mobile devices did not trigger placing the ball or hitting the cue ball. The check guarding the event listener attachment for ontouchstart was removed so dblclick is registered on all devices.

---
*PR created automatically by Jules for task [6990706564027583024](https://jules.google.com/task/6990706564027583024) started by @tailuge*