### PR TITLE
Fix Arena result upload when losing to bot and improve bot game-ending detection

### DIFF
--- a/src/controller/end.ts
+++ b/src/controller/end.ts
@@ -16,23 +16,31 @@ async function submitResults(
   const session = Session.getInstance()
   if (!scoreReporter) return
 
-  await scoreReporter.submitMatchResult(result)
-  if (!session.tournamentId || !result.winnerId) {
-    return
+  const matchPromise = scoreReporter.submitMatchResult(result).catch((e) => {
+    console.error("Error submitting match result:", e)
+  })
+
+  let tournamentPromise: Promise<void> | undefined
+  if (session.tournamentId && result.winnerId) {
+    const challengeId =
+      Session.isBotMode() && session.tableId === "default"
+        ? `G_${Date.now().toString()}`
+        : session.tableId
+
+    tournamentPromise = scoreReporter
+      .submitTournamentResult(
+        session.tournamentId,
+        challengeId,
+        result.winnerId,
+        result.loserId,
+        result.winnerId?.startsWith("bot-") ? undefined : result.beserk
+      )
+      .catch((e) => {
+        console.error("Error submitting tournament result:", e)
+      })
   }
 
-  const challengeId =
-    Session.isBotMode() && session.tableId === "default"
-      ? `G_${Date.now().toString()}`
-      : session.tableId
-
-  await scoreReporter.submitTournamentResult(
-    session.tournamentId,
-    challengeId,
-    result.winnerId,
-    result.loserId,
-    result.winnerId?.startsWith("bot-") ? undefined : result.beserk
-  )
+  await Promise.allSettled([matchPromise, tournamentPromise])
 }
 
 export class End extends Controller {

--- a/src/network/bot/boteventhandler.ts
+++ b/src/network/bot/boteventhandler.ts
@@ -417,8 +417,8 @@ export class BotEventHandler {
     this.assignEightBallType(session, outcome)
 
     if (
-      this.container.rules.rulename === "snooker" &&
-      this.botRules.isEndOfGame(outcome, this.botType())
+      this.botRules.isEndOfGame(outcome, this.botType()) ||
+      this.container.rules.isEndOfGame(outcome, this.botType())
     ) {
       this.handleGameEnd()
       return

--- a/test/network/bot/eventhandler.spec.ts
+++ b/test/network/bot/eventhandler.spec.ts
@@ -627,6 +627,32 @@ describe("BotEventHandler Respot Logic", () => {
     expect(events.find((e) => e instanceof StartAimEvent)).toBeUndefined()
   })
 
+  it("threecushion: bot scores winning point in handlePot and game ends correctly", () => {
+    Ball.id = 0
+    Session.init("test-client", "TestPlayer", "test-table", false)
+
+    const threeContainer = new Container({
+      element: undefined,
+      log: (_: any) => {},
+      assets: Assets.localAssets(),
+      ruletype: "threecushion",
+    })
+
+    const events: GameEvent[] = []
+    const handler = createBotEventHandler(threeContainer, events)
+    const updateControllerSpy = jest.spyOn(threeContainer, "updateController")
+
+    jest.spyOn(threeContainer.rules, "isEndOfGame").mockReturnValue(false)
+    jest.spyOn(handler.botRules, "isEndOfGame").mockReturnValue(true)
+    jest.spyOn(handler.botRules, "foulReason").mockReturnValue(null)
+    jest.spyOn(handler.botRules, "getAmountScored").mockReturnValue(1)
+
+    handler.handle(mockEvent(EventType.BEGIN))
+
+    expect(updateControllerSpy).toHaveBeenCalled()
+    expect(events.find((e) => e instanceof WatchEvent)).toBeUndefined()
+  })
+
   it("snooker foul: bot pots red and black - black is respotted, StartAimEvent sent", () => {
     Ball.id = 0
     const snookerContainer = new Container({

--- a/test/rules/matchresult.spec.ts
+++ b/test/rules/matchresult.spec.ts
@@ -221,6 +221,48 @@ describe("MatchResult Construction", () => {
     expect(result.bot).to.be.true
   })
 
+  it("should upload tournament result even if match result submission fails in bot mode loss", async () => {
+    Session.init(
+      "test-client",
+      "TestPlayer",
+      "test-table",
+      false,
+      true, // botMode
+      false,
+      false,
+      1,
+      false,
+      false,
+      "arena-123" // tournamentId
+    )
+    container = createNineBallContainer()
+    const scoreReporter = new ScoreReporter()
+    const submitMatchSpy = jest
+      .spyOn(scoreReporter, "submitMatchResult")
+      .mockRejectedValue(new Error("Scoreboard server down"))
+    const submitTournamentSpy = jest
+      .spyOn(scoreReporter, "submitTournamentResult")
+      .mockResolvedValue(undefined)
+
+    container.scoreReporter = scoreReporter
+    const endController = (container.rules as any).handleGameEnd(false) as End
+
+    endController.onFirst()
+
+    // Flush promises to let async submitResults finish
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(submitMatchSpy.mock.calls.length).to.equal(1)
+    expect(submitTournamentSpy.mock.calls.length).to.equal(1)
+    expect(submitTournamentSpy.mock.calls[0]).to.deep.equal([
+      "arena-123",
+      "test-table",
+      "bot-clawbreak",
+      "test-client",
+      undefined,
+    ])
+  })
+
   it("MatchResultHelper should show the top 3 high breaks in game over notification", () => {
     container = createNineBallContainer()
     container.ballTray.addBreak({ shots: [] }, 4)


### PR DESCRIPTION
This change fixes the issue where Arena tournament results were not uploaded after losing to a bot.

Key changes:
1. Concurrently executed `submitMatchResult` and `submitTournamentResult` in `src/controller/end.ts` via `Promise.allSettled`, preventing network retries/delays in global match result submission from delaying or blocking Arena result submission.
2. Removed the `snooker`-only restriction in `BotEventHandler.handlePot` (`src/network/bot/boteventhandler.ts`), allowing game-end logic to trigger for all game rule types when a bot scores the winning point.
3. Added unit tests in `test/network/bot/eventhandler.spec.ts` and `test/rules/matchresult.spec.ts` verifying both fixes.

---
*PR created automatically by Jules for task [16838597233289385839](https://jules.google.com/task/16838597233289385839) started by @tailuge*