### PR TITLE
Add requested User-agents to robots.txt

### DIFF
--- a/dist/robots.txt
+++ b/dist/robots.txt
@@ -1,3 +1,34 @@
 User-agent: *
 Allow: /
+
+User-agent: Yeti
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: Yandex
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
 Sitemap: https://tailuge.github.io/billiards/dist/sitemap.xml


### PR DESCRIPTION
Added requested user-agent directives (Yeti, Googlebot, Bingbot, Yandex, DuckDuckBot, OAI-SearchBot, ChatGPT-User, Claude-Web, anthropic-ai, PerplexityBot) with `Allow: /` to `dist/robots.txt` while maintaining valid syntax and preserving existing wildcard and sitemap directives.

---
*PR created automatically by Jules for task [899924675280579151](https://jules.google.com/task/899924675280579151) started by @tailuge*