### PR TITLE
Fix replay camera alternating topview and aimz

### DIFF
--- a/src/controller/replay.ts
+++ b/src/controller/replay.ts
@@ -14,6 +14,8 @@ import { ChatEvent } from "../events/chatevent"
 import { share, shorten } from "../utils/shorten"
 import { LOBBY_URL } from "../network/client/constants"
 import { gameOverButtons } from "../utils/gameover"
+import { Camera } from "../view/camera"
+import { Outcome } from "../model/outcome"
 
 export class Replay extends ControllerBase {
   override get name() {
@@ -26,6 +28,7 @@ export class Replay extends ControllerBase {
   timer
   init
   diagram?: boolean
+  private cameraToggle = false
 
   constructor(container, init, shots, _retry = false, delay = 1500, diagram?) {
     super(container)
@@ -39,7 +42,7 @@ export class Replay extends ControllerBase {
     this.container.table.updateFromShortSerialised(this.init)
     console.log(`shots: ${this.shots.length}`)
     console.log(`shots: ${JSON.stringify(this.shots)}`)
-    this.container.view.camera.forceMode(this.container.view.camera.aimView)
+    this.container.view.camera.aimzLerp = Camera.aimLerp
     this.playNextShot(this.delay * 1.5)
   }
 
@@ -103,13 +106,14 @@ export class Replay extends ControllerBase {
     return true
   }
 
-  private suggestRandomCamera() {
+  private alternateCamera() {
     const camera = this.container.view.camera
-    if (Math.random() < 0.5) {
+    if (this.cameraToggle) {
       camera.suggestMode(camera.topView)
     } else {
       camera.cycleModeToAimz()
     }
+    this.cameraToggle = !this.cameraToggle
   }
 
   playNextShot(delay) {
@@ -135,7 +139,7 @@ export class Replay extends ControllerBase {
     this.container.updateLastShot()
     this.container.table.cue.updateAimInput()
     this.container.table.cue.t = 1
-    this.suggestRandomCamera()
+    this.alternateCamera()
     clearTimeout(this.timer)
     this.timer = setTimeout(() => {
       this.container.table.proximityIndicator.hide()
@@ -144,6 +148,19 @@ export class Replay extends ControllerBase {
       )
       this.timer = undefined
     }, delay)
+  }
+
+  override hit() {
+    this.container.sound.lastOutcomeTime = -1
+    this.container.table.outcome = [
+      Outcome.hit(
+        this.container.table.cueball,
+        this.container.table.cue.aim.power,
+        0
+      ),
+    ]
+    this.container.table.hit()
+    this.container.table.cue.showHelper(false)
   }
 
   override handleHit(_: HitEvent) {

--- a/test/controller/replay.spec.ts
+++ b/test/controller/replay.spec.ts
@@ -15,6 +15,7 @@ import { Aim } from "../../src/controller/aim"
 import { End } from "../../src/controller/end"
 import { canvas3d, initDom } from "../view/dom"
 import { Assets } from "../../src/view/assets"
+import { Camera } from "../../src/view/camera"
 
 initDom()
 
@@ -296,6 +297,49 @@ describe("Controller Replay", () => {
     )
     const p2 = document.getElementById("p2Score") as HTMLElement
     expect(p2.classList.contains("is-active")).to.be.true
+    done()
+  })
+
+  it("sets camera aimzLerp and alternates between aimzView and topView across shots", (done) => {
+    jest.clearAllTimers()
+    const multiShotState = {
+      init: state.init,
+      shots: [
+        state.shots[0],
+        state.shots[0],
+        state.shots[0],
+      ],
+    }
+    const replay = new Replay(
+      container,
+      multiShotState.init,
+      multiShotState.shots as any,
+      false,
+      100
+    )
+    container.controller = replay
+
+    expect(container.view.camera.aimzLerp).to.equal(Camera.aimLerp)
+    // First shot played on construction: initial toggle is false so camera mode is aimzView
+    expect(container.view.camera.mode).to.equal(container.view.camera.aimzView)
+
+    // Advance timer to trigger HitEvent and process stationary to trigger playNextShot for 2nd shot
+    jest.runOnlyPendingTimers()
+    container.processEvents()
+    container.table.cueball.setStationary()
+    container.eventQueue.push(new StationaryEvent())
+    container.processEvents()
+
+    expect(container.view.camera.mode).to.equal(container.view.camera.topView)
+
+    // Trigger playNextShot for 3rd shot
+    jest.runOnlyPendingTimers()
+    container.processEvents()
+    container.table.cueball.setStationary()
+    container.eventQueue.push(new StationaryEvent())
+    container.processEvents()
+
+    expect(container.view.camera.mode).to.equal(container.view.camera.aimzView)
     done()
   })
 })


### PR DESCRIPTION
Fix replay camera to alternate between topview and aimz views across replay shots instead of randomly switching to regular aim view or spectator view.

---
*PR created automatically by Jules for task [10650823450751678789](https://jules.google.com/task/10650823450751678789) started by @tailuge*