### PR TITLE
Fix SEO and social media preview meta tags in korean.html

### DIFF
--- a/dist/korean.html
+++ b/dist/korean.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="ko">
   <head>
-    <title>무료 온라인 당구게임 - 3쿠션 · 사구(4구) | 브라우저에서 바로</title>
+    <title>무료 온라인 당구게임 - 3쿠션 & 사구(4구) | 브라우저 바로 실행</title>
     <link rel="icon" type="image/png" href="favicon.png" />
     <meta charset="UTF-8" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta
       name="description"
-      content="설치와 가입 없이 브라우저에서 바로 즐기는 무료 온라인 당구게임. 3쿠션 게임과 사구(4구) 게임을 현실적인 물리 엔진으로, PC와 모바일 어디서든 온라인 대전까지 지원합니다."
+      content="설치와 가입 없이 웹 브라우저에서 바로 즐기는 무료 온라인 당구게임. 3쿠션과 사구(4구) 실시간 대전 및 연습 봇 제공."
     />
     <meta
       name="keywords"
@@ -53,11 +53,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       property="og:title"
-      content="무료 온라인 당구게임 - 3쿠션 · 사구(4구)"
+      content="무료 온라인 당구게임 - 3쿠션 & 사구(4구)"
     />
     <meta
       property="og:description"
-      content="설치 없이 브라우저에서 바로 즐기는 무료 당구게임. 현실적인 물리로 3쿠션과 사구(4구), 온라인 대전까지 PC와 모바일에서 지원합니다."
+      content="설치 없이 브라우저에서 바로 즐기는 리얼한 WebGL 3D 당구게임"
     />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="ko_KR" />
@@ -74,11 +74,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="무료 온라인 당구게임 - 3쿠션 · 사구(4구)"
+      content="무료 온라인 당구게임 - 3쿠션 & 사구(4구)"
     />
     <meta
       name="twitter:description"
-      content="설치 없이 브라우저에서 바로 즐기는 무료 당구게임. 3쿠션과 사구(4구)를 지금 바로 플레이하세요."
+      content="설치 없이 브라우저에서 바로 즐기는 리얼한 WebGL 3D 당구게임"
     />
     <meta
       name="twitter:image"


### PR DESCRIPTION
Updated title, description, og:title, og:description, twitter:title, and twitter:description meta tags in dist/korean.html to match the requested SEO copy and improve link previews on social platforms like KakaoTalk, Naver, and Twitter.

---
*PR created automatically by Jules for task [1893793171839539201](https://jules.google.com/task/1893793171839539201) started by @tailuge*